### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sudo: false
 language: java
 
 matrix:


### PR DESCRIPTION
[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

_"If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration"_