### PR TITLE
Performance Improvement: Call toArray with 0 Array Size

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -261,7 +261,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream {
                     }
                     extendedHeaders.add(extendedHeaderBytes);
                 }
-                localFileHeader.extendedHeaders = extendedHeaders.toArray(new byte[extendedHeaders.size()][]);
+                localFileHeader.extendedHeaders = extendedHeaders.toArray(new byte[0][]);
 
                 return localFileHeader;
             }

--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZOutputFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZOutputFile.java
@@ -322,7 +322,7 @@ public class SevenZOutputFile implements Closeable {
             first = false;
         }
         if (!moreStreams.isEmpty()) {
-            additionalCountingStreams = moreStreams.toArray(new CountingOutputStream[moreStreams.size()]);
+            additionalCountingStreams = moreStreams.toArray(new CountingOutputStream[0]);
         }
         return new CountingOutputStream(out) {
             @Override

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -411,7 +411,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
                 newFields.add( field);
             }
         }
-        extraFields = newFields.toArray(new ZipExtraField[newFields.size()]);
+        extraFields = newFields.toArray(new ZipExtraField[0]);
         setExtra();
     }
 
@@ -560,7 +560,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry
         if (extraFields.length == newResult.size()) {
             throw new java.util.NoSuchElementException();
         }
-        extraFields = newResult.toArray(new ZipExtraField[newResult.size()]);
+        extraFields = newResult.toArray(new ZipExtraField[0]);
         setExtra();
     }
 


### PR DESCRIPTION
Since Java 6, calling toArray with an array of size is faster than calling it with the size of the array (https://shipilev.net/blog/2016/arrays-wisdom-ancients/). This is also a PMD recommendation: https://pmd.github.io/latest/pmd_rules_java_performance.html#optimizabletoarraycall 
I changed this in the code.