### PR TITLE
COMPRESS-404: Use java.nio.Path in TarArchiveEntry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.marschall</groupId>
+      <artifactId>memoryfilesystem</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- integration test verifiying OSGi bundle works -->
     <dependency>

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -20,13 +20,18 @@ package org.apache.commons.compress.archivers.tar;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipEncoding;
@@ -39,17 +44,17 @@ import org.apache.commons.compress.utils.ArchiveUtils;
  * they are to be used.
  * <p>
  * TarEntries that are created from the header bytes read from
- * an archive are instantiated with the TarEntry( byte[] )
+ * an archive are instantiated with the {@link TarArchiveEntry#TarArchiveEntry(byte[])}
  * constructor. These entries will be used when extracting from
  * or listing the contents of an archive. These entries have their
  * header filled in using the header bytes. They also set the File
  * to null, since they reference an archive entry not a file.
  * <p>
  * TarEntries that are created from Files that are to be written
- * into an archive are instantiated with the TarEntry( File )
- * constructor. These entries have their header filled in using
- * the File's information. They also keep a reference to the File
- * for convenience when writing entries.
+ * into an archive are instantiated with the {@link TarArchiveEntry#TarArchiveEntry(File)}
+ * or {@link TarArchiveEntry#TarArchiveEntry(Path)} constructor.
+ * These entries have their header filled in using the File's information.
+ * They also keep a reference to the File for convenience when writing entries.
  * <p>
  * Finally, TarEntries can be constructed from nothing but a name.
  * This allows the programmer to construct the entry by hand, for
@@ -223,7 +228,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
     private boolean starSparse;
 
     /** The entry's file reference */
-    private final File file;
+    private final Path file;
 
     /** Extra, user supplied pax headers     */
     private final Map<String,String> extraPaxHeaders = new HashMap<>();
@@ -357,6 +362,24 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
     /**
      * Construct an entry for a file. File is set to file, and the
      * header is constructed from information from the file.
+     * The name is set from the normalized file path.
+     *
+     * <p>The entry's name will be the value of the {@code file}'s
+     * path with all file separators replaced by forward slashes and
+     * leading slashes as well as Windows drive letters stripped. The
+     * name will end in a slash if the {@code file} represents a
+     * directory.</p>
+     *
+     * @param file The file that the entry represents.
+     * @since 1.21
+     */
+    public TarArchiveEntry(final Path file) {
+        this(file, file.toString());
+    }
+
+    /**
+     * Construct an entry for a file. File is set to file, and the
+     * header is constructed from information from the file.
      *
      * <p>The entry's name will be the value of the {@code fileName}
      * argument with all file separators replaced by forward slashes
@@ -368,10 +391,28 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      * @param fileName the name to be used for the entry.
      */
     public TarArchiveEntry(final File file, final String fileName) {
+        this(file.toPath(), fileName);
+    }
+
+    /**
+     * Construct an entry for a file. File is set to file, and the
+     * header is constructed from information from the file.
+     *
+     * <p>The entry's name will be the value of the {@code fileName}
+     * argument with all file separators replaced by forward slashes
+     * and leading slashes as well as Windows drive letters stripped.
+     * The name will end in a slash if the {@code file} represents a
+     * directory.</p>
+     *
+     * @param file The file that the entry represents.
+     * @param fileName the name to be used for the entry.
+     * @since 1.21
+     */
+    public TarArchiveEntry(final Path file, final String fileName) {
         final String normalizedName = normalizeFileName(fileName, false);
         this.file = file;
 
-        if (file.isDirectory()) {
+        if (Files.isDirectory(file)) {
             this.mode = DEFAULT_DIR_MODE;
             this.linkFlag = LF_DIR;
 
@@ -384,11 +425,19 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
         } else {
             this.mode = DEFAULT_FILE_MODE;
             this.linkFlag = LF_NORMAL;
-            this.size = file.length();
+            try {
+                this.size = Files.size(file);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
             this.name = normalizedName;
         }
 
-        this.modTime = file.lastModified() / MILLIS_PER_SECOND;
+        try {
+            this.modTime = Files.getLastModifiedTime(file).to(TimeUnit.SECONDS);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
         this.userName = "";
         preserveAbsolutePath = false;
     }
@@ -724,11 +773,26 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      * Get this entry's file.
      *
      * <p>This method is only useful for entries created from a {@code
-     * File} but not for entries read from an archive.</p>
+     * File} or {@code Path} but not for entries read from an archive.</p>
      *
-     * @return This entry's file.
+     * @return This entry's file or null if the entry was not created from a file.
      */
     public File getFile() {
+        if (file == null) {
+            return null;
+        }
+        return file.toFile();
+    }
+
+    /**
+     * Get this entry's file.
+     *
+     * <p>This method is only useful for entries created from a {@code
+     * File} or {@code Path} but not for entries read from an archive.</p>
+     *
+     * @return This entry's file or null if the entry was not created from a file.
+     */
+    public Path getPath() {
         return file;
     }
 
@@ -957,7 +1021,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
     @Override
     public boolean isDirectory() {
         if (file != null) {
-            return file.isDirectory();
+            return Files.isDirectory(file);
         }
 
         if (linkFlag == LF_DIR) {
@@ -975,7 +1039,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      */
     public boolean isFile() {
         if (file != null) {
-            return file.isFile();
+            return Files.isRegularFile(file);
         }
         if (linkFlag == LF_OLDNORM || linkFlag == LF_NORMAL) {
             return true;
@@ -1189,26 +1253,26 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      * an array of TarEntries for this entry's children.
      *
      * <p>This method is only useful for entries created from a {@code
-     * File} but not for entries read from an archive.</p>
+     * File} or {@code Path} but not for entries read from an archive.</p>
      *
      * @return An array of TarEntry's for this entry's children.
      */
     public TarArchiveEntry[] getDirectoryEntries() {
-        if (file == null || !file.isDirectory()) {
+        if (file == null || !isDirectory()) {
             return EMPTY_TAR_ARCHIVE_ENTRIES;
         }
 
-        final String[] list = file.list();
-        if (list == null) {
+        List<TarArchiveEntry> entries = new ArrayList<>();
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(file)) {
+            Iterator<Path> iterator = dirStream.iterator();
+            while (iterator.hasNext()) {
+                Path p = iterator.next();
+                entries.add(new TarArchiveEntry(p));
+            }
+        } catch (IOException e) {
             return EMPTY_TAR_ARCHIVE_ENTRIES;
         }
-        final TarArchiveEntry[] result = new TarArchiveEntry[list.length];
-
-        for (int i = 0; i < result.length; ++i) {
-            result[i] = new TarArchiveEntry(new File(file, list[i]));
-        }
-
-        return result;
+        return entries.toArray(new TarArchiveEntry[0]);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -358,6 +358,11 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      * name will end in a slash if the {@code file} represents a
      * directory.</p>
      *
+     * <p>Note: Since 1.21 this internally uses the same code as the
+     * TarArchiveEntry constructors with a {@link Path} as parameter.
+     * But all thrown exceptions are ignored. If handling those
+     * exceptions is needed consider switching to the path constructors.</p>
+     *
      * @param file The file that the entry represents.
      */
     public TarArchiveEntry(final File file) {
@@ -393,6 +398,11 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      * The name will end in a slash if the {@code file} represents a
      * directory.</p>
      *
+     * <p>Note: Since 1.21 this internally uses the same code as the
+     * TarArchiveEntry constructors with a {@link Path} as parameter.
+     * But all thrown exceptions are ignored. If handling those
+     * exceptions is needed consider switching to the path constructors.</p>
+     *
      * @param file The file that the entry represents.
      * @param fileName the name to be used for the entry.
      */
@@ -403,14 +413,20 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
         try {
             readFileMode(this.file, normalizedName);
         } catch (IOException e) {
-            // Ignore for backwards compatibility
+            // Ignore exceptions from NIO for backwards compatibility
+            // Fallback to get size of file if it's no directory to the old file api
+            if (!file.isDirectory()) {
+                this.size = file.length();
+            }
         }
 
         this.userName = "";
         try {
             readOsSpecificProperties(this.file);
         } catch (IOException e) {
-            // Ignore for backwards compatibility
+            // Ignore exceptions from NIO for backwards compatibility
+            // Fallback to get the last modified date of the file from the old file api
+            this.modTime = file.lastModified() / MILLIS_PER_SECOND;
         }
         preserveAbsolutePath = false;
     }
@@ -788,6 +804,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      * Set this entry's modification time.
      *
      * @param time This entry's new modification time.
+     * @since 1.21
      */
     public void setModTime(final FileTime time) {
         modTime = time.to(TimeUnit.SECONDS);
@@ -840,6 +857,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
      * File} or {@code Path} but not for entries read from an archive.</p>
      *
      * @return This entry's file or null if the entry was not created from a file.
+     * @since 1.21
      */
     public Path getPath() {
         return file;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -448,8 +448,8 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
                 this.userName = posixFileAttributes.owner().getName();
                 this.groupName = posixFileAttributes.group().getName();
                 if (availableAttributeViews.contains("unix")) {
-                    this.userId = (long) Files.getAttribute(file, "unix:uid");
-                    this.groupId = (long) Files.getAttribute(file, "unix:gid");
+                    this.userId = ((Number) Files.getAttribute(file, "unix:uid")).longValue();
+                    this.groupId = ((Number) Files.getAttribute(file, "unix:gid")).longValue();
                 }
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/test/java/org/apache/commons/compress/AbstractTestCase.java
+++ b/src/test/java/org/apache/commons/compress/AbstractTestCase.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -77,6 +78,10 @@ public abstract class AbstractTestCase {
             throw new IOException(ex);
         }
         return new File(uri);
+    }
+
+    public static Path getPath(final String path) throws IOException {
+        return getFile(path).toPath();
     }
 
     @After

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.archivers.tar;
 
 import static org.apache.commons.compress.AbstractTestCase.getFile;
+import static org.apache.commons.compress.AbstractTestCase.getPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -207,7 +208,7 @@ public class TarArchiveEntryTest implements TarConstants {
     }
 
     @Test
-    public void testLinuxFileInformationFromPath() throws IOException {
+    public void testLinuxFileInformationFromFile() throws IOException {
         assumeTrue("Information is only available on linux", OS.equals("linux"));
         TarArchiveEntry entry = new TarArchiveEntry(getFile("test1.xml"));
         assertNotEquals(0, entry.getLongUserId());
@@ -216,9 +217,25 @@ public class TarArchiveEntryTest implements TarConstants {
     }
 
     @Test
-    public void testWindowsFileInformationFromPath() throws IOException {
+    public void testLinuxFileInformationFromPath() throws IOException {
+        assumeTrue("Information is only available on linux", OS.equals("linux"));
+        TarArchiveEntry entry = new TarArchiveEntry(getPath("test1.xml"));
+        assertNotEquals(0, entry.getLongUserId());
+        assertNotEquals(0, entry.getLongGroupId());
+        assertNotEquals("", entry.getUserName());
+    }
+
+    @Test
+    public void testWindowsFileInformationFromFile() throws IOException {
         assumeTrue("Information should only be checked on Windows", OS.startsWith("windows"));
         TarArchiveEntry entry = new TarArchiveEntry(getFile("test1.xml"));
+        assertNotEquals("", entry.getUserName());
+    }
+
+    @Test
+    public void testWindowsFileInformationFromPath() throws IOException {
+        assumeTrue("Information should only be checked on Windows", OS.startsWith("windows"));
+        TarArchiveEntry entry = new TarArchiveEntry(getPath("test1.xml"));
         assertNotEquals("", entry.getUserName());
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.commons.compress.archivers.tar;
 
+import static org.apache.commons.compress.AbstractTestCase.getFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,8 +33,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.Locale;
 import org.apache.commons.compress.AbstractTestCase;
 import org.junit.Test;
@@ -205,6 +204,22 @@ public class TarArchiveEntryTest implements TarConstants {
         TarArchiveEntry entry = new TarArchiveEntry("test.txt");
         assertNull(entry.getFile());
         assertNull(entry.getPath());
+    }
+
+    @Test
+    public void testLinuxFileInformationFromPath() throws IOException {
+        assumeTrue("Information is only available on linux", OS.equals("linux"));
+        TarArchiveEntry entry = new TarArchiveEntry(getFile("test1.xml"));
+        assertNotEquals(0, entry.getLongUserId());
+        assertNotEquals(0, entry.getLongGroupId());
+        assertNotEquals("", entry.getUserName());
+    }
+
+    @Test
+    public void testWindowsFileInformationFromPath() throws IOException {
+        assumeTrue("Information should only be checked on Windows", OS.startsWith("windows"));
+        TarArchiveEntry entry = new TarArchiveEntry(getFile("test1.xml"));
+        assertNotEquals("", entry.getUserName());
     }
 
     private void assertGnuMagic(final TarArchiveEntry t) {

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
@@ -200,6 +200,13 @@ public class TarArchiveEntryTest implements TarConstants {
         assertEquals("C:/foo.txt", t.getName());
     }
 
+    @Test
+    public void getFileFromNonFileEntry() {
+        TarArchiveEntry entry = new TarArchiveEntry("test.txt");
+        assertNull(entry.getFile());
+        assertNull(entry.getPath());
+    }
+
     private void assertGnuMagic(final TarArchiveEntry t) {
         assertEquals(MAGIC_GNU + VERSION_GNU_SPACE, readMagic(t));
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarMemoryFileSystemTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarMemoryFileSystemTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.commons.compress.archivers.tar;
+
+import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.UserPrincipal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TarMemoryFileSystemTest {
+
+    @Test
+    public void tarFromMemoryFileSystem() throws IOException, ArchiveException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Path p = fileSystem.getPath("test.txt");
+            Files.write(p, "Test".getBytes(StandardCharsets.UTF_8));
+
+            final File f = File.createTempFile("commons-compress-memoryfs", ".tar");
+            try (final OutputStream out = Files.newOutputStream(f.toPath());
+                 final ArchiveOutputStream tarOut = new ArchiveStreamFactory().createArchiveOutputStream(ArchiveStreamFactory.TAR, out)) {
+                final TarArchiveEntry entry = new TarArchiveEntry(p);
+                tarOut.putArchiveEntry(entry);
+
+                Files.copy(p, tarOut);
+                tarOut.closeArchiveEntry();
+                assertEquals(f.length(), tarOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void tarToMemoryFileSystem() throws IOException, ArchiveException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Path p = fileSystem.getPath("target.tar");
+
+            try (final OutputStream out = Files.newOutputStream(p);
+                 final ArchiveOutputStream tarOut = new ArchiveStreamFactory().createArchiveOutputStream(ArchiveStreamFactory.TAR, out)) {
+                final String content = "Test";
+                final TarArchiveEntry entry = new TarArchiveEntry("test.txt");
+                entry.setSize(content.length());
+                tarOut.putArchiveEntry(entry);
+
+                tarOut.write("Test".getBytes(StandardCharsets.UTF_8));
+                tarOut.closeArchiveEntry();
+
+                assertTrue(Files.exists(p));
+                assertEquals(Files.size(p), tarOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void checkUserInformationInTarEntry() throws IOException, ArchiveException {
+        final String user = "commons";
+        final String group = "compress";
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().addUser(user).addGroup(group).build()) {
+            final Path source = fileSystem.getPath("original-file.txt");
+            Files.write(source, "Test".getBytes(StandardCharsets.UTF_8));
+            Files.setAttribute(source, "posix:owner", new UserPrincipal() {
+                @Override
+                public String getName() {
+                    return user;
+                }
+            });
+            Files.setAttribute(source, "posix:group", new GroupPrincipal() {
+                @Override
+                public String getName() {
+                    return group;
+                }
+            });
+
+            final Path target = fileSystem.getPath("original-file.tar");
+            try (final OutputStream out = Files.newOutputStream(target);
+                 final ArchiveOutputStream tarOut = new ArchiveStreamFactory().createArchiveOutputStream(ArchiveStreamFactory.TAR, out)) {
+                final TarArchiveEntry entry = new TarArchiveEntry(source);
+                tarOut.putArchiveEntry(entry);
+
+                Files.copy(source, tarOut);
+                tarOut.closeArchiveEntry();
+            }
+
+            try (final InputStream input = Files.newInputStream(target);
+                 final TarArchiveInputStream tarIn = new TarArchiveInputStream(input)) {
+                TarArchiveEntry nextTarEntry = tarIn.getNextTarEntry();
+
+                assertEquals(user, nextTarEntry.getUserName());
+                assertEquals(group, nextTarEntry.getGroupName());
+            }
+        }
+    }
+}


### PR DESCRIPTION
I wan't to use the NIO API more in my application and therefore would need some additional methods which support the NIO API. Found this already existent issue and thought this would be a good starting point.

The first commit handles the internal migration to the Path object. The second adds additional information to the TarArchiveEntry. Before adding more functionality (e.g. symlinks) I would like to get some feedback for the error handling. Since the old File constructor didn't throw an exception the now delegating constructor also shouldn't throw an exception. But with NIO most file access operations are throwing one.