### PR TITLE
[COMPRESS-429] Provide information about source of name / comment field values (e.g. Unicode)

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -98,7 +98,8 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
     private long localHeaderOffset = OFFSET_UNKNOWN;
     private long dataOffset = OFFSET_UNKNOWN;
     private boolean isStreamContiguous = false;
-
+    private boolean hasUnicodeName = false;
+    private boolean hasUnicodeComment = false;
 
     /**
      * Creates a new zip entry with the specified name.
@@ -926,5 +927,21 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
      */
     public void setRawFlag(final int rawFlag) {
         this.rawFlag = rawFlag;
+    }
+
+    public boolean hasUnicodeName() {
+        return hasUnicodeName;
+    }
+
+    public void setHasUnicodeName(boolean hasUnicodeName) {
+        this.hasUnicodeName = hasUnicodeName;
+    }
+
+    public boolean hasUnicodeComment() {
+        return hasUnicodeComment;
+    }
+
+    public void setHasUnicodeComment(boolean hasUnicodeComment) {
+        this.hasUnicodeComment = hasUnicodeComment;
     }
 }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -59,6 +59,17 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
     private static final int SHORT_SHIFT = 16;
     private static final byte[] EMPTY = new byte[0];
 
+    public enum NameSource {
+        NAME,
+        NAME_WITH_EFS_FLAG,
+        UNICODE_EXTRA_FIELD
+    }
+
+    public enum CommentSource {
+        COMMENT,
+        UNICODE_EXTRA_FIELD
+    }
+
     /**
      * The {@link java.util.zip.ZipEntry} base class only supports
      * the compression methods STORED and DEFLATED. We override the
@@ -98,8 +109,9 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
     private long localHeaderOffset = OFFSET_UNKNOWN;
     private long dataOffset = OFFSET_UNKNOWN;
     private boolean isStreamContiguous = false;
-    private boolean hasUnicodeName = false;
-    private boolean hasUnicodeComment = false;
+    private NameSource nameSource = NameSource.NAME;
+    private CommentSource commentSource = CommentSource.COMMENT;
+
 
     /**
      * Creates a new zip entry with the specified name.
@@ -929,19 +941,40 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
         this.rawFlag = rawFlag;
     }
 
-    public boolean hasUnicodeName() {
-        return hasUnicodeName;
+    /**
+     * The source of the name field value.
+     * @return source of the name field value
+     * @since 1.16
+     */
+    public NameSource getNameSource() {
+        return nameSource;
     }
 
-    public void setHasUnicodeName(boolean hasUnicodeName) {
-        this.hasUnicodeName = hasUnicodeName;
+    /**
+     * Sets the source of the name field value.
+     * @param nameSource source of the name field value
+     * @since 1.16
+     */
+    public void setNameSource(NameSource nameSource) {
+        this.nameSource = nameSource;
     }
 
-    public boolean hasUnicodeComment() {
-        return hasUnicodeComment;
+    /**
+     * The source of the comment field value.
+     * @return source of the comment field value
+     * @since 1.16
+     */
+    public CommentSource getCommentSource() {
+        return commentSource;
     }
 
-    public void setHasUnicodeComment(boolean hasUnicodeComment) {
-        this.hasUnicodeComment = hasUnicodeComment;
+    /**
+     * Sets the source of the comment field value.
+     * @param commentSource source of the comment field value
+     * @since 1.16
+     */
+    public void setCommentSource(CommentSource commentSource) {
+        this.commentSource = commentSource;
     }
+
 }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -17,38 +17,21 @@
  */
 package org.apache.commons.compress.archivers.zip;
 
-import java.io.BufferedInputStream;
-import java.io.Closeable;
-import java.io.EOFException;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipException;
 
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
-import org.apache.commons.compress.utils.IOUtils;
-
-import static org.apache.commons.compress.archivers.zip.ZipConstants.DWORD;
-import static org.apache.commons.compress.archivers.zip.ZipConstants.SHORT;
-import static org.apache.commons.compress.archivers.zip.ZipConstants.WORD;
-import static org.apache.commons.compress.archivers.zip.ZipConstants.ZIP64_MAGIC;
-import static org.apache.commons.compress.archivers.zip.ZipConstants.ZIP64_MAGIC_SHORT;
+import static org.apache.commons.compress.archivers.zip.ZipConstants.*;
 
 /**
  * Replacement for <code>java.util.ZipFile</code>.
@@ -652,6 +635,9 @@ public class ZipFile implements Closeable {
         final boolean hasUTF8Flag = gpFlag.usesUTF8ForNames();
         final ZipEncoding entryEncoding =
             hasUTF8Flag ? ZipEncodingHelper.UTF8_ZIP_ENCODING : zipEncoding;
+        if (hasUTF8Flag) {
+            ze.setNameSource(ZipArchiveEntry.NameSource.NAME_WITH_EFS_FLAG);
+        }
         ze.setGeneralPurposeBit(gpFlag);
         ze.setRawFlag(ZipShort.getValue(cfhBuf, off));
 

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
@@ -239,7 +239,7 @@ public abstract class ZipUtil {
                                                            originalNameBytes);
         if (newName != null && !originalName.equals(newName)) {
             ze.setName(newName);
-            ze.setHasUnicodeName(true);
+            ze.setNameSource(ZipArchiveEntry.NameSource.UNICODE_EXTRA_FIELD);
         }
 
         if (commentBytes != null && commentBytes.length > 0) {
@@ -249,7 +249,7 @@ public abstract class ZipUtil {
                 getUnicodeStringIfOriginalMatches(cmt, commentBytes);
             if (newComment != null) {
                 ze.setComment(newComment);
-                ze.setHasUnicodeComment(true);
+                ze.setCommentSource(ZipArchiveEntry.CommentSource.UNICODE_EXTRA_FIELD);
             }
         }
     }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
@@ -239,6 +239,7 @@ public abstract class ZipUtil {
                                                            originalNameBytes);
         if (newName != null && !originalName.equals(newName)) {
             ze.setName(newName);
+            ze.setHasUnicodeName(true);
         }
 
         if (commentBytes != null && commentBytes.length > 0) {
@@ -248,6 +249,7 @@ public abstract class ZipUtil {
                 getUnicodeStringIfOriginalMatches(cmt, commentBytes);
             if (newComment != null) {
                 ze.setComment(newComment);
+                ze.setHasUnicodeComment(true);
             }
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/COMPRESS-429