### PR TITLE
Bugfix for COMPRESS-343

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@ jar, tar, zip, dump, 7z, arj.
     <!-- configuration bits for cutting a release candidate -->
     <commons.release.version>${project.version}</commons.release.version>
     <commons.rc.version>RC1</commons.rc.version>
+    <powermock.version>1.6.4</powermock.version>
   </properties>
 
   <issueManagement>
@@ -64,6 +65,18 @@ jar, tar, zip, dump, 7z, arj.
       <artifactId>xz</artifactId>
       <version>1.5</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/Coders.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/Coders.java
@@ -154,13 +154,59 @@ class Coders {
         InputStream decode(final String archiveName, final InputStream in, long uncompressedLength,
                 final Coder coder, final byte[] password)
             throws IOException {
-            return new InflaterInputStream(new DummyByteAddingInputStream(in),
-                                           new Inflater(true));
+            final Inflater inflater = new Inflater(true);
+            final InflaterInputStream inflaterInputStream = new InflaterInputStream(new DummyByteAddingInputStream(in),
+                    inflater);
+            return new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    return inflaterInputStream.read();
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len) throws IOException {
+                    return inflaterInputStream.read(b, off, len);
+                }
+
+                @Override
+                public int read(byte[] b) throws IOException {
+                    return inflaterInputStream.read(b);
+                }
+
+                @Override
+                public void close() throws IOException {
+                    inflaterInputStream.close();
+                    inflater.end();
+                }
+            };
         }
         @Override
         OutputStream encode(final OutputStream out, final Object options) {
             int level = numberOptionOrDefault(options, 9);
-            return new DeflaterOutputStream(out, new Deflater(level, true));
+            final Deflater deflater = new Deflater(level, true);
+            final DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(out, deflater);
+            return new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    deflaterOutputStream.write(b);
+                }
+
+                @Override
+                public void write(byte[] b) throws IOException {
+                    deflaterOutputStream.write(b);
+                }
+
+                @Override
+                public void write(byte[] b, int off, int len) throws IOException {
+                    deflaterOutputStream.write(b, off, len);
+                }
+
+                @Override
+                public void close() throws IOException {
+                    deflaterOutputStream.close();
+                    deflater.end();
+                }
+            };
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZNativeHeapTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZNativeHeapTest.java
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.compress.archivers.sevenz;
+
+import org.apache.commons.compress.AbstractTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Coders.DeflateDecoder.class)
+public class SevenZNativeHeapTest extends AbstractTestCase {
+
+    @InjectMocks
+    Coders.DeflateDecoder deflateDecoder;
+
+    @Test
+    public void testEndDeflaterOnCloseStream() throws Exception {
+        final Deflater deflater = PowerMockito.spy(new Deflater());
+        PowerMockito.whenNew(Deflater.class).withAnyArguments().thenReturn(deflater);
+
+        final OutputStream outputStream = deflateDecoder.encode(new ByteArrayOutputStream(), 9);
+        outputStream.close();
+
+        Mockito.verify(deflater).end();
+    }
+
+    @Test
+    public void testEndInflaterOnCloseStream() throws Exception {
+        final Inflater inflater = PowerMockito.spy(new Inflater());
+        PowerMockito.whenNew(Inflater.class).withAnyArguments().thenReturn(inflater);
+
+        final InputStream inputStream = deflateDecoder.decode("dummy",new ByteArrayInputStream(new byte[0]),0,null,null);
+        inputStream.close();
+
+        Mockito.verify(inflater).end();
+    }
+}


### PR DESCRIPTION
The class ...sevenz.Coders.DeflateDecoder does not close (end()) the Deflater and Inflater. This can lead to native memory issues: see https://bugs.openjdk.java.net/browse/JDK-8074108.

This bugfix solves the problem.