### PR TITLE
Changes to allow byte-for-byte replication of Zip entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,43 +146,6 @@ jar, tar, zip, dump, 7z, arj.
   </scm>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <!-- Override Javadoc config in parent pom to add JCIP tags -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration> 
-            <quiet>true</quiet>
-            <source>${maven.compiler.source}</source>
-            <encoding>${commons.encoding}</encoding>
-            <docEncoding>${commons.docEncoding}</docEncoding>
-            <linksource>true</linksource>
-            <links>
-              <link>${commons.javadoc.java.link}</link>
-              <link>${commons.javadoc.javaee.link}</link>
-            </links>
-            <tags>
-              <tag>
-                <name>Immutable</name>
-                <placement>a</placement>
-                <head>This class is immutable</head>
-              </tag>
-              <tag>
-                <name>NotThreadSafe</name>
-                <placement>a</placement>
-                <head>This class is not thread-safe</head>
-              </tag>
-              <tag>
-                <name>ThreadSafe</name>
-                <placement>a</placement>
-                <head>This class is thread-safe</head>
-              </tag>
-            </tags>
-          </configuration> 
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <!-- create the source and binary assemblies -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.commons</groupId>
-    <artifactId>commons-parent</artifactId>
-    <version>39</version>
+    <groupId>io.takari</groupId>
+    <artifactId>takari</artifactId>
+    <version>14</version>
   </parent>
 
-  <groupId>org.apache.commons</groupId>
+  <groupId>io.takari</groupId>
   <artifactId>commons-compress</artifactId>
   <version>1.11-SNAPSHOT</version>
   <name>Apache Commons Compress</name>

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -78,7 +78,10 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
     private long size = SIZE_UNKNOWN;
 
     private int internalAttributes = 0;
+    private int versionRequired;
+    private int versionMadeBy;
     private int platform = PLATFORM_FAT;
+    private int rawFlag;
     private long externalAttributes = 0;
     private ZipExtraField[] extraFields;
     private UnparseableExtraFieldData unparseableExtra = null;
@@ -798,5 +801,29 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
             && Arrays.equals(getLocalFileDataExtra(),
                              other.getLocalFileDataExtra())
             && gpb.equals(other.gpb);
+    }
+
+    public void setVersionMadeBy(int versionMadeBy) {
+        this.versionMadeBy = versionMadeBy;
+    }
+
+    public void setVersionRequired(int versionRequired) {
+        this.versionRequired = versionRequired;
+    }
+
+    public int getVersionRequired() {
+        return versionRequired;
+    }
+
+    public int getVersionMadeBy() {
+        return versionMadeBy;
+    }
+
+    public int getRawFlag() {
+        return rawFlag;
+    }
+
+    public void setRawFlag(int rawFlag) {
+        this.rawFlag = rawFlag;
     }
 }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -559,18 +559,22 @@ public class ZipFile implements Closeable {
 
         int versionMadeBy = ZipShort.getValue(CFH_BUF, off);
         off += SHORT;
+        ze.setVersionMadeBy(versionMadeBy);
         ze.setPlatform((versionMadeBy >> BYTE_SHIFT) & NIBLET_MASK);
 
-        off += SHORT; // skip version info
+        ze.setVersionRequired(ZipShort.getValue(CFH_BUF, off));
+        off += SHORT; // version required
 
         final GeneralPurposeBit gpFlag = GeneralPurposeBit.parse(CFH_BUF, off);
         final boolean hasUTF8Flag = gpFlag.usesUTF8ForNames();
         final ZipEncoding entryEncoding =
             hasUTF8Flag ? ZipEncodingHelper.UTF8_ZIP_ENCODING : zipEncoding;
         ze.setGeneralPurposeBit(gpFlag);
+        ze.setRawFlag(ZipShort.getValue(CFH_BUF, off));
 
         off += SHORT;
 
+        //noinspection MagicConstant
         ze.setMethod(ZipShort.getValue(CFH_BUF, off));
         off += SHORT;
 


### PR DESCRIPTION
Two small changes required in order to do this are:

- Read general purpose bit as raw flag
- Support for reading versions made by and required

This is for a general purpose library for doing deltas on JARs
using a merkletree mechanism.