### PR TITLE
Made some variable names more consistent with the other parts.

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
@@ -268,9 +268,9 @@ public class ArArchiveInputStream extends ArchiveInputStream {
             return -1;
         }
         final int toRead = (int) Math.min(len, entryEnd - offset);
-        final int ret = this.input.read(b, off, toRead);
-        trackReadBytes(ret);
-        return ret;
+        final int read = this.input.read(b, off, toRead);
+        trackReadBytes(read);
+        return read;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/BitStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/BitStream.java
@@ -48,14 +48,14 @@ class BitStream extends BitInputStream {
     /**
      * Returns the integer value formed by the n next bits (up to 8 bits).
      *
-     * @param n the number of bits read (up to 8)
-     * @return The value formed by the n bits, or -1 if the end of the stream has been reached
+     * @param count the number of bits read (up to 8)
+     * @return The value formed by the count bits, or -1 if the end of the stream has been reached
      */
-    long nextBits(final int n) throws IOException {
-        if (n < 0 || n > 8) {
-            throw new IOException("Trying to read " + n + " bits, at most 8 are allowed");
+    long nextBits(final int count) throws IOException {
+        if (count < 0 || count > 8) {
+            throw new IOException("Trying to read " + count + " bits, at most 8 are allowed");
         }
-        return readBits(n);
+        return readBits(count);
     }
 
     int nextByte() throws IOException {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/StreamCompressor.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/StreamCompressor.java
@@ -259,9 +259,9 @@ public abstract class StreamCompressor implements Closeable {
     }
 
     void deflate() throws IOException {
-        final int len = def.deflate(outputBuffer, 0, outputBuffer.length);
-        if (len > 0) {
-            writeCounted(outputBuffer, 0, len);
+        final int length = def.deflate(outputBuffer, 0, outputBuffer.length);
+        if (length > 0) {
+            writeCounted(outputBuffer, 0, length);
         }
     }
 

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipEncodingHelper.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipEncodingHelper.java
@@ -47,15 +47,15 @@ public abstract class ZipEncodingHelper {
      *     If the requested characer set cannot be found, the platform default will
      *     be used instead.
      * </p>
-     * @param name The name of the zip encoding. Specify {@code null} for
+     * @param encoding The name of the zip encoding. Specify {@code null} for
      *             the platform's default encoding.
      * @return A zip encoding for the given encoding name.
      */
-    public static ZipEncoding getZipEncoding(final String name) {
+    public static ZipEncoding getZipEncoding(final String encoding) {
         Charset cs = Charset.defaultCharset();
-        if (name != null) {
+        if (encoding != null) {
             try {
-                cs = Charset.forName(name);
+                cs = Charset.forName(encoding);
             } catch (UnsupportedCharsetException e) { // NOSONAR we use the default encoding instead
             }
         }

--- a/src/main/java/org/apache/commons/compress/compressors/z/ZCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/z/ZCompressorInputStream.java
@@ -103,12 +103,12 @@ public class ZCompressorInputStream extends LZWInputStream {
     @Override
     protected int addEntry(final int previousCode, final byte character) throws IOException {
         final int maxTableSize = 1 << getCodeSize();
-        final int r = addEntry(previousCode, character, maxTableSize);
+        final int idx = addEntry(previousCode, character, maxTableSize);
         if (getTableSize() == maxTableSize && getCodeSize() < maxCodeSize) {
             reAlignReading();
             incrementCodeSize();
         }
-        return r;
+        return idx;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/utils/ByteUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/ByteUtils.java
@@ -71,16 +71,16 @@ public final class ByteUtils {
     /**
      * Reads the given byte array as a little endian long.
      * @param bytes the byte array to convert
-     * @param off the offset into the array that starts the value
+     * @param offset the offset into the array that starts the value
      * @param length the number of bytes representing the value
      * @return the number read
      * @throws IllegalArgumentException if len is bigger than eight
      */
-    public static long fromLittleEndian(byte[] bytes, final int off, final int length) {
+    public static long fromLittleEndian(byte[] bytes, final int offset, final int length) {
         checkReadLength(length);
         long l = 0;
         for (int i = 0; i < length; i++) {
-            l |= (bytes[off + i] & 0xffL) << (8 * i);
+            l |= (bytes[offset + i] & 0xffL) << (8 * i);
         }
         return l;
     }
@@ -159,13 +159,13 @@ public final class ByteUtils {
      * sequence of the given length starting at the given offset.
      * @param b the array to write into
      * @param value the value to insert
-     * @param off the offset into the array that receives the first byte
+     * @param offset the offset into the array that receives the first byte
      * @param length the number of bytes to use to represent the value
      */
-    public static void toLittleEndian(final byte[] b, final long value, final int off, final int length) {
+    public static void toLittleEndian(final byte[] b, final long value, final int offset, final int length) {
         long num = value;
         for (int i = 0; i < length; i++) {
-            b[off + i] = (byte) (num & 0xff);
+            b[offset + i] = (byte) (num & 0xff);
             num >>= 8;
         }
     }


### PR DESCRIPTION
Hello, we're developing an automated system that detects inconsistent variable names in a large software project. Our system checks if each variable name is consistent with other variables in the project in its usage pattern, and proposes correct candidates if inconsistency is detected. This is a part of academic research that we hope to publish soon, but as a part of the evaluation, we applied our systems to your projects and got a few interesting results. We carefully reviewed our system output and manually created a patch to correct a few variable names. We would be delighted if this patch is found to be useful. If you have a question or suggestion regarding this patch, we'd happily
answer. Thank you.