### PR TITLE
Missing Test Case for octal to binary conversion

### DIFF
--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -367,5 +367,15 @@ public class TarUtilsTest {
         };
         assertEquals(expected, TarUtils.parseOctalOrBinary(buffer, 0, buffer.length));
     }
+    
+    @Test
+    public void testRoundTripOctalOrBinary8_ValueTooBigForBinary() {
+        try {
+        	checkRoundTripOctalOrBinary(Long.MAX_VALUE, 8);
+            fail("Should throw exception - value is too long to fit buffer of this len");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Value 9223372036854775807 is too large for 8 byte field.", e.getMessage());
+        }
+    }
 
 }


### PR DESCRIPTION
In order to ensure that there is at least one test that will enter the octal string conversion, we  added a test that for value = Long.MAX\_VALUE with an insufficient small length of 8 for the buffer. This will check that the value can not be converted into an octal and throw an exception with an appropriate message which we check. This missing test case was an outcome of our mutation testing analysis performed on your system.