### PR TITLE
(doc) minor javadoc fix

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -696,9 +696,9 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
     }
 
     /**
-     * Set this entry's modification time.
+     * Get this entry's modification time.
      *
-     * @return time This entry's new modification time.
+     * @return This entry's modification time.
      */
     public Date getModTime() {
         return new Date(modTime * MILLIS_PER_SECOND);


### PR DESCRIPTION
Just a trivial change to `TarArchiveEntry#getModTime()`