### PR TITLE
COMPRESS-485 keep zip entries order in parallel zip creation

### DIFF
--- a/src/site/xdoc/zip.xml
+++ b/src/site/xdoc/zip.xml
@@ -551,14 +551,17 @@
           <p>To assist this process, clients can use
           <code>ParallelScatterZipCreator</code> that will handle threads
           pools and correct memory model consistency so the client
-          can avoid these issues. Please note that when writing well-formed
-          Zip files this way, it is usually necessary to keep a
-          separate <code>ScatterZipOutputStream</code> that receives all directories
-          and writes this to the target <code>ZipArchiveOutputStream</code> before
-          the ones created through <code>ParallelScatterZipCreator</code>. This is the responsibility of the client.</p>
+          can avoid these issues.</p>
 
-          <p>There is no guarantee of order of the entries when writing a Zip
-          file with <code>ParallelScatterZipCreator</code>.</p>
+          <p>Until version 1.18, there was no guarantee of order of the entries when writing a Zip
+          file with <code>ParallelScatterZipCreator</code>.  In consequence, when writing well-formed
+          Zip files this way, it was usually necessary to keep a
+          separate <code>ScatterZipOutputStream</code> that received all directories
+          and wrote this to the target <code>ZipArchiveOutputStream</code> before
+          the ones created through <code>ParallelScatterZipCreator</code>. This was the responsibility of the client.</p>
+
+          <p>Starting with version 1.19, entries order is kept, then this specific handling of directories is not
+          necessary any more.</p>
 
           See the examples section for a code sample demonstrating how to make a zip file.
       </subsection>

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ParallelScatterZipCreatorTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ParallelScatterZipCreatorTest.java
@@ -98,12 +98,15 @@ public class ParallelScatterZipCreatorTest {
     private void removeEntriesFoundInZipFile(final File result, final Map<String, byte[]> entries) throws IOException {
         final ZipFile zf = new ZipFile(result);
         final Enumeration<ZipArchiveEntry> entriesInPhysicalOrder = zf.getEntriesInPhysicalOrder();
+        int i = 0;
         while (entriesInPhysicalOrder.hasMoreElements()){
             final ZipArchiveEntry zipArchiveEntry = entriesInPhysicalOrder.nextElement();
             final InputStream inputStream = zf.getInputStream(zipArchiveEntry);
             final byte[] actual = IOUtils.toByteArray(inputStream);
             final byte[] expected = entries.remove(zipArchiveEntry.getName());
             assertArrayEquals( "For " + zipArchiveEntry.getName(),  expected, actual);
+            // check order of zip entries vs order of order of addition to the parallel zip creator
+            assertEquals( "For " + zipArchiveEntry.getName(),  "file" + i++, zipArchiveEntry.getName());
         }
         zf.close();
     }
@@ -145,7 +148,7 @@ public class ParallelScatterZipCreatorTest {
                     return new ByteArrayInputStream(payloadBytes);
                 }
             };
-            final Callable<Object> callable;
+            final Callable<ScatterZipOutputStream> callable;
             if (i % 2 == 0) {
                 callable = zipCreator.createCallable(za, iss);
             } else {


### PR DESCRIPTION
this will enable Reproducible Builds when creating zip or jar archives

this is another implementation of idea in PR #77 