### PR TITLE
COMPRESS-407 - Validate Block and Record Sizes and use 512 blocks if none given. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@
 
 language: java
 sudo: false
+cache:
+  directories:
+    - $HOME/.m2
+
 
 jdk:
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@
 
 language: java
 sudo: false
-cache:
-  directories:
-    - $HOME/.m2
-
 
 jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+
+cache:
+  directories:
+    - $HOME/.m2
 
 after_success:
   - mvn clean apache-rat:check test jacoco:report coveralls:report -Ptravis-jacoco

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,3 +1,19 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 # Building Apache Commons Compress
 
 In order to build Commons Compress a JDK implementation 1.7 or higher

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,10 @@ jar, tar, zip, dump, 7z, arj.
     <contributor>
       <name>BELUGA BEHR</name>
     </contributor>
+    <contributor>
+      <name>Michael Hausegger</name>
+      <email>hausegger.michael@googlemail.com</email>
+    </contributor>
   </contributors>
 
   <scm>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -63,8 +63,14 @@ The <action> type attribute can be add,update,fix,remove.
         Java.
       </action>
       <action issue="COMPRESS-406" type="fix" date="2017-06-12"
-              due-to="Simon Spero ">
+              due-to="Simon Spero">
         BUILDING.md now passes the RAT check.
+      </action>
+      <action issue="COMPRESS-405" type="add" date="2017-06-15"
+              due-to="Simon Spero ">
+        Added a new utility class FixedLengthBlockOutputStream that
+        can be used to ensure writing always happens in blocks of a
+        given size.
       </action>
     </release>
     <release version="1.14" date="2017-05-14"

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,11 @@ The <action> type attribute can be add,update,fix,remove.
         can be used to ensure writing always happens in blocks of a
         given size.
       </action>
+      <action issue="COMPRESS-412" type="fix" date="2017-06-17"
+              due-to="Michael Hausegger">
+        Made sure ChecksumCalculatingInputStream receives valid
+        checksum and input stream instances via the cnstructor.
+      </action>
     </release>
     <release version="1.14" date="2017-05-14"
              description="Release 1.14">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,6 +62,10 @@ The <action> type attribute can be add,update,fix,remove.
         The MANIFEST of 1.14 lacks an OSGi Import-Package for XZ for
         Java.
       </action>
+      <action issue="COMPRESS-406" type="fix" date="2017-06-12"
+              due-to="Simon Spero ">
+        BUILDING.md now passes the RAT check.
+      </action>
     </release>
     <release version="1.14" date="2017-05-14"
              description="Release 1.14">

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -61,18 +61,18 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
 
     /** POSIX/PAX extensions are used to store big numbers in the archive. */
     public static final int BIGNUMBER_POSIX = 2;
+    private static final int RECORD_SIZE = 512;
 
-    private long      currSize;
-    private String    currName;
-    private long      currBytes;
-    private final byte[]    recordBuf;
-    private int       assemLen;
-    private final byte[]    assemBuf;
-    private int       longFileMode = LONGFILE_ERROR;
-    private int       bigNumberMode = BIGNUMBER_ERROR;
+    private long currSize;
+    private String currName;
+    private long currBytes;
+    private final byte[] recordBuf;
+    private int assemLen;
+    private final byte[] assemBuf;
+    private int longFileMode = LONGFILE_ERROR;
+    private int bigNumberMode = BIGNUMBER_ERROR;
     private int recordsWritten;
     private final int recordsPerBlock;
-    private final int recordSize;
 
     private boolean closed = false;
 
@@ -93,12 +93,14 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     private static final ZipEncoding ASCII =
         ZipEncodingHelper.getZipEncoding("ASCII");
 
+    private static int BLOCK_SIZE_UNSPECIFIED = -511;
+
     /**
      * Constructor for TarInputStream.
      * @param os the output stream to use
      */
     public TarArchiveOutputStream(final OutputStream os) {
-        this(os, TarConstants.DEFAULT_BLKSIZE, TarConstants.DEFAULT_RCDSIZE);
+        this(os, BLOCK_SIZE_UNSPECIFIED);
     }
 
     /**
@@ -108,59 +110,82 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
      * @since 1.4
      */
     public TarArchiveOutputStream(final OutputStream os, final String encoding) {
-        this(os, TarConstants.DEFAULT_BLKSIZE, TarConstants.DEFAULT_RCDSIZE, encoding);
+        this(os, BLOCK_SIZE_UNSPECIFIED, encoding);
     }
 
     /**
      * Constructor for TarInputStream.
      * @param os the output stream to use
-     * @param blockSize the block size to use
+     * @param blockSize the block size to use. Must be a multiple of 512 bytes.
      */
     public TarArchiveOutputStream(final OutputStream os, final int blockSize) {
-        this(os, blockSize, TarConstants.DEFAULT_RCDSIZE);
+        this(os, blockSize, null);
     }
+
 
     /**
      * Constructor for TarInputStream.
      * @param os the output stream to use
      * @param blockSize the block size to use
-     * @param encoding name of the encoding to use for file names
-     * @since 1.4
+     * @param recordSize the record size to use. Must be 512 bytes.
+     * @deprecated recordSize must always be 512 bytes. An IllegalArgumentException will be thrown
+     * if any other value is used
      */
+    @Deprecated
     public TarArchiveOutputStream(final OutputStream os, final int blockSize,
-                                  final String encoding) {
-        this(os, blockSize, TarConstants.DEFAULT_RCDSIZE, encoding);
-    }
-
-    /**
-     * Constructor for TarInputStream.
-     * @param os the output stream to use
-     * @param blockSize the block size to use
-     * @param recordSize the record size to use
-     */
-    public TarArchiveOutputStream(final OutputStream os, final int blockSize, final int recordSize) {
+        final int recordSize) {
         this(os, blockSize, recordSize, null);
     }
 
     /**
      * Constructor for TarInputStream.
      * @param os the output stream to use
-     * @param blockSize the block size to use
-     * @param recordSize the record size to use
+     * @param blockSize the block size to use . Must be a multiple of 512 bytes.
+     * @param recordSize the record size to use. Must be 512 bytes.
+     * @param encoding name of the encoding to use for file names
+     * @since 1.4
+     * @deprecated recordSize must always be 512 bytes. An IllegalArgumentException will be thrown
+     * if any other value is used.
+     */
+    @Deprecated
+    public TarArchiveOutputStream(final OutputStream os, final int blockSize,
+        final int recordSize, final String encoding) {
+        this(os, blockSize, encoding);
+        if (recordSize != RECORD_SIZE) {
+            throw new IllegalArgumentException(
+                "Tar record size must always be 512 bytes. Attempt to set size of " + recordSize);
+        }
+
+    }
+
+    /**
+     * Constructor for TarInputStream.
+     *
+     * @param os the output stream to use
+     * @param blockSize the block size to use. Must be a multiple of 512 bytes.
      * @param encoding name of the encoding to use for file names
      * @since 1.4
      */
     public TarArchiveOutputStream(final OutputStream os, final int blockSize,
-                                  final int recordSize, final String encoding) {
+        final String encoding) {
+        int realBlockSize;
+        if (BLOCK_SIZE_UNSPECIFIED == blockSize) {
+            realBlockSize = RECORD_SIZE;
+        } else {
+            realBlockSize = blockSize;
+        }
+
+        if(realBlockSize <=0 || realBlockSize % RECORD_SIZE != 0) {
+            throw new IllegalArgumentException("Block size must be a multiple of 512 bytes. Attempt to use set size of " + blockSize);
+        }
         out = new CountingOutputStream(os);
         this.encoding = encoding;
         this.zipEncoding = ZipEncodingHelper.getZipEncoding(encoding);
 
         this.assemLen = 0;
-        this.assemBuf = new byte[recordSize];
-        this.recordBuf = new byte[recordSize];
-        this.recordSize = recordSize;
-        this.recordsPerBlock = blockSize / recordSize;
+        this.assemBuf = new byte[RECORD_SIZE];
+        this.recordBuf = new byte[RECORD_SIZE];
+        this.recordsPerBlock = realBlockSize / RECORD_SIZE;
     }
 
     /**
@@ -208,11 +233,11 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
 
     /**
      * Ends the TAR archive without closing the underlying OutputStream.
-     * 
+     *
      * An archive consists of a series of file entries terminated by an
-     * end-of-archive entry, which consists of two 512 blocks of zero bytes. 
+     * end-of-archive entry, which consists of two 512 blocks of zero bytes.
      * POSIX.1 requires two EOF records, like some other implementations.
-     * 
+     *
      * @throws IOException on error
      */
     @Override
@@ -251,9 +276,11 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
      * Get the record size being used by this stream's TarBuffer.
      *
      * @return The TarBuffer record size.
+     * @deprecated
      */
+    @Deprecated
     public int getRecordSize() {
-        return this.recordSize;
+        return RECORD_SIZE;
     }
 
     /**
@@ -278,12 +305,12 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         final Map<String, String> paxHeaders = new HashMap<>();
         final String entryName = entry.getName();
         final boolean paxHeaderContainsPath = handleLongName(entry, entryName, paxHeaders, "path",
-                                                       TarConstants.LF_GNUTYPE_LONGNAME, "file name");
+            TarConstants.LF_GNUTYPE_LONGNAME, "file name");
 
         final String linkName = entry.getLinkName();
         final boolean paxHeaderContainsLinkPath = linkName != null && linkName.length() > 0
             && handleLongName(entry, linkName, paxHeaders, "linkpath",
-                              TarConstants.LF_GNUTYPE_LONGLINK, "link name");
+            TarConstants.LF_GNUTYPE_LONGLINK, "link name");
 
         if (bigNumberMode == BIGNUMBER_POSIX) {
             addPaxHeadersForBigNumbers(paxHeaders, entry);
@@ -307,7 +334,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         }
 
         entry.writeEntryHeader(recordBuf, zipEncoding,
-                               bigNumberMode == BIGNUMBER_STAR);
+            bigNumberMode == BIGNUMBER_STAR);
         writeRecord(recordBuf);
 
         currBytes = 0;
@@ -336,7 +363,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         if (finished) {
             throw new IOException("Stream has already been finished");
         }
-        if (!haveUnclosedEntry){
+        if (!haveUnclosedEntry) {
             throw new IOException("No current entry to close");
         }
         if (assemLen > 0) {
@@ -352,9 +379,9 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
 
         if (currBytes < currSize) {
             throw new IOException("entry '" + currName + "' closed at '"
-                                  + currBytes
-                                  + "' before the '" + currSize
-                                  + "' bytes specified in the header were written");
+                + currBytes
+                + "' before the '" + currSize
+                + "' bytes specified in the header were written");
         }
         haveUnclosedEntry = false;
     }
@@ -380,9 +407,9 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         }
         if (currBytes + numToWrite > currSize) {
             throw new IOException("request to write '" + numToWrite
-                                  + "' bytes exceeds size in header of '"
-                                  + currSize + "' bytes for entry '"
-                                  + currName + "'");
+                + "' bytes exceeds size in header of '"
+                + currSize + "' bytes for entry '"
+                + currName + "'");
 
             //
             // We have to deal with assembly!!!
@@ -398,9 +425,9 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
                 final int aLen = recordBuf.length - assemLen;
 
                 System.arraycopy(assemBuf, 0, recordBuf, 0,
-                                 assemLen);
+                    assemLen);
                 System.arraycopy(wBuf, wOffset, recordBuf,
-                                 assemLen, aLen);
+                    assemLen, aLen);
                 writeRecord(recordBuf);
 
                 currBytes += recordBuf.length;
@@ -409,7 +436,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
                 assemLen = 0;
             } else {
                 System.arraycopy(wBuf, wOffset, assemBuf, assemLen,
-                                 numToWrite);
+                    numToWrite);
 
                 wOffset += numToWrite;
                 assemLen += numToWrite;
@@ -425,7 +452,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         while (numToWrite > 0) {
             if (numToWrite < recordBuf.length) {
                 System.arraycopy(wBuf, wOffset, assemBuf, assemLen,
-                                 numToWrite);
+                    numToWrite);
 
                 assemLen += numToWrite;
 
@@ -447,14 +474,14 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
      * @since 1.4
      */
     void writePaxHeaders(final TarArchiveEntry entry,
-                         final String entryName,
-                         final Map<String, String> headers) throws IOException {
+        final String entryName,
+        final Map<String, String> headers) throws IOException {
         String name = "./PaxHeaders.X/" + stripTo7Bits(entryName);
         if (name.length() >= TarConstants.NAMELEN) {
             name = name.substring(0, TarConstants.NAMELEN - 1);
         }
         final TarArchiveEntry pex = new TarArchiveEntry(name,
-                                                  TarConstants.LF_PAX_EXTENDED_HEADER_LC);
+            TarConstants.LF_PAX_EXTENDED_HEADER_LC);
         transferModTime(entry, pex);
 
         final StringWriter w = new StringWriter();
@@ -500,8 +527,8 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     }
 
     /**
-     * @return true if the character could lead to problems when used
-     * inside a TarArchiveEntry name for a PAX header.
+     * @return true if the character could lead to problems when used inside a TarArchiveEntry name
+     * for a PAX header.
      */
     private boolean shouldBeReplaced(final char c) {
         return c == 0 // would be read as Trailing null
@@ -510,8 +537,8 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     }
 
     /**
-     * Write an EOF (end of archive) record to the tar archive.
-     * An EOF record consists of a record of all zeros.
+     * Write an EOF (end of archive) record to the tar archive. An EOF record consists of a record
+     * of all zeros.
      */
     private void writeEOFRecord() throws IOException {
         Arrays.fill(recordBuf, (byte) 0);
@@ -525,13 +552,13 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
 
     @Override
     public ArchiveEntry createArchiveEntry(final File inputFile, final String entryName)
-            throws IOException {
-        if(finished) {
+        throws IOException {
+        if (finished) {
             throw new IOException("Stream has already been finished");
         }
         return new TarArchiveEntry(inputFile, entryName);
     }
-    
+
     /**
      * Write an archive record to the archive.
      *
@@ -539,17 +566,17 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
      * @throws IOException on error
      */
     private void writeRecord(final byte[] record) throws IOException {
-        if (record.length != recordSize) {
+        if (record.length != RECORD_SIZE) {
             throw new IOException("record to write has length '"
-                                  + record.length
-                                  + "' which is not the record size of '"
-                                  + recordSize + "'");
+                + record.length
+                + "' which is not the record size of '"
+                + RECORD_SIZE + "'");
         }
 
         out.write(record);
         recordsWritten++;
     }
-    
+
     /**
      * Write an archive record to the archive, where the record may be
      * inside of a larger array buffer. The buffer must be "offset plus
@@ -560,15 +587,15 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
      * @throws IOException on error
      */
     private void writeRecord(final byte[] buf, final int offset) throws IOException {
- 
-        if (offset + recordSize > buf.length) {
+
+        if (offset + RECORD_SIZE > buf.length) {
             throw new IOException("record has length '" + buf.length
-                                  + "' with offset '" + offset
-                                  + "' which is less than the record size of '"
-                                  + recordSize + "'");
+                + "' with offset '" + offset
+                + "' which is less than the record size of '"
+                + RECORD_SIZE + "'");
         }
 
-        out.write(buf, offset, recordSize);
+        out.write(buf, offset, RECORD_SIZE);
         recordsWritten++;
     }
 
@@ -582,28 +609,28 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     }
 
     private void addPaxHeadersForBigNumbers(final Map<String, String> paxHeaders,
-                                            final TarArchiveEntry entry) {
+        final TarArchiveEntry entry) {
         addPaxHeaderForBigNumber(paxHeaders, "size", entry.getSize(),
-                                 TarConstants.MAXSIZE);
+            TarConstants.MAXSIZE);
         addPaxHeaderForBigNumber(paxHeaders, "gid", entry.getLongGroupId(),
-                                 TarConstants.MAXID);
+            TarConstants.MAXID);
         addPaxHeaderForBigNumber(paxHeaders, "mtime",
-                                 entry.getModTime().getTime() / 1000,
-                                 TarConstants.MAXSIZE);
+            entry.getModTime().getTime() / 1000,
+            TarConstants.MAXSIZE);
         addPaxHeaderForBigNumber(paxHeaders, "uid", entry.getLongUserId(),
-                                 TarConstants.MAXID);
+            TarConstants.MAXID);
         // star extensions by J\u00f6rg Schilling
         addPaxHeaderForBigNumber(paxHeaders, "SCHILY.devmajor",
-                                 entry.getDevMajor(), TarConstants.MAXID);
+            entry.getDevMajor(), TarConstants.MAXID);
         addPaxHeaderForBigNumber(paxHeaders, "SCHILY.devminor",
-                                 entry.getDevMinor(), TarConstants.MAXID);
+            entry.getDevMinor(), TarConstants.MAXID);
         // there is no PAX header for file mode
         failForBigNumber("mode", entry.getMode(), TarConstants.MAXID);
     }
 
     private void addPaxHeaderForBigNumber(final Map<String, String> paxHeaders,
-                                          final String header, final long value,
-                                          final long maxValue) {
+        final String header, final long value,
+        final long maxValue) {
         if (value < 0 || value > maxValue) {
             paxHeaders.put(header, String.valueOf(value));
         }
@@ -613,29 +640,32 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         failForBigNumber("entry size", entry.getSize(), TarConstants.MAXSIZE);
         failForBigNumberWithPosixMessage("group id", entry.getLongGroupId(), TarConstants.MAXID);
         failForBigNumber("last modification time",
-                         entry.getModTime().getTime() / 1000,
-                         TarConstants.MAXSIZE);
+            entry.getModTime().getTime() / 1000,
+            TarConstants.MAXSIZE);
         failForBigNumber("user id", entry.getLongUserId(), TarConstants.MAXID);
         failForBigNumber("mode", entry.getMode(), TarConstants.MAXID);
         failForBigNumber("major device number", entry.getDevMajor(),
-                         TarConstants.MAXID);
+            TarConstants.MAXID);
         failForBigNumber("minor device number", entry.getDevMinor(),
-                         TarConstants.MAXID);
+            TarConstants.MAXID);
     }
 
     private void failForBigNumber(final String field, final long value, final long maxValue) {
         failForBigNumber(field, value, maxValue, "");
     }
 
-    private void failForBigNumberWithPosixMessage(final String field, final long value, final long maxValue) {
-        failForBigNumber(field, value, maxValue, " Use STAR or POSIX extensions to overcome this limit");
+    private void failForBigNumberWithPosixMessage(final String field, final long value,
+        final long maxValue) {
+        failForBigNumber(field, value, maxValue,
+            " Use STAR or POSIX extensions to overcome this limit");
     }
 
-    private void failForBigNumber(final String field, final long value, final long maxValue, final String additionalMsg) {
+    private void failForBigNumber(final String field, final long value, final long maxValue,
+        final String additionalMsg) {
         if (value < 0 || value > maxValue) {
             throw new RuntimeException(field + " '" + value //NOSONAR
-                    + "' is too big ( > "
-                    + maxValue + " )." + additionalMsg);
+                + "' is too big ( > "
+                + maxValue + " )." + additionalMsg);
         }
     }
 
@@ -661,9 +691,9 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
      * @param fieldName the name of the field
      * @return whether a pax header has been written.
      */
-    private boolean handleLongName(final TarArchiveEntry entry , final String name,
-                                   final Map<String, String> paxHeaders,
-                                   final String paxHeaderName, final byte linkType, final String fieldName)
+    private boolean handleLongName(final TarArchiveEntry entry, final String name,
+        final Map<String, String> paxHeaders,
+        final String paxHeaderName, final byte linkType, final String fieldName)
         throws IOException {
         final ByteBuffer encodedName = zipEncoding.encode(name);
         final int len = encodedName.limit() - encodedName.position();
@@ -675,7 +705,8 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
             } else if (longFileMode == LONGFILE_GNU) {
                 // create a TarEntry for the LongLink, the contents
                 // of which are the link's name
-                final TarArchiveEntry longLinkEntry = new TarArchiveEntry(TarConstants.GNU_LONGLINK, linkType);
+                final TarArchiveEntry longLinkEntry = new TarArchiveEntry(TarConstants.GNU_LONGLINK,
+                    linkType);
 
                 longLinkEntry.setSize(len + 1l); // +1 for NUL
                 transferModTime(entry, longLinkEntry);
@@ -685,8 +716,8 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
                 closeArchiveEntry();
             } else if (longFileMode != LONGFILE_TRUNCATE) {
                 throw new RuntimeException(fieldName + " '" + name //NOSONAR
-                                           + "' is too long ( > "
-                                           + TarConstants.NAMELEN + " bytes)");
+                    + "' is too long ( > "
+                    + TarConstants.NAMELEN + " bytes)");
             }
         }
         return false;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -484,8 +484,9 @@ public class TarUtils {
 
         if (length < 9) {
             formatLongBinary(value, buf, offset, length, negative);
+        } else {
+            formatBigIntegerBinary(value, buf, offset, length, negative);
         }
-        formatBigIntegerBinary(value, buf, offset, length, negative);
 
         buf[offset] = (byte) (negative ? 0xff : 0x80);
         return offset + length;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -503,8 +503,8 @@ public class TarUtils {
         }
         if (negative) {
             val ^= max - 1;
-            val |= 0xff << bits;
             val++;
+            val |= 0xffl << bits;
         }
         for (int i = offset + length - 1; i >= offset; i--) {
             buf[i] = (byte) val;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -496,8 +496,8 @@ public class TarUtils {
                                          final boolean negative) {
         final int bits = (length - 1) * 8;
         final long max = 1l << bits;
-        long val = Math.abs(value);
-        if (val >= max) {
+        long val = Math.abs(value); // Long.MIN_VALUE stays Long.MIN_VALUE
+        if (val < 0 || val >= max) {
             throw new IllegalArgumentException("Value " + value +
                 " is too large for " + length + " byte field.");
         }

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -519,6 +519,10 @@ public class TarUtils {
         final BigInteger val = BigInteger.valueOf(value);
         final byte[] b = val.toByteArray();
         final int len = b.length;
+        if (len > length - 1) {
+            throw new IllegalArgumentException("Value " + value +
+                " is too large for " + length + " byte field.");
+        }
         final int off = offset + length - len;
         System.arraycopy(b, 0, buf, off, len);
         final byte fill = (byte) (negative ? 0xff : 0);

--- a/src/main/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStream.java
+++ b/src/main/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStream.java
@@ -31,6 +31,15 @@ public class ChecksumCalculatingInputStream extends InputStream {
     private final Checksum checksum;
 
     public ChecksumCalculatingInputStream(final Checksum checksum, final InputStream in) {
+
+        if ( checksum == null ){
+            throw new NullPointerException("Parameter checksum must not be null");
+        }
+
+        if ( in == null ){
+            throw new NullPointerException("Parameter in must not be null");
+        }
+
         this.checksum = checksum;
         this.in = in;
     }

--- a/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.commons.compress.utils;
 
 import java.io.FileOutputStream;

--- a/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
@@ -27,6 +27,25 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * This class supports writing to an Outputstream or WritableByteChannel in fixed length blocks.
+ * It can be be used to support output to devices such as tape drives that require output in this
+ * format. If the final block does not have enough content to fill an entire block, the output will
+ * be padded to a full block size.
+ * <p/>
+ * This class can be used to support TAR,PAX, and CPIO blocked output to character special devices.
+ * It is not recommended that this class be used unless writing to such devices, as the padding
+ * serves no useful purpose in such cases.
+ * <p/>
+ * This class should normally wrap a FileOutputStream or associated WritableByteChannel directly.
+ * If there is an intervening filter that modified the output, such as a CompressorOutputStream, or
+ * performs its own buffering, such as BufferedOutputStream,  output to the device may
+ * no longer be of the specified size.
+ * <p/>
+ * Any content written to this stream should be self-delimiting and should tolerate any padding
+ * added to fill the last block
+ * .
+ */
 public class FixedLengthBlockOutputStream extends OutputStream implements WritableByteChannel,
     AutoCloseable {
 
@@ -35,6 +54,11 @@ public class FixedLengthBlockOutputStream extends OutputStream implements Writab
     private final ByteBuffer buffer;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
+    /**
+     * Create a fixed length block output stream with given destination stream and block size
+     * @param os   The stream to wrap.
+     * @param blockSize The block size to use.
+     */
     public FixedLengthBlockOutputStream(OutputStream os, int blockSize) {
         if (os instanceof FileOutputStream) {
             FileOutputStream fileOutputStream = (FileOutputStream) os;
@@ -46,6 +70,10 @@ public class FixedLengthBlockOutputStream extends OutputStream implements Writab
         }
         this.blockSize = blockSize;
     }
+     /** Create a fixed length block output stream with given destination writable byte channel and block size
+     * @param out   The writable byte channel to wrap.
+     * @param blockSize The block size to use.
+        */
 
     public FixedLengthBlockOutputStream(WritableByteChannel out, int blockSize) {
         this.out = out;

--- a/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
@@ -47,8 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @since 1.15
  */
-public class FixedLengthBlockOutputStream extends OutputStream implements WritableByteChannel,
-    AutoCloseable {
+public class FixedLengthBlockOutputStream extends OutputStream implements WritableByteChannel {
 
     private final WritableByteChannel out;
     private final int blockSize;

--- a/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
@@ -29,22 +29,23 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class supports writing to an Outputstream or WritableByteChannel in fixed length blocks.
- * It can be be used to support output to devices such as tape drives that require output in this
+ * <p>It can be be used to support output to devices such as tape drives that require output in this
  * format. If the final block does not have enough content to fill an entire block, the output will
- * be padded to a full block size.
- * <p/>
- * This class can be used to support TAR,PAX, and CPIO blocked output to character special devices.
+ * be padded to a full block size.</p>
+ *
+ * <p>This class can be used to support TAR,PAX, and CPIO blocked output to character special devices.
  * It is not recommended that this class be used unless writing to such devices, as the padding
- * serves no useful purpose in such cases.
- * <p/>
- * This class should normally wrap a FileOutputStream or associated WritableByteChannel directly.
+ * serves no useful purpose in such cases.</p>
+ *
+ * <p>This class should normally wrap a FileOutputStream or associated WritableByteChannel directly.
  * If there is an intervening filter that modified the output, such as a CompressorOutputStream, or
  * performs its own buffering, such as BufferedOutputStream,  output to the device may
- * no longer be of the specified size.
- * <p/>
- * Any content written to this stream should be self-delimiting and should tolerate any padding
- * added to fill the last block
- * .
+ * no longer be of the specified size.</p>
+ *
+ * <p>Any content written to this stream should be self-delimiting and should tolerate any padding
+ * added to fill the last block.</p>
+ *
+ * @since 1.15
  */
 public class FixedLengthBlockOutputStream extends OutputStream implements WritableByteChannel,
     AutoCloseable {
@@ -70,11 +71,11 @@ public class FixedLengthBlockOutputStream extends OutputStream implements Writab
         }
         this.blockSize = blockSize;
     }
-     /** Create a fixed length block output stream with given destination writable byte channel and block size
+     /**
+      * Create a fixed length block output stream with given destination writable byte channel and block size
      * @param out   The writable byte channel to wrap.
      * @param blockSize The block size to use.
-        */
-
+     */
     public FixedLengthBlockOutputStream(WritableByteChannel out, int blockSize) {
         this.out = out;
         this.blockSize = blockSize;

--- a/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStream.java
@@ -1,0 +1,209 @@
+package org.apache.commons.compress.utils;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class FixedLengthBlockOutputStream extends OutputStream implements WritableByteChannel,
+    AutoCloseable {
+
+    private final WritableByteChannel out;
+    private final int blockSize;
+    private final ByteBuffer buffer;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public FixedLengthBlockOutputStream(OutputStream os, int blockSize) {
+        if (os instanceof FileOutputStream) {
+            FileOutputStream fileOutputStream = (FileOutputStream) os;
+            out = fileOutputStream.getChannel();
+            buffer = ByteBuffer.allocateDirect(blockSize);
+        } else {
+            out = new BufferAtATimeOutputChannel(os);
+            buffer = ByteBuffer.allocate(blockSize);
+        }
+        this.blockSize = blockSize;
+    }
+
+    public FixedLengthBlockOutputStream(WritableByteChannel out, int blockSize) {
+        this.out = out;
+        this.blockSize = blockSize;
+        this.buffer = ByteBuffer.allocateDirect(blockSize);
+    }
+
+    private void maybeFlush() throws IOException {
+        if (!buffer.hasRemaining()) {
+            writeBlock();
+        }
+    }
+
+    private void writeBlock() throws IOException {
+        buffer.flip();
+        int i = out.write(buffer);
+        boolean hasRemaining = buffer.hasRemaining();
+        if (i != blockSize || hasRemaining) {
+            String msg = String
+                .format("Failed to write %,d bytes atomically. Only wrote  %,d",
+                    blockSize, i);
+            throw new IOException(msg);
+        }
+        buffer.clear();
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if(!isOpen()) {
+            throw new ClosedChannelException();
+        }
+        buffer.put((byte) b);
+        maybeFlush();
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if(!isOpen()) {
+            throw new ClosedChannelException();
+        }
+        while (len > 0) {
+            int n = Math.min(len, buffer.remaining());
+            buffer.put(b, off, n);
+            maybeFlush();
+            len -= n;
+            off += n;
+        }
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        if(!isOpen()) {
+            throw new ClosedChannelException();
+        }
+        int srcRemaining = src.remaining();
+
+        if (srcRemaining < buffer.remaining()) {
+            // if don't have enough bytes in src to fill up a block we must buffer
+            buffer.put(src);
+        } else {
+            int srcLeft = srcRemaining;
+            int savedLimit = src.limit();
+            // If we're not at the start of buffer, we have some bytes already  buffered
+            // fill up the reset of buffer and write the block.
+            if (buffer.position() != 0) {
+                int n = buffer.remaining();
+                src.limit(src.position() + n);
+                buffer.put(src);
+                writeBlock();
+                srcLeft -= n;
+            }
+            // whilst we have enough bytes in src for complete blocks,
+            // write them directly from src without copying them to buffer
+            while (srcLeft >= blockSize) {
+                src.limit(src.position() + blockSize);
+                out.write(src);
+                srcLeft -= blockSize;
+            }
+            // copy any remaining bytes into buffer
+            src.limit(savedLimit);
+            buffer.put(src);
+        }
+        return srcRemaining;
+    }
+
+    @Override
+    public boolean isOpen() {
+        if(!out.isOpen()) {
+            closed.set(true);
+        }
+        return !closed.get();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed.compareAndSet(false, true)) {
+            if (buffer.position() != 0) {
+                padLastBlock();
+                writeBlock();
+            }
+            out.close();
+        }
+    }
+
+    private void padLastBlock() {
+        buffer.order(ByteOrder.nativeOrder());
+        int bytesToWrite = buffer.remaining();
+        if (bytesToWrite > 8) {
+            int align = (buffer.position() & 7);
+            if (align != 0) {
+                int limit = 8 - align;
+                for (int i = 0; i < limit; i++) {
+                    buffer.put((byte) 0);
+                }
+                bytesToWrite -= limit;
+            }
+
+            while (bytesToWrite >= 8) {
+                buffer.putLong(0L);
+                bytesToWrite -= 8;
+            }
+        }
+        while (buffer.hasRemaining()) {
+            buffer.put((byte) 0);
+        }
+    }
+
+    /**
+     * Helper class to provide channel wrapper for arbitrary output stream that doesn't alter the
+     * size of writes.  We can't use Channels.newChannel, because for non FileOutputStreams, it
+     * breaks up writes into 8KB max chunks. Since the purpose of this class is to always write
+     * complete blocks, we need to write a simple class to take care of it.
+     */
+    private static class BufferAtATimeOutputChannel implements WritableByteChannel {
+
+        private final OutputStream out;
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        private BufferAtATimeOutputChannel(OutputStream out) {
+            this.out = out;
+        }
+
+        @Override
+        public int write(ByteBuffer buffer) throws IOException {
+            assert isOpen() : "somehow trying to write to closed BufferAtATimeOutputChannel";
+            assert buffer.hasArray() :
+                "direct buffer somehow written to BufferAtATimeOutputChannel";
+
+            try {
+                int pos = buffer.position();
+                int len = buffer.limit() - pos;
+                out.write(buffer.array(), buffer.arrayOffset() + pos, len);
+                buffer.position(buffer.limit());
+                return len;
+            } catch (IOException e) {
+                  try {
+                      close();
+                  } finally {
+                      throw e;
+                  }
+            }
+        }
+
+        @Override
+        public boolean isOpen() {
+            return !closed.get();
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed.compareAndSet(false, true)) {
+                out.close();
+            }
+        }
+
+    }
+
+
+}

--- a/src/test/java/org/apache/commons/compress/ArchiveUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/ArchiveUtilsTest.java
@@ -18,10 +18,11 @@
 
 package org.apache.commons.compress;
 
-import static org.junit.Assert.*;
-
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.utils.ArchiveUtils;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class ArchiveUtilsTest extends AbstractTestCase {
 
@@ -93,6 +94,53 @@ public class ArchiveUtilsTest extends AbstractTestCase {
         final String input = "\b12345678901234567890123456789012345678901234567890123456789";
         final String expected = "?12345678901234567890123456789012345678901234567890123456789";
         assertEquals(expected, ArchiveUtils.sanitize(input));
+    }
+
+    @Test
+    public void testIsEqualWithNullWithPositive() {
+
+        byte[] byteArray = new byte[8];
+        byteArray[1] = (byte) (-77);
+
+        assertFalse(ArchiveUtils.isEqualWithNull(byteArray, 0, (byte)0, byteArray, (byte)0, (byte)80));
+
+    }
+
+    @Test
+    public void testToAsciiBytes() {
+
+        byte[] byteArray = ArchiveUtils.toAsciiBytes("SOCKET");
+
+        assertArrayEquals(new byte[] {(byte)83, (byte)79, (byte)67, (byte)75, (byte)69, (byte)84}, byteArray);
+
+        assertFalse(ArchiveUtils.isEqualWithNull(byteArray, 0, 46, byteArray, 63, 0));
+
+    }
+
+    @Test
+    public void testToStringWithNonNull() {
+
+        SevenZArchiveEntry sevenZArchiveEntry = new SevenZArchiveEntry();
+        String string = ArchiveUtils.toString(sevenZArchiveEntry);
+
+        assertEquals("-       0 null", string);
+
+    }
+
+    @Test
+    public void testIsEqual() {
+
+        assertTrue(ArchiveUtils.isEqual((byte[]) null, 0, 0, (byte[]) null, 0, 0));
+
+    }
+
+    @Test(expected = StringIndexOutOfBoundsException.class)
+    public void testToAsciiStringThrowsStringIndexOutOfBoundsException() {
+
+        byte[] byteArray = new byte[3];
+
+        ArchiveUtils.toAsciiString(byteArray, 940, 2730);
+
     }
 
     private void asciiToByteAndBackOK(final String inputString) {

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioUtilTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioUtilTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.commons.compress.archivers.cpio;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
 
 public class CpioUtilTest {
 
@@ -52,5 +52,32 @@ public class CpioUtilTest {
                      CpioUtil.byteArray2long(new byte[] { 0x71, (byte) 0xc7 },
                                              true));
     }
+
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testLong2byteArrayWithZeroThrowsUnsupportedOperationException() {
+
+        CpioUtil.long2byteArray(0L, 0, false);
+
+    }
+
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testLong2byteArrayWithPositiveThrowsUnsupportedOperationException() {
+
+        CpioUtil.long2byteArray(0L, 1021, false);
+
+    }
+
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testByteArray2longThrowsUnsupportedOperationException() {
+
+        byte[] byteArray = new byte[1];
+
+        CpioUtil.byteArray2long(byteArray, true);
+
+    }
+
 
 }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.MessageDigest;
 import java.util.Calendar;
 import java.util.Date;
@@ -100,10 +101,10 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.write(new byte[10 * 1024]);
         final byte[] data = bos.toByteArray();
         assertEquals(0x80,
-                     data[TarConstants.NAMELEN
-                        + TarConstants.MODELEN
-                        + TarConstants.UIDLEN
-                        + TarConstants.GIDLEN] & 0x80);
+            data[TarConstants.NAMELEN
+                + TarConstants.MODELEN
+                + TarConstants.UIDLEN
+                + TarConstants.GIDLEN] & 0x80);
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -126,12 +127,12 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.write(new byte[10 * 1024]);
         final byte[] data = bos.toByteArray();
         assertEquals("00000000000 ",
-                     new String(data,
-                                1024 + TarConstants.NAMELEN
-                                + TarConstants.MODELEN
-                                + TarConstants.UIDLEN
-                                + TarConstants.GIDLEN, 12,
-                                CharsetNames.UTF_8));
+            new String(data,
+                1024 + TarConstants.NAMELEN
+                    + TarConstants.MODELEN
+                    + TarConstants.UIDLEN
+                    + TarConstants.GIDLEN, 12,
+                CharsetNames.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -148,11 +149,11 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         m.put("a", "b");
         final byte[] data = writePaxHeader(m);
         assertEquals("00000000006 ",
-                     new String(data, TarConstants.NAMELEN
-                                + TarConstants.MODELEN
-                                + TarConstants.UIDLEN
-                                + TarConstants.GIDLEN, 12,
-                                CharsetNames.UTF_8));
+            new String(data, TarConstants.NAMELEN
+                + TarConstants.MODELEN
+                + TarConstants.UIDLEN
+                + TarConstants.GIDLEN, 12,
+                CharsetNames.UTF_8));
         assertEquals("6 a=b\n", new String(data, 512, 6, CharsetNames.UTF_8));
     }
 
@@ -160,38 +161,38 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
     public void testPaxHeadersWithLength99() throws Exception {
         final Map<String, String> m = new HashMap<>();
         m.put("a",
-              "0123456789012345678901234567890123456789"
-              + "01234567890123456789012345678901234567890123456789"
-              + "012");
+            "0123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "012");
         final byte[] data = writePaxHeader(m);
         assertEquals("00000000143 ",
-                     new String(data, TarConstants.NAMELEN
-                                + TarConstants.MODELEN
-                                + TarConstants.UIDLEN
-                                + TarConstants.GIDLEN, 12,
-                                CharsetNames.UTF_8));
+            new String(data, TarConstants.NAMELEN
+                + TarConstants.MODELEN
+                + TarConstants.UIDLEN
+                + TarConstants.GIDLEN, 12,
+                CharsetNames.UTF_8));
         assertEquals("99 a=0123456789012345678901234567890123456789"
-              + "01234567890123456789012345678901234567890123456789"
-              + "012\n", new String(data, 512, 99, CharsetNames.UTF_8));
+            + "01234567890123456789012345678901234567890123456789"
+            + "012\n", new String(data, 512, 99, CharsetNames.UTF_8));
     }
 
     @Test
     public void testPaxHeadersWithLength101() throws Exception {
         final Map<String, String> m = new HashMap<>();
         m.put("a",
-              "0123456789012345678901234567890123456789"
-              + "01234567890123456789012345678901234567890123456789"
-              + "0123");
+            "0123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "0123");
         final byte[] data = writePaxHeader(m);
         assertEquals("00000000145 ",
-                     new String(data, TarConstants.NAMELEN
-                                + TarConstants.MODELEN
-                                + TarConstants.UIDLEN
-                                + TarConstants.GIDLEN, 12,
-                                CharsetNames.UTF_8));
+            new String(data, TarConstants.NAMELEN
+                + TarConstants.MODELEN
+                + TarConstants.UIDLEN
+                + TarConstants.GIDLEN, 12,
+                CharsetNames.UTF_8));
         assertEquals("101 a=0123456789012345678901234567890123456789"
-              + "01234567890123456789012345678901234567890123456789"
-              + "0123\n", new String(data, 512, 101, CharsetNames.UTF_8));
+            + "01234567890123456789012345678901234567890123456789"
+            + "0123\n", new String(data, 512, 101, CharsetNames.UTF_8));
     }
 
     private byte[] writePaxHeader(final Map<String, String> m) throws Exception {
@@ -226,7 +227,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.closeArchiveEntry();
         final byte[] data = bos.toByteArray();
         assertEquals("160 path=" + n + "\n",
-                     new String(data, 512, 160, CharsetNames.UTF_8));
+            new String(data, 512, 160, CharsetNames.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -248,11 +249,11 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.write(new byte[10 * 1024]);
         final byte[] data = bos.toByteArray();
         assertEquals((byte) 0xff,
-                     data[TarConstants.NAMELEN
-                          + TarConstants.MODELEN
-                          + TarConstants.UIDLEN
-                          + TarConstants.GIDLEN
-                          + TarConstants.SIZELEN]);
+            data[TarConstants.NAMELEN
+                + TarConstants.MODELEN
+                + TarConstants.UIDLEN
+                + TarConstants.GIDLEN
+                + TarConstants.SIZELEN]);
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -279,13 +280,13 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.write(new byte[10 * 1024]);
         final byte[] data = bos.toByteArray();
         assertEquals("00000000000 ",
-                     new String(data,
-                                1024 + TarConstants.NAMELEN
-                                + TarConstants.MODELEN
-                                + TarConstants.UIDLEN
-                                + TarConstants.GIDLEN
-                                + TarConstants.SIZELEN, 12,
-                                CharsetNames.UTF_8));
+            new String(data,
+                1024 + TarConstants.NAMELEN
+                    + TarConstants.MODELEN
+                    + TarConstants.UIDLEN
+                    + TarConstants.GIDLEN
+                    + TarConstants.SIZELEN, 12,
+                CharsetNames.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -328,7 +329,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.close();
         final byte[] data = bos.toByteArray();
         assertEquals("11 path=" + n + "\n",
-                     new String(data, 512, 11, CharsetNames.UTF_8));
+            new String(data, 512, 11, CharsetNames.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -351,7 +352,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.close();
         final byte[] data = bos.toByteArray();
         assertEquals("15 linkpath=" + n + "\n",
-                     new String(data, 512, 15, CharsetNames.UTF_8));
+            new String(data, 512, 15, CharsetNames.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -399,8 +400,8 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
     @Test
     public void testWriteLongDirectoryNameErrorMode() throws Exception {
         final String n = "01234567890123456789012345678901234567890123456789"
-                + "01234567890123456789012345678901234567890123456789"
-                + "01234567890123456789012345678901234567890123456789/";
+            + "01234567890123456789012345678901234567890123456789"
+            + "01234567890123456789012345678901234567890123456789/";
 
         try {
             final TarArchiveEntry t = new TarArchiveEntry(n);
@@ -524,8 +525,8 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
     @Test
     public void testWriteLongLinkNameErrorMode() throws Exception {
         final String linkname = "01234567890123456789012345678901234567890123456789"
-                + "01234567890123456789012345678901234567890123456789"
-                + "01234567890123456789012345678901234567890123456789/test";
+            + "01234567890123456789012345678901234567890123456789"
+            + "01234567890123456789012345678901234567890123456789/test";
         final TarArchiveEntry entry = new TarArchiveEntry("test", TarConstants.LF_SYMLINK);
         entry.setLinkName(linkname);
 
@@ -548,7 +549,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         final String linkname = "01234567890123456789012345678901234567890123456789"
             + "01234567890123456789012345678901234567890123456789"
             + "01234567890123456789012345678901234567890123456789/";
-        final TarArchiveEntry entry = new TarArchiveEntry("test" , TarConstants.LF_SYMLINK);
+        final TarArchiveEntry entry = new TarArchiveEntry("test", TarConstants.LF_SYMLINK);
         entry.setLinkName(linkname);
 
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -607,31 +608,92 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tin.close();
     }
 
+    @SuppressWarnings("deprecation")
+    @Test public void testRecordSize() throws IOException {
+        try {
+            TarArchiveOutputStream tos =
+                new TarArchiveOutputStream(new ByteArrayOutputStream(),512,511);
+            fail("should have rejected recordSize of 511");
+        } catch(IllegalArgumentException e) {
+            // expected;
+        }
+        try {
+            TarArchiveOutputStream tos =
+                new TarArchiveOutputStream(new ByteArrayOutputStream(),512,511,null);
+            fail("should have rejected recordSize of 511");
+        } catch(IllegalArgumentException e) {
+            // expected;
+        }
+        try (TarArchiveOutputStream tos = new TarArchiveOutputStream(new ByteArrayOutputStream(),
+            512, 512)) {
+            assertEquals("recordSize",512,tos.getRecordSize());
+        }
+        try (TarArchiveOutputStream tos = new TarArchiveOutputStream(new ByteArrayOutputStream(),
+            512, 512, null)) {
+            assertEquals("recordSize",512,tos.getRecordSize());
+        }
+    }
     @Test
-    public void testPadsOutputToFullBlockLength() throws Exception {
+    public void testBlockSizes() throws Exception {
+        String fileName = "/test1.xml";
+        byte[] contents = getResourceContents(fileName);
+        testPadding(TarConstants.DEFAULT_BLKSIZE, fileName, contents); // USTAR / pre-pax
+        testPadding(5120, fileName, contents); // PAX default
+        testPadding(1<<15, fileName, contents); //PAX max
+        testPadding(-2, fileName, contents);    // don't specify a block size -> use minimum length
+        try {
+            testPadding(511, fileName, contents);    // don't specify a block size -> use minimum length
+            fail("should have thrown an illegal argument exception");
+        } catch (IllegalArgumentException e) {
+            //expected
+       }
+        try {
+            testPadding(0, fileName, contents);    // don't specify a block size -> use minimum length
+            fail("should have thrown an illegal argument exception");
+        } catch (IllegalArgumentException e) {
+            //expected
+       }
+    }
+
+    private void testPadding(int blockSize, String fileName, byte[] contents) throws IOException {
         final File f = File.createTempFile("commons-compress-padding", ".tar");
         f.deleteOnExit();
         final FileOutputStream fos = new FileOutputStream(f);
-        final TarArchiveOutputStream tos = new TarArchiveOutputStream(fos);
-        final File file1 = getFile("test1.xml");
-        final TarArchiveEntry sEntry = new TarArchiveEntry(file1, file1.getName());
+        final TarArchiveOutputStream tos;
+        if(blockSize != -2) {
+            tos = new TarArchiveOutputStream(fos, blockSize);
+        } else {
+            blockSize = 512;
+            tos = new TarArchiveOutputStream(fos);
+        }
+        TarArchiveEntry sEntry;
+        sEntry = new TarArchiveEntry(fileName);
+        sEntry.setSize(contents.length);
         tos.putArchiveEntry(sEntry);
-        final FileInputStream in = new FileInputStream(file1);
-        IOUtils.copy(in, tos);
-        in.close();
+        tos.write(contents);
         tos.closeArchiveEntry();
         tos.close();
-        // test1.xml is small enough to fit into the default block size
-        assertEquals(TarConstants.DEFAULT_BLKSIZE, f.length());
+        int fileRecordsSize = (int)Math.ceil((double) contents.length / 512)*512;
+        final int headerSize = 512;
+        final int endOfArchiveSize = 1024;
+        int unpaddedSize = headerSize + fileRecordsSize + endOfArchiveSize;
+        int paddedSize = (int)Math.ceil((double)unpaddedSize/blockSize)*blockSize;
+        assertEquals(paddedSize, f.length());
+    }
+
+    private byte[] getResourceContents(String name) throws IOException {
+        ByteArrayOutputStream bos;
+        try (InputStream resourceAsStream = getClass().getResourceAsStream(name)) {
+            bos = new ByteArrayOutputStream();
+            IOUtils.copy(resourceAsStream, bos);
+        }
+        return bos.toByteArray();
     }
 
     /**
-     * When using long file names the longLinkEntry included the
-     * current timestamp as the Entry modification date. This was
-     * never exposed to the client but it caused identical archives to
+     * When using long file names the longLinkEntry included the current timestamp as the Entry
+     * modification date. This was never exposed to the client but it caused identical archives to
      * have different MD5 hashes.
-     *
-     * @throws Exception
      */
     @Test
     public void testLongNameMd5Hash() throws Exception {
@@ -655,15 +717,18 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         // do I still have the correct modification date?
         // let a second elapse so we don't get the current time
         Thread.sleep(1000);
-        final TarArchiveInputStream tarIn = new TarArchiveInputStream(new ByteArrayInputStream(archive2));
+        final TarArchiveInputStream tarIn = new TarArchiveInputStream(
+            new ByteArrayInputStream(archive2));
         final ArchiveEntry nextEntry = tarIn.getNextEntry();
         assertEquals(longFileName, nextEntry.getName());
         // tar archive stores modification time to second granularity only (floored)
-        assertEquals(modificationDate.getTime() / 1000, nextEntry.getLastModifiedDate().getTime() / 1000);
+        assertEquals(modificationDate.getTime() / 1000,
+            nextEntry.getLastModifiedDate().getTime() / 1000);
         tarIn.close();
     }
 
-    private static byte[] createTarArchiveContainingOneDirectory(final String fname, final Date modificationDate) throws IOException {
+    private static byte[] createTarArchiveContainingOneDirectory(final String fname,
+        final Date modificationDate) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final TarArchiveOutputStream tarOut = new TarArchiveOutputStream(baos, 1024);
         tarOut.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -160,7 +160,8 @@ public class TarUtilsTest {
         checkRoundTripOctalOrBinary(1, length);
         checkRoundTripOctalOrBinary(TarConstants.MAXSIZE, length); // will need binary format
         checkRoundTripOctalOrBinary(-1, length); // will need binary format
-        checkRoundTripOctalOrBinary(0xff00000000000001l, length);
+        checkRoundTripOctalOrBinary(0xffffffffffffffl, length);
+        checkRoundTripOctalOrBinary(-0xffffffffffffffl, length);
     }
 
     // Check correct trailing bytes are generated

--- a/src/test/java/org/apache/commons/compress/changes/ChangeTest.java
+++ b/src/test/java/org/apache/commons/compress/changes/ChangeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.changes;
+
+import org.apache.commons.compress.archivers.memory.MemoryArchiveEntry;
+import org.junit.Test;
+
+import java.io.PipedInputStream;
+
+
+/**
+ * Unit tests for class {@link Change}.
+ *
+ * @date 16.06.2017
+ * @see Change
+ **/
+public class ChangeTest {
+
+
+    @Test(expected = NullPointerException.class)
+    public void testFailsToCreateChangeTakingFourArgumentsThrowsNullPointerExceptionOne() {
+
+        MemoryArchiveEntry memoryArchiveEntry = new MemoryArchiveEntry("x");
+
+        Change change  = new Change(memoryArchiveEntry, null, false);
+
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void testFailsToCreateChangeTakingFourArgumentsThrowsNullPointerExceptionTwo() {
+
+        PipedInputStream pipedInputStream = new PipedInputStream(1);
+
+        Change change  = new Change(null, pipedInputStream, false);
+
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void testFailsToCreateChangeTakingThreeArgumentsThrowsNullPointerException() {
+
+        Change change  = new Change(null, (-407));
+
+    }
+
+
+}

--- a/src/test/java/org/apache/commons/compress/compressors/xz/XZCompressorOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/xz/XZCompressorOutputStreamTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.compress.compressors.xz;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -39,12 +40,15 @@ public class XZCompressorOutputStreamTest {
     public void testWrite() throws IOException {
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(4590);
-        XZCompressorOutputStream xZCompressorOutputStream = new XZCompressorOutputStream(byteArrayOutputStream);
-        xZCompressorOutputStream.write(4590);
+        try (XZCompressorOutputStream xZCompressorOutputStream = new XZCompressorOutputStream(byteArrayOutputStream)) {
+            xZCompressorOutputStream.write(4590);
+        }
 
-        assertEquals(24, byteArrayOutputStream.size());
-        assertEquals("\uFFFD7zXZ\u0000\u0000\u0004\uFFFD\u05B4F\u0002\u0000!\u0001\u0016\u0000\u0000\u0000t/\uFFFD", byteArrayOutputStream.toString());
-
+        try (XZCompressorInputStream xZCompressorInputStream =
+            new XZCompressorInputStream(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))) {
+            assertEquals(4590 % 256, xZCompressorInputStream.read());
+            assertEquals(-1, xZCompressorInputStream.read());
+        }
     }
 
 

--- a/src/test/java/org/apache/commons/compress/compressors/xz/XZCompressorOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/xz/XZCompressorOutputStreamTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.compressors.xz;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Unit tests for class {@link XZCompressorOutputStream}.
+ *
+ * @date 16.06.2017
+ * @see XZCompressorOutputStream
+ **/
+public class XZCompressorOutputStreamTest {
+
+
+    @Test
+    public void testWrite() throws IOException {
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(4590);
+        XZCompressorOutputStream xZCompressorOutputStream = new XZCompressorOutputStream(byteArrayOutputStream);
+        xZCompressorOutputStream.write(4590);
+
+        assertEquals(24, byteArrayOutputStream.size());
+        assertEquals("\uFFFD7zXZ\u0000\u0000\u0004\uFFFD\u05B4F\u0002\u0000!\u0001\u0016\u0000\u0000\u0000t/\uFFFD", byteArrayOutputStream.toString());
+
+    }
+
+
+}

--- a/src/test/java/org/apache/commons/compress/compressors/z/ZCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/z/ZCompressorInputStreamTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.compressors.z;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.SequenceInputStream;
+import java.util.Enumeration;
+
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+
+
+/**
+ * Unit tests for class {@link ZCompressorInputStream}.
+ *
+ * @date 16.06.2017
+ * @see ZCompressorInputStream
+ **/
+public class ZCompressorInputStreamTest {
+
+
+    @Test(expected = IOException.class)
+    public void testFailsToCreateZCompressorInputStreamAndThrowsIOException() throws IOException {
+
+        Enumeration<SequenceInputStream> enumeration = (Enumeration<SequenceInputStream>) mock(Enumeration.class);
+        SequenceInputStream sequenceInputStream = new SequenceInputStream(enumeration);
+        ZCompressorInputStream zCompressorInputStream = null;
+
+        doReturn(false).when(enumeration).hasMoreElements();
+
+        zCompressorInputStream = new ZCompressorInputStream(sequenceInputStream);
+
+    }
+
+
+}

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.*;
 /**
  * Unit tests for class {@link ChecksumCalculatingInputStream org.apache.commons.compress.utils.ChecksumCalculatingInputStream}.
  *
- * @author Michael Hausegger, hausegger.michael@googlemail.com
  * @date 13.06.2017
  * @see ChecksumCalculatingInputStream
  **/

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
@@ -89,17 +89,6 @@ public class ChecksumCalculatingInputStreamTest {
     }
 
 
-    @Test(expected = NullPointerException.class) //I assume this behaviour to be a bug or at least a defect.
-    public void testGetValueThrowsNullPointerException() {
-
-        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(null,null);
-
-        checksumCalculatingInputStream.getValue();
-
-
-    }
-
-
     @Test
     public void testReadTakingByteArray() throws IOException {
 

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
@@ -22,6 +22,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.zip.Adler32;
+import java.util.zip.CRC32;
 
 import static org.junit.Assert.*;
 
@@ -105,6 +106,31 @@ public class ChecksumCalculatingInputStreamTest {
 
     }
 
+
+    @Test(expected = NullPointerException.class)
+    public void testClassInstantiationWithParameterBeingNullThrowsNullPointerExceptionOne() {
+
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(null,null);
+
+
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void testClassInstantiationWithParameterBeingNullThrowsNullPointerExceptionTwo() {
+
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(null,new ByteArrayInputStream(new byte[1]));
+
+
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void testClassInstantiationWithParameterBeingNullThrowsNullPointerExceptionThree() {
+
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(new CRC32(),null);
+
+    }
 
 
 }

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
@@ -38,10 +38,10 @@ public class ChecksumCalculatingInputStreamTest {
     @Test
     public void testSkipReturningZero() throws IOException {
 
-        Adler32 adler32_ = new Adler32();
+        Adler32 adler32 = new Adler32();
         byte[] byteArray = new byte[0];
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
-        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32, byteArrayInputStream);
         long skipResult = checksumCalculatingInputStream.skip(60L);
 
         assertEquals(0L, skipResult);
@@ -55,10 +55,10 @@ public class ChecksumCalculatingInputStreamTest {
     @Test
     public void testSkipReturningPositive() throws IOException {
 
-        Adler32 adler32_ = new Adler32();
+        Adler32 adler32 = new Adler32();
         byte[] byteArray = new byte[6];
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
-        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32, byteArrayInputStream);
         long skipResult = checksumCalculatingInputStream.skip((byte)0);
 
         assertEquals(1L, skipResult);
@@ -71,10 +71,10 @@ public class ChecksumCalculatingInputStreamTest {
     @Test
     public void testReadTakingNoArguments() throws IOException {
 
-        Adler32 adler32_ = new Adler32();
+        Adler32 adler32 = new Adler32();
         byte[] byteArray = new byte[6];
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
-        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32, byteArrayInputStream);
         BufferedInputStream bufferedInputStream = new BufferedInputStream(checksumCalculatingInputStream);
         int inputStreamReadResult = bufferedInputStream.read(byteArray, 0, 1);
         int checkSumCalculationReadResult = checksumCalculatingInputStream.read();
@@ -92,10 +92,10 @@ public class ChecksumCalculatingInputStreamTest {
     @Test
     public void testReadTakingByteArray() throws IOException {
 
-        Adler32 adler32_ = new Adler32();
+        Adler32 adler32 = new Adler32();
         byte[] byteArray = new byte[6];
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
-        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32, byteArrayInputStream);
         int readResult = checksumCalculatingInputStream.read(byteArray);
 
         assertEquals(6, readResult);

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumCalculatingInputStreamTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.compress.utils;
+
+import org.junit.Test;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.zip.Adler32;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for class {@link ChecksumCalculatingInputStream org.apache.commons.compress.utils.ChecksumCalculatingInputStream}.
+ *
+ * @author Michael Hausegger, hausegger.michael@googlemail.com
+ * @date 13.06.2017
+ * @see ChecksumCalculatingInputStream
+ **/
+public class ChecksumCalculatingInputStreamTest {
+
+
+
+    @Test
+    public void testSkipReturningZero() throws IOException {
+
+        Adler32 adler32_ = new Adler32();
+        byte[] byteArray = new byte[0];
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        long skipResult = checksumCalculatingInputStream.skip(60L);
+
+        assertEquals(0L, skipResult);
+
+        assertEquals(1L, checksumCalculatingInputStream.getValue());
+
+
+    }
+
+
+    @Test
+    public void testSkipReturningPositive() throws IOException {
+
+        Adler32 adler32_ = new Adler32();
+        byte[] byteArray = new byte[6];
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        long skipResult = checksumCalculatingInputStream.skip((byte)0);
+
+        assertEquals(1L, skipResult);
+
+        assertEquals(65537L, checksumCalculatingInputStream.getValue());
+
+    }
+
+
+    @Test
+    public void testReadTakingNoArguments() throws IOException {
+
+        Adler32 adler32_ = new Adler32();
+        byte[] byteArray = new byte[6];
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        BufferedInputStream bufferedInputStream = new BufferedInputStream(checksumCalculatingInputStream);
+        int inputStreamReadResult = bufferedInputStream.read(byteArray, 0, 1);
+        int checkSumCalculationReadResult = checksumCalculatingInputStream.read();
+
+        assertFalse(checkSumCalculationReadResult == inputStreamReadResult);
+        assertEquals((-1), checkSumCalculationReadResult);
+
+        assertEquals(0, byteArrayInputStream.available());
+
+        assertEquals(393217L, checksumCalculatingInputStream.getValue());
+
+    }
+
+
+    @Test(expected = NullPointerException.class) //I assume this behaviour to be a bug or at least a defect.
+    public void testGetValueThrowsNullPointerException() {
+
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(null,null);
+
+        checksumCalculatingInputStream.getValue();
+
+
+    }
+
+
+    @Test
+    public void testReadTakingByteArray() throws IOException {
+
+        Adler32 adler32_ = new Adler32();
+        byte[] byteArray = new byte[6];
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+        ChecksumCalculatingInputStream checksumCalculatingInputStream = new ChecksumCalculatingInputStream(adler32_, byteArrayInputStream);
+        int readResult = checksumCalculatingInputStream.read(byteArray);
+
+        assertEquals(6, readResult);
+
+        assertEquals(0, byteArrayInputStream.available());
+        assertEquals(393217L, checksumCalculatingInputStream.getValue());
+
+    }
+
+
+
+}

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumVerifyingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumVerifyingInputStreamTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * Unit tests for class {@link ChecksumVerifyingInputStream org.apache.commons.compress.utils.ChecksumVerifyingInputStream}.
  *
- * @author Michael Hausegger, hausegger.michael@googlemail.com
  * @date 13.06.2017
  * @see ChecksumVerifyingInputStream
  **/

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumVerifyingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumVerifyingInputStreamTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.compress.utils;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.zip.Adler32;
+import java.util.zip.CRC32;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for class {@link ChecksumVerifyingInputStream org.apache.commons.compress.utils.ChecksumVerifyingInputStream}.
+ *
+ * @author Michael Hausegger, hausegger.michael@googlemail.com
+ * @date 13.06.2017
+ * @see ChecksumVerifyingInputStream
+ **/
+public class ChecksumVerifyingInputStreamTest {
+
+
+
+    @Test(expected = IOException.class)
+    public void testReadTakingByteArrayThrowsIOException() throws IOException {
+
+        Adler32 adler32_ = new Adler32();
+        byte[] byteArray = new byte[3];
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+        ChecksumVerifyingInputStream checksumVerifyingInputStream = new ChecksumVerifyingInputStream(adler32_, byteArrayInputStream, (-1859L), (byte) (-68));
+
+        checksumVerifyingInputStream.read(byteArray);
+
+    }
+
+
+    @Test(expected = IOException.class)
+    public void testReadTakingNoArgumentsThrowsIOException() throws IOException {
+
+        CRC32 cRC32_ = new CRC32();
+        byte[] byteArray = new byte[9];
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+        ChecksumVerifyingInputStream checksumVerifyingInputStream = new ChecksumVerifyingInputStream(cRC32_, byteArrayInputStream, (byte)1, (byte)1);
+
+        checksumVerifyingInputStream.read();
+
+    }
+
+
+    @Test
+    public void testSkip() throws IOException {
+
+        CRC32 cRC32_ = new CRC32();
+        byte[] byteArray = new byte[4];
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+        ChecksumVerifyingInputStream checksumVerifyingInputStream = new ChecksumVerifyingInputStream(cRC32_, byteArrayInputStream, (byte)33, 2303L);
+        int intOne = checksumVerifyingInputStream.read(byteArray);
+
+        long skipReturnValue = checksumVerifyingInputStream.skip((byte)1);
+
+        assertEquals(558161692L, cRC32_.getValue());
+        assertEquals(0, byteArrayInputStream.available());
+
+        assertArrayEquals(new byte[] {(byte)0, (byte)0, (byte)0, (byte)0}, byteArray);
+        assertEquals(0L, skipReturnValue);
+
+    }
+
+
+
+}

--- a/src/test/java/org/apache/commons/compress/utils/ChecksumVerifyingInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ChecksumVerifyingInputStreamTest.java
@@ -39,10 +39,10 @@ public class ChecksumVerifyingInputStreamTest {
     @Test(expected = IOException.class)
     public void testReadTakingByteArrayThrowsIOException() throws IOException {
 
-        Adler32 adler32_ = new Adler32();
+        Adler32 adler32 = new Adler32();
         byte[] byteArray = new byte[3];
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
-        ChecksumVerifyingInputStream checksumVerifyingInputStream = new ChecksumVerifyingInputStream(adler32_, byteArrayInputStream, (-1859L), (byte) (-68));
+        ChecksumVerifyingInputStream checksumVerifyingInputStream = new ChecksumVerifyingInputStream(adler32, byteArrayInputStream, (-1859L), (byte) (-68));
 
         checksumVerifyingInputStream.read(byteArray);
 

--- a/src/test/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStreamTest.java
@@ -1,0 +1,365 @@
+package org.apache.commons.compress.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Test;
+import org.mockito.internal.matchers.GreaterOrEqual;
+
+public class FixedLengthBlockOutputStreamTest {
+
+    @Test
+    public void testSmallWrite() throws IOException {
+        testWriteAndPad(10240, "hello world!\n", false);
+        testWriteAndPad(512, "hello world!\n", false);
+        testWriteAndPad(11, "hello world!\n", false);
+        testWriteAndPad(3, "hello world!\n", false);
+    }
+
+    @Test
+    public void testSmallWriteToStream() throws IOException {
+        testWriteAndPadToStream(10240, "hello world!\n", false);
+        testWriteAndPadToStream(512, "hello world!\n", false);
+        testWriteAndPadToStream(11, "hello world!\n", false);
+        testWriteAndPadToStream(3, "hello     world!\n", false);
+    }
+
+    @Test
+    public void testWriteSingleBytes() throws IOException {
+        int blockSize = 4;
+        MockWritableByteChannel mock = new MockWritableByteChannel(blockSize, false);
+        ByteArrayOutputStream bos = mock.bos;
+        String text = "hello world avengers";
+        byte msg[] = text.getBytes();
+        int len = msg.length;
+        try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
+            for (int i = 0; i < len; i++) {
+                out.write(msg[i]);
+            }
+        }
+        byte[] output = bos.toByteArray();
+
+        validate(blockSize, msg, output);
+    }
+
+
+    @Test
+    public void testWriteBuf() throws IOException {
+        String hwa = "hello world avengers";
+        testBuf(4, hwa);
+        testBuf(512, hwa);
+        testBuf(10240, hwa);
+        testBuf(11, hwa + hwa + hwa);
+    }
+
+    @Test
+    public void testMultiWriteBuf() throws IOException {
+        int blockSize = 13;
+        MockWritableByteChannel mock = new MockWritableByteChannel(blockSize, false);
+        String testString = "hello world";
+        byte msg[] = testString.getBytes();
+        int reps = 17;
+
+        try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
+            for (int i = 0; i < reps; i++) {
+                ByteBuffer buf = getByteBuffer(msg);
+                out.write(buf);
+            }
+        }
+        ByteArrayOutputStream bos = mock.bos;
+        double v = Math.ceil((reps * msg.length) / (double) blockSize) * blockSize;
+        assertEquals("wrong size", (long) v, bos.size());
+        int strLen = msg.length * reps;
+        byte[] output = bos.toByteArray();
+        String l = new String(output, 0, strLen);
+        StringBuilder buf = new StringBuilder(strLen);
+        for (int i = 0; i < reps; i++) {
+            buf.append(testString);
+        }
+        assertEquals(buf.toString(), l);
+        for (int i = strLen; i < output.length; i++) {
+            assertEquals(0, output[i]);
+        }
+    }
+
+    @Test
+    public void testPartialWritingThrowsException() {
+        try {
+            testWriteAndPad(512, "hello world!\n", true);
+            fail("Exception for partial write not thrown");
+        } catch (IOException e) {
+            String msg = e.getMessage();
+            assertEquals("exception message",
+                "Failed to write 512 bytes atomically. Only wrote  511", msg);
+        }
+
+    }
+
+    @Test
+    public void testWriteFailsAfterFLClosedThrowsException() {
+        try {
+            FixedLengthBlockOutputStream out = getClosedFLBOS();
+            out.write(1);
+            fail("expected Closed Channel Exception");
+        } catch (IOException e) {
+            assertThat(e, IsInstanceOf.instanceOf(ClosedChannelException.class));
+            // expected
+        }
+        try {
+            FixedLengthBlockOutputStream out = getClosedFLBOS();
+            out.write(new byte[] {0,1,2,3});
+            fail("expected Closed Channel Exception");
+        } catch (IOException e) {
+            assertThat(e, IsInstanceOf.instanceOf(ClosedChannelException.class));
+            // expected
+        }
+
+        try {
+            FixedLengthBlockOutputStream out = getClosedFLBOS();
+            out.write(ByteBuffer.wrap(new byte[] {0,1,2,3}));
+            fail("expected Closed Channel Exception");
+        } catch (IOException e) {
+            assertThat(e, IsInstanceOf.instanceOf(ClosedChannelException.class));
+            // expected
+        }
+
+    }
+
+    private FixedLengthBlockOutputStream getClosedFLBOS() throws IOException {
+        int blockSize = 512;
+        FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(
+            new MockOutputStream(blockSize, false), blockSize);
+        out.write(1);
+        assertTrue(out.isOpen());
+        out.close();
+        assertFalse(out.isOpen());
+        return out;
+    }
+
+    @Test
+    public void testWriteFailsAfterDestClosedThrowsException() {
+        int blockSize = 2;
+        MockOutputStream mock = new MockOutputStream(blockSize, false);
+        FixedLengthBlockOutputStream out =
+            new FixedLengthBlockOutputStream(mock, blockSize);
+        try {
+            out.write(1);
+            assertTrue(out.isOpen());
+            mock.close();
+            out.write(1);
+            fail("expected IO Exception");
+        } catch (IOException e) {
+            // expected
+        }
+        assertFalse(out.isOpen());
+    }
+
+    @Test
+    public void testWithFileOutputStream() throws IOException {
+        final Path tempFile = Files.createTempFile("xxx", "yyy");
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (IOException e) {
+                }
+            }
+        });
+        int blockSize = 512;
+        int reps = 1000;
+        OutputStream os = new FileOutputStream(tempFile.toFile());
+        try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(
+            os, blockSize)) {
+            DataOutputStream dos = new DataOutputStream(out);
+            for (int i = 0; i < reps; i++) {
+               dos.writeInt(i);
+            }
+        }
+        long expectedDataSize = reps * 4L;
+        long expectedFileSize = (long)Math.ceil(expectedDataSize/(double)blockSize)*blockSize;
+        assertEquals("file size",expectedFileSize, Files.size(tempFile));
+        DataInputStream din = new DataInputStream(Files.newInputStream(tempFile));
+        for(int i=0;i<reps;i++) {
+            assertEquals("file int",i,din.readInt());
+        }
+        for(int i=0;i<expectedFileSize - expectedDataSize;i++) {
+            assertEquals(0,din.read());
+        }
+        assertEquals(-1,din.read());
+    }
+
+    private void testBuf(int blockSize, String text) throws IOException {
+        MockWritableByteChannel mock = new MockWritableByteChannel(blockSize, false);
+
+        ByteArrayOutputStream bos = mock.bos;
+        byte msg[] = text.getBytes();
+        ByteBuffer buf = getByteBuffer(msg);
+        try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
+            out.write(buf);
+        }
+        double v = Math.ceil(msg.length / (double) blockSize) * blockSize;
+        assertEquals("wrong size", (long) v, bos.size());
+        byte[] output = bos.toByteArray();
+        String l = new String(output, 0, msg.length);
+        assertEquals(text, l);
+        for (int i = msg.length; i < bos.size(); i++) {
+            assertEquals(String.format("output[%d]", i), 0, output[i]);
+
+        }
+    }
+
+    private ByteBuffer getByteBuffer(byte[] msg) {
+        int len = msg.length;
+        ByteBuffer buf = ByteBuffer.allocate(len);
+        buf.put(msg);
+        buf.flip();
+        return buf;
+    }
+
+
+    private void testWriteAndPad(int blockSize, String text, boolean doPartialWrite)
+        throws IOException {
+        MockWritableByteChannel mock = new MockWritableByteChannel(blockSize, doPartialWrite);
+        byte[] msg = text.getBytes(StandardCharsets.US_ASCII);
+
+        ByteArrayOutputStream bos = mock.bos;
+        try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
+
+            out.write(msg);
+            assertEquals("no partial write", (msg.length / blockSize) * blockSize, bos.size());
+        }
+        validate(blockSize, msg, bos.toByteArray());
+    }
+
+    private void testWriteAndPadToStream(int blockSize, String text, boolean doPartialWrite)
+        throws IOException {
+        MockOutputStream mock = new MockOutputStream(blockSize, doPartialWrite);
+        byte[] msg = text.getBytes(StandardCharsets.US_ASCII);
+
+        ByteArrayOutputStream bos = mock.bos;
+        try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
+            out.write(msg);
+            assertEquals("no partial write", (msg.length / blockSize) * blockSize, bos.size());
+        }
+        validate(blockSize, msg, bos.toByteArray());
+
+    }
+
+
+    private void validate(int blockSize, byte[] expectedBytes, byte[] actualBytes) {
+        double v = Math.ceil(expectedBytes.length / (double) blockSize) * blockSize;
+        assertEquals("wrong size", (long) v, actualBytes.length);
+        assertContainsAtOffset("output", expectedBytes, 0, actualBytes);
+        for (int i = expectedBytes.length; i < actualBytes.length; i++) {
+            assertEquals(String.format("output[%d]", i), 0, actualBytes[i]);
+
+        }
+    }
+
+    private static void assertContainsAtOffset(String msg, byte[] expected, int offset,
+        byte[] actual) {
+        assertThat(actual.length, new GreaterOrEqual<>(offset + expected.length));
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(String.format("%s ([%d])", msg, i), expected[i], actual[i + offset]);
+        }
+    }
+
+    private static class MockOutputStream extends OutputStream {
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        private final int requiredWriteSize;
+        private final boolean doPartialWrite;
+        private AtomicBoolean closed = new AtomicBoolean();
+
+        private MockOutputStream(int requiredWriteSize, boolean doPartialWrite) {
+            this.requiredWriteSize = requiredWriteSize;
+            this.doPartialWrite = doPartialWrite;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            checkIsOpen();
+            assertEquals("write size", requiredWriteSize, len);
+            if (doPartialWrite) {
+                len--;
+            }
+            bos.write(b, off, len);
+        }
+
+        private void checkIsOpen() throws IOException {
+            if (closed.get()) {
+                IOException e = new IOException("Closed");
+                throw e;
+            }
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            checkIsOpen();
+            assertEquals("write size", requiredWriteSize, 1);
+            bos.write(b);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed.compareAndSet(false, true)) {
+                bos.close();
+            }
+        }
+    }
+
+    private static class MockWritableByteChannel implements WritableByteChannel {
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        private final int requiredWriteSize;
+        private final boolean doPartialWrite;
+
+        private MockWritableByteChannel(int requiredWriteSize, boolean doPartialWrite) {
+            this.requiredWriteSize = requiredWriteSize;
+            this.doPartialWrite = doPartialWrite;
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            assertEquals("write size", requiredWriteSize, src.remaining());
+            if (doPartialWrite) {
+                src.limit(src.limit() - 1);
+            }
+            int bytesOut = src.remaining();
+            while (src.hasRemaining()) {
+                bos.write(src.get());
+            }
+            return bytesOut;
+        }
+
+        AtomicBoolean closed = new AtomicBoolean();
+
+        @Override
+        public boolean isOpen() {
+            return !closed.get();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed.compareAndSet(false, true);
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStreamTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.commons.compress.utils;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/apache/commons/compress/utils/ServiceLoaderIteratorTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ServiceLoaderIteratorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.utils;
+
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Unit tests for class {@link ServiceLoaderIterator org.apache.commons.compress.utils.ServiceLoaderIterator}.
+ *
+ * @author Michael Hausegger, hausegger.michael@googlemail.com
+ * @date 13.06.2017
+ * @see ServiceLoaderIterator
+ **/
+public class ServiceLoaderIteratorTest {
+
+
+
+    @Test(expected = NoSuchElementException.class)
+    public void testNextThrowsNoSuchElementException() {
+
+        Class<String> clasz = String.class;
+        ServiceLoaderIterator<String> serviceLoaderIterator = new ServiceLoaderIterator<String>(clasz);
+
+        serviceLoaderIterator.next();
+
+    }
+
+
+    @Test
+    public void testHasNextReturnsFalse() {
+
+        Class<Object> clasz = Object.class;
+        ServiceLoaderIterator<Object> serviceLoaderIterator = new ServiceLoaderIterator<Object>(clasz);
+        boolean result = serviceLoaderIterator.hasNext();
+
+        assertFalse(result);
+
+    }
+
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemoveThrowsUnsupportedOperationException() {
+
+        Class<Integer> clasz = Integer.class;
+        ServiceLoaderIterator<Integer> serviceLoaderIterator = new ServiceLoaderIterator<Integer>(clasz);
+
+        serviceLoaderIterator.remove();
+
+
+    }
+
+
+
+}

--- a/src/test/java/org/apache/commons/compress/utils/ServiceLoaderIteratorTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ServiceLoaderIteratorTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertFalse;
 /**
  * Unit tests for class {@link ServiceLoaderIterator org.apache.commons.compress.utils.ServiceLoaderIterator}.
  *
- * @author Michael Hausegger, hausegger.michael@googlemail.com
  * @date 13.06.2017
  * @see ServiceLoaderIterator
  **/


### PR DESCRIPTION
This PR includes the commits for COMPRESS-405 and COMPRESS-406.  
The new content is  
https://github.com/sesuncedu/commons-compress/commit/d754d8922a507da887aba70292aa650823a7a38c if cherry-picking.

The rest of the block size changes will be all be based on here, since they become less  separable