### PR TITLE
Use Java 7 Files.createTempDirectory instead of creating file, deleti…

### DIFF
--- a/src/test/java/org/apache/commons/compress/AbstractTestCase.java
+++ b/src/test/java/org/apache/commons/compress/AbstractTestCase.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,16 +56,9 @@ public abstract class AbstractTestCase {
 
     @Before
     public void setUp() throws Exception {
-        dir = mkdir("dir");
-        resultDir = mkdir("dir-result");
+        dir = Files.createTempDirectory("dir").toFile();
+        resultDir = Files.createTempDirectory("dir-result").toFile();
         archive = null;
-    }
-
-    public static File mkdir(final String name) throws IOException {
-        final File f = File.createTempFile(name, "");
-        f.delete();
-        f.mkdir();
-        return f;
     }
 
     public static File getFile(final String path) throws IOException {
@@ -314,7 +308,7 @@ public abstract class AbstractTestCase {
      */
     protected File checkArchiveContent(final ArchiveInputStream in, final List<String> expected, final boolean cleanUp)
             throws Exception {
-        final File result = mkdir("dir-result");
+        final File result = Files.createTempDirectory("dir-result").toFile();
         result.deleteOnExit();
 
         try {
@@ -385,7 +379,7 @@ public abstract class AbstractTestCase {
     }
 
     protected File createTempDir() throws IOException {
-        final File tmpDir = mkdir("testdir");
+        final File tmpDir = Files.createTempDirectory("testdir").toFile();
         tmpDir.deleteOnExit();
         return tmpDir;
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
@@ -19,7 +19,6 @@
 package org.apache.commons.compress.archivers.tar;
 
 import static org.apache.commons.compress.AbstractTestCase.getFile;
-import static org.apache.commons.compress.AbstractTestCase.mkdir;
 import static org.apache.commons.compress.AbstractTestCase.rmdir;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -35,6 +34,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
@@ -232,7 +232,7 @@ public class TarArchiveInputStreamTest {
 
     @Test(expected = IOException.class)
     public void shouldThrowAnExceptionOnTruncatedEntries() throws Exception {
-        final File dir = mkdir("COMPRESS-279");
+        final File dir = Files.createTempDirectory("COMPRESS-279").toFile();
         final TarArchiveInputStream is = getTestStream("/COMPRESS-279.tar");
         FileOutputStream out = null;
         try {

--- a/src/test/java/org/apache/commons/compress/archivers/zip/DataDescriptorTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/DataDescriptorTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import org.apache.commons.compress.utils.IOUtils;
@@ -29,7 +30,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.apache.commons.compress.AbstractTestCase.mkdir;
 import static org.apache.commons.compress.AbstractTestCase.rmdir;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -41,7 +41,7 @@ public class DataDescriptorTest {
 
     @Before
     public void setUp() throws Exception {
-        dir = mkdir("ddtest");
+        dir = Files.createTempDirectory("ddtest").toFile();
     }
 
     @After

--- a/src/test/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestampTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestampTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -34,7 +35,6 @@ import java.util.TimeZone;
 import java.util.zip.ZipException;
 
 import static org.apache.commons.compress.AbstractTestCase.getFile;
-import static org.apache.commons.compress.AbstractTestCase.mkdir;
 import static org.apache.commons.compress.AbstractTestCase.rmdir;
 import static org.apache.commons.compress.archivers.zip.X5455_ExtendedTimestamp.ACCESS_TIME_BIT;
 import static org.apache.commons.compress.archivers.zip.X5455_ExtendedTimestamp.CREATE_TIME_BIT;
@@ -420,7 +420,7 @@ public class X5455_ExtendedTimestampTest {
 
     @Test
     public void testWriteReadRoundtrip() throws IOException {
-        tmpDir = mkdir("X5455");
+        tmpDir = Files.createTempDirectory("X5455").toFile();
         final File output = new File(tmpDir, "write_rewrite.zip");
         final OutputStream out = new FileOutputStream(output);
         final Date d = new Date(97, 8, 24, 15, 10, 2);


### PR DESCRIPTION
…ng it and create directory

The self-written mkdir deletes a temporary file with a prefix, deletes it and creates an directory with the same name. Creating a temporary file by Files.createTempDirectory so is cleaner and faster.