### PR TITLE
Deprecated constructors of ZstdOutputStream fix

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorOutputStream.java
@@ -45,7 +45,9 @@ public class ZstdCompressorOutputStream extends CompressorOutputStream {
      */
     public ZstdCompressorOutputStream(final OutputStream outStream, int level, boolean closeFrameOnFlush,
         boolean useChecksum) throws IOException {
-        this.encOS = new ZstdOutputStream(outStream, level, closeFrameOnFlush, useChecksum);
+        this.encOS = new ZstdOutputStream(outStream, level);
+        this.encOS.setCloseFrameOnFlush(closeFrameOnFlush);
+        this.encOS.setChecksum(useChecksum);
     }
 
     /**
@@ -58,7 +60,8 @@ public class ZstdCompressorOutputStream extends CompressorOutputStream {
      */
     public ZstdCompressorOutputStream(final OutputStream outStream, int level, boolean closeFrameOnFlush)
         throws IOException {
-        this.encOS = new ZstdOutputStream(outStream, level, closeFrameOnFlush);
+        this.encOS = new ZstdOutputStream(outStream, level);
+        this.encOS.setCloseFrameOnFlush(closeFrameOnFlush);
     }
 
     /**


### PR DESCRIPTION
The zstd-jni was updated to 1.4.4-7, and some constructors of ZstdOutputStream were deprecated.

This PR fix them as the comment was recommended :
/**
*  @deprecated
*  Use ZstdOutputStream() or ZstdOutputStream(level) and set the other params with the setters
**/
