### PR TITLE
CPIO crc overflow resolved for large files

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -329,6 +329,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream implements
         if (this.entry.getFormat() == FORMAT_NEW_CRC) {
             for (int pos = 0; pos < tmpread; pos++) {
                 this.crc += b[pos] & 0xFF;
+                this.crc &= 0xFFFFFFFFL;
             }
         }
         this.entryBytesRead += tmpread;


### PR DESCRIPTION
When unpacking a CPIO file containing a large file the crc check will
overflow and throw an IOException("CRC Error...").

Did not find a nice way to test this since it requires a very large
input file.