### PR TITLE
Correctly track compression level change in ZipArchiveOutputStream

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
@@ -875,7 +875,10 @@ public class ZipArchiveOutputStream extends ArchiveOutputStream {
             throw new IllegalArgumentException("Invalid compression level: "
                                                + level);
         }
-        hasCompressionLevelChanged = (this.level != level);
+        if (this.level == level) {
+            return;
+        }
+        hasCompressionLevelChanged = true;
         this.level = level;
     }
 


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=62686 describes a bug in Ant project's `ZipOutputStream`. The same bug is applicable here in `ZipArchiveOutputStream`. The commit here fixes that issue.