### PR TITLE
Allow specifying Zstandard compression level

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorOutputStream.java
@@ -34,8 +34,20 @@ public class ZstdCompressorOutputStream extends CompressorOutputStream {
 
     private final ZstdOutputStream encOS;
 
-    public ZstdCompressorOutputStream(final OutputStream out) throws IOException {
-        this.encOS = new ZstdOutputStream(out);
+    public ZstdCompressorOutputStream(final OutputStream outStream, int level, boolean closeFrameOnFlush, boolean useChecksum) throws IOException {
+        this.encOS = new ZstdOutputStream(outStream, level, closeFrameOnFlush, useChecksum);
+    }
+
+    public ZstdCompressorOutputStream(final OutputStream outStream, int level, boolean closeFrameOnFlush) throws IOException {
+        this.encOS = new ZstdOutputStream(outStream, level, closeFrameOnFlush);
+    }
+
+    public ZstdCompressorOutputStream(final OutputStream outStream, int level) throws IOException {
+        this.encOS = new ZstdOutputStream(outStream, level);
+    }
+
+    public ZstdCompressorOutputStream(final OutputStream outStream) throws IOException {
+        this.encOS = new ZstdOutputStream(outStream);
     }
 
     @Override


### PR DESCRIPTION
ZstdCompressorOutputStream allows data compression using Zstandard, but the default compression level of 3 is hard-coded.
Programs that wish to use a different compression level must reimplement ZstdCompressorOutputStream.
This PR adds a constructor that takes a compression level and passes it to 
`new ZstdOutputStream(...)`.