### PR TITLE
COMPRESS-503 : "open when actually needed" for MultiReadOnlySeekableByteChannel

### DIFF
--- a/src/test/java/org/apache/commons/compress/utils/MultiReadOnlySeekableByteChannelTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/MultiReadOnlySeekableByteChannelTest.java
@@ -46,7 +46,8 @@ public class MultiReadOnlySeekableByteChannelTest {
     @Test
     public void constructorThrowsOnNullArg() {
         thrown.expect(NullPointerException.class);
-        new MultiReadOnlySeekableByteChannel(null);
+        List nullList = null;
+        new MultiReadOnlySeekableByteChannel(nullList);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/utils/ZipSplitReadOnlySeekableByteChannelTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ZipSplitReadOnlySeekableByteChannelTest.java
@@ -42,7 +42,8 @@ public class ZipSplitReadOnlySeekableByteChannelTest {
     @Test
     public void constructorThrowsOnNullArg() throws IOException {
         thrown.expect(NullPointerException.class);
-        new ZipSplitReadOnlySeekableByteChannel(null);
+        List nullList = null;
+        new ZipSplitReadOnlySeekableByteChannel(nullList);
     }
 
     @Test


### PR DESCRIPTION
Please refer (#90)[https://github.com/apache/commons-compress/pull/90]

When I was adding zip64 support for split zip, I encountered a problem : 
When adding testcases in `Zip64SupportIT`, I created a split zip with 10,000+ split segments. Then I found that I was unable to unzip it because there would be too many open files when extracting it. We can oepn the files when actually needed and therefore we can successfully extract such split zips with great amount of segments.

I have set a threshold of 20 in `MultiReadOnlySeekableByteChannel`. The "open when actually needed" procedure will only work when the number of split segments is greater than the threshold.

Actually this is a pretty rare case cause most split zips would not have too many segments. So you can decide whether to merge this PR or not. :-)