### PR TITLE
COMPRESS-520: Implement ZCompressorInputStreamTest without powermock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
     <commons.rc.version>RC1</commons.rc.version>
     <!-- old version used by japicmp -->
     <commons.bc.version>1.20</commons.bc.version>
-    <powermock.version>1.7.4</powermock.version>
+    <mockito.version>1.10.19</mockito.version>
     <commons.pmd-plugin.version>3.12.0</commons.pmd-plugin.version>
 
     <commons.manifestlocation>${project.build.outputDirectory}/META-INF</commons.manifestlocation>
@@ -110,15 +110,9 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/org/apache/commons/compress/compressors/z/ZCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/z/ZCompressorInputStreamTest.java
@@ -26,13 +26,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
-import java.util.Enumeration;
+import java.util.Collections;
 import org.apache.commons.compress.utils.IOUtils;
 
 import static org.apache.commons.compress.AbstractTestCase.getFile;
-import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
-
 
 /**
  * Unit tests for class {@link ZCompressorInputStream}.
@@ -45,23 +42,8 @@ public class ZCompressorInputStreamTest {
 
     @Test(expected = IOException.class)
     public void testFailsToCreateZCompressorInputStreamAndThrowsIOException() throws IOException {
-        boolean java9 = false;
-        try {
-            Class.forName("java.lang.module.ModuleDescriptor");
-            java9 = true;
-        } catch (Exception ex) {
-            // not Java9
-        }
-        org.junit.Assume.assumeFalse("can't use PowerMock with Java9", java9);
-
-        Enumeration<SequenceInputStream> enumeration = (Enumeration<SequenceInputStream>) mock(Enumeration.class);
-        SequenceInputStream sequenceInputStream = new SequenceInputStream(enumeration);
-        ZCompressorInputStream zCompressorInputStream = null;
-
-        doReturn(false).when(enumeration).hasMoreElements();
-
-        zCompressorInputStream = new ZCompressorInputStream(sequenceInputStream);
-
+        SequenceInputStream sequenceInputStream = new SequenceInputStream(Collections.<InputStream>emptyEnumeration());
+        ZCompressorInputStream zCompressorInputStream = new ZCompressorInputStream(sequenceInputStream);
     }
 
     @Test


### PR DESCRIPTION
Noticed this test is skipped while checking the unit tests log. The mockito dependency was transitive before.
Is there a Jira ticket needed for a change like this?