### PR TITLE
Correct EOF check in ArArchiveInputStream

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
@@ -121,13 +121,12 @@ public class ArArchiveInputStream extends ArchiveInputStream {
             trackReadBytes(1);
         }
 
-        if (input.available() == 0) {
-            return null;
-        }
-
         {
             final int read = IOUtils.readFully(input, metaData);
             trackReadBytes(read);
+            if (read == 0) {
+                return null;
+            }
             if (read < metaData.length) {
                 throw new IOException("truncated ar archive");
             }


### PR DESCRIPTION
The original code appears to be checking for end-of-file
using the InputStream.available() method.

This however, misunderstands the InputStream API. The available()
method only returns an estimate, and cannot be used
to check for the remaining bytes in the file. From the documentation:

> Returns an estimate of the number of bytes that can be read (or
> skipped over) from this input stream without blocking by the next
> invocation of a method for this input stream. The next invocation
> might be the same thread or another thread.  A single read or skip of this
> many bytes will not block, but may read or skip fewer bytes.
> **Note that while some implementations of InputStream will return
> the total number of bytes in the stream, many will not.**  It is
> never correct to use the return value of this method to allocate
> a buffer intended to hold all data in this stream.

This patch includes a unit test that demonstrates the bug and
verifies the fix.
