### PR TITLE
[COMPRESS-534] use StandardCharsets.

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveOutputStream.java
@@ -21,6 +21,7 @@ package org.apache.commons.compress.archivers.ar;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
@@ -123,7 +124,7 @@ public class ArArchiveOutputStream extends ArchiveOutputStream {
     }
 
     private long write( final String data ) throws IOException {
-        final byte[] bytes = data.getBytes("ascii");
+        final byte[] bytes = data.getBytes(StandardCharsets.US_ASCII);
         write(bytes);
         return bytes.length;
     }

--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
@@ -982,7 +982,7 @@ public class SevenZFile implements Closeable {
                     int nextName = 0;
                     for (int i = 0; i < names.length; i += 2) {
                         if (names[i] == 0 && names[i+1] == 0) {
-                            files[nextFile++].setName(new String(names, nextName, i-nextName, CharsetNames.UTF_16LE));
+                            files[nextFile++].setName(new String(names, nextName, i-nextName, StandardCharsets.UTF_16LE));
                             nextName = i + 2;
                         }
                     }

--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZOutputFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZOutputFile.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -573,7 +574,7 @@ public class SevenZOutputFile implements Closeable {
         final DataOutputStream out = new DataOutputStream(baos);
         out.write(0);
         for (final SevenZArchiveEntry entry : files) {
-            out.write(entry.getName().getBytes("UTF-16LE"));
+            out.write(entry.getName().getBytes(StandardCharsets.UTF_16LE));
             out.writeShort(0);
         }
         out.flush();

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -26,6 +26,7 @@ package org.apache.commons.compress.archivers.tar;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -724,7 +725,7 @@ public class TarArchiveInputStream extends ArchiveInputStream {
                                 }
                                 // Drop trailing NL
                                 final String value = new String(rest, 0,
-                                                          restLen - 1, CharsetNames.UTF_8);
+                                                          restLen - 1, StandardCharsets.UTF_8);
                                 headers.put(keyword, value);
 
                                 // for 0.0 PAX Headers

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -494,7 +495,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
                 + 3 /* blank, equals and newline */
                 + 2 /* guess 9 < actual length < 100 */;
             String line = len + " " + key + "=" + value + "\n";
-            int actualLength = line.getBytes(CharsetNames.UTF_8).length;
+            int actualLength = line.getBytes(StandardCharsets.UTF_8).length;
             while (len != actualLength) {
                 // Adjust for cases where length < 10 or > 100
                 // or where UTF-8 encoding isn't a single octet
@@ -503,11 +504,11 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
                 // first pass so we'd need a second.
                 len = actualLength;
                 line = len + " " + key + "=" + value + "\n";
-                actualLength = line.getBytes(CharsetNames.UTF_8).length;
+                actualLength = line.getBytes(StandardCharsets.UTF_8).length;
             }
             w.write(line);
         }
-        return w.toString().getBytes(CharsetNames.UTF_8);
+        return w.toString().getBytes(StandardCharsets.UTF_8);
     }
 
     private String stripTo7Bits(final String name) {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/AbstractUnicodeExtraField.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/AbstractUnicodeExtraField.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.archivers.zip;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.CRC32;
 import java.util.zip.ZipException;
 
@@ -53,11 +54,7 @@ public abstract class AbstractUnicodeExtraField implements ZipExtraField {
         crc32.update(bytes, off, len);
         nameCRC32 = crc32.getValue();
 
-        try {
-            unicodeName = text.getBytes(CharsetNames.UTF_8);
-        } catch (final UnsupportedEncodingException e) {
-            throw new RuntimeException("FATAL: UTF-8 encoding not supported.", e); //NOSONAR
-        }
+        unicodeName = text.getBytes(StandardCharsets.UTF_8);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.BufferedInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
@@ -239,13 +240,13 @@ public class GzipCompressorInputStream extends CompressorInputStream
         // Original file name
         if ((flg & FNAME) != 0) {
             parameters.setFilename(new String(readToNull(inData),
-                                              CharsetNames.ISO_8859_1));
+                    StandardCharsets.ISO_8859_1));
         }
 
         // Comment
         if ((flg & FCOMMENT) != 0) {
             parameters.setComment(new String(readToNull(inData),
-                                             CharsetNames.ISO_8859_1));
+                    StandardCharsets.ISO_8859_1));
         }
 
         // Header "CRC16" which is actually a truncated CRC32 (which isn't

--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorOutputStream.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
@@ -111,12 +112,12 @@ public class GzipCompressorOutputStream extends CompressorOutputStream {
         out.write(buffer.array());
 
         if (filename != null) {
-            out.write(filename.getBytes(CharsetNames.ISO_8859_1));
+            out.write(filename.getBytes(StandardCharsets.ISO_8859_1));
             out.write(0);
         }
 
         if (comment != null) {
-            out.write(comment.getBytes(CharsetNames.ISO_8859_1));
+            out.write(comment.getBytes(StandardCharsets.ISO_8859_1));
             out.write(0);
         }
     }

--- a/src/main/java/org/apache/commons/compress/utils/ArchiveUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/ArchiveUtils.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.utils;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -72,12 +73,7 @@ public class ArchiveUtils {
     public static boolean matchAsciiBuffer(
             final String expected, final byte[] buffer, final int offset, final int length){
         byte[] buffer1;
-        try {
-            buffer1 = expected.getBytes(CharsetNames.US_ASCII);
-        } catch (final UnsupportedEncodingException e) {
-            // Should not happen
-            throw new RuntimeException(e); //NOSONAR
-        }
+        buffer1 = expected.getBytes(StandardCharsets.US_ASCII);
         return isEqual(buffer1, 0, buffer1.length, buffer, offset, length, false);
     }
 
@@ -100,12 +96,7 @@ public class ArchiveUtils {
      * @return the bytes
      */
     public static byte[] toAsciiBytes(final String inputString){
-        try {
-            return inputString.getBytes(CharsetNames.US_ASCII);
-        } catch (final UnsupportedEncodingException e) {
-            // Should never happen
-            throw new RuntimeException(e); //NOSONAR
-        }
+        return inputString.getBytes(StandardCharsets.US_ASCII);
     }
 
     /**
@@ -115,12 +106,7 @@ public class ArchiveUtils {
      * @return the bytes, interpreted as an Ascii string
      */
     public static String toAsciiString(final byte[] inputBytes){
-        try {
-            return new String(inputBytes, CharsetNames.US_ASCII);
-        } catch (final UnsupportedEncodingException e) {
-            // Should never happen
-            throw new RuntimeException(e); //NOSONAR
-        }
+        return new String(inputBytes, StandardCharsets.US_ASCII);
     }
 
     /**
@@ -132,12 +118,7 @@ public class ArchiveUtils {
      * @return the bytes, interpreted as an Ascii string
      */
     public static String toAsciiString(final byte[] inputBytes, final int offset, final int length){
-        try {
-            return new String(inputBytes, offset, length, CharsetNames.US_ASCII);
-        } catch (final UnsupportedEncodingException e) {
-            // Should never happen
-            throw new RuntimeException(e); //NOSONAR
-        }
+        return new String(inputBytes, offset, length, StandardCharsets.US_ASCII);
     }
 
     /**

--- a/src/test/java/org/apache/commons/compress/archivers/TarTestCase.java
+++ b/src/test/java/org/apache/commons/compress/archivers/TarTestCase.java
@@ -30,6 +30,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.compress.AbstractTestCase;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -64,7 +65,7 @@ public final class TarTestCase extends AbstractTestCase {
     @Test
     public void testTarArchiveLongNameCreation() throws Exception {
         final String name = "testdata/12345678901234567890123456789012345678901234567890123456789012345678901234567890123456.xml";
-        final byte[] bytes = name.getBytes(CharsetNames.UTF_8);
+        final byte[] bytes = name.getBytes(StandardCharsets.UTF_8);
         assertEquals(bytes.length, 99);
 
         final File output = new File(dir, "bla.tar");

--- a/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
@@ -152,7 +152,7 @@ public class SevenZFileTest extends AbstractTestCase {
     public void test7zDecryptUnarchive() throws Exception {
         if (isStrongCryptoAvailable()) {
             test7zUnarchive(getFile("bla.encrypted.7z"), SevenZMethod.LZMA, // stack LZMA + AES
-                            "foo".getBytes("UTF-16LE"));
+                            "foo".getBytes(StandardCharsets.UTF_16LE));
         }
     }
 
@@ -433,7 +433,7 @@ public class SevenZFileTest extends AbstractTestCase {
                         assert (bytesRead >= 0);
                         off += bytesRead;
                     }
-                    assertEquals(testTxtContents, new String(contents, "UTF-8"));
+                    assertEquals(testTxtContents, new String(contents, StandardCharsets.UTF_8));
                     break;
                 }
             }
@@ -487,7 +487,7 @@ public class SevenZFileTest extends AbstractTestCase {
                         off += bytesRead;
                     }
                     assertEquals(SevenZMethod.LZMA2, entry.getContentMethods().iterator().next().getMethod());
-                    assertEquals(filesTxtContents, new String(contents, "UTF-8"));
+                    assertEquals(filesTxtContents, new String(contents, StandardCharsets.UTF_8));
                     break;
                 }
             }
@@ -506,7 +506,7 @@ public class SevenZFileTest extends AbstractTestCase {
                 off += bytesRead;
             }
             assertEquals(SevenZMethod.LZMA2, nextEntry.getContentMethods().iterator().next().getMethod());
-            assertEquals(testTxtContents, new String(contents, "UTF-8"));
+            assertEquals(testTxtContents, new String(contents, StandardCharsets.UTF_8));
         }
     }
 
@@ -553,7 +553,7 @@ public class SevenZFileTest extends AbstractTestCase {
                     off += bytesRead;
                 }
                 assertEquals(SevenZMethod.LZMA2, testTxtEntry.getContentMethods().iterator().next().getMethod());
-                assertEquals(testTxtContents, new String(contents, "UTF-8"));
+                assertEquals(testTxtContents, new String(contents, StandardCharsets.UTF_8));
             }
 
             // then read the next entry using getNextEntry
@@ -618,7 +618,7 @@ public class SevenZFileTest extends AbstractTestCase {
                         off += bytesRead;
                     }
                     assertEquals(SevenZMethod.LZMA2, testTxtEntry.getContentMethods().iterator().next().getMethod());
-                    assertEquals(testTxtContents, new String(contents, "UTF-8"));
+                    assertEquals(testTxtContents, new String(contents, StandardCharsets.UTF_8));
                 }
             }
         }
@@ -658,7 +658,7 @@ public class SevenZFileTest extends AbstractTestCase {
                         off += bytesRead;
                     }
                     assertEquals(SevenZMethod.LZMA2, testTxtEntry.getContentMethods().iterator().next().getMethod());
-                    assertEquals(testTxtContents, new String(contents, "UTF-8"));
+                    assertEquals(testTxtContents, new String(contents, StandardCharsets.UTF_8));
                 }
             }
         }
@@ -734,7 +734,7 @@ public class SevenZFileTest extends AbstractTestCase {
             assert (bytesRead >= 0);
             off += bytesRead;
         }
-        assertEquals(TEST2_CONTENT, new String(contents, "UTF-8"));
+        assertEquals(TEST2_CONTENT, new String(contents, StandardCharsets.UTF_8));
         assertNull(sevenZFile.getNextEntry());
     }
 
@@ -749,7 +749,7 @@ public class SevenZFileTest extends AbstractTestCase {
                 assert (bytesRead >= 0);
                 off += bytesRead;
             }
-            assertEquals("Hello, world!\n", new String(contents, "UTF-8"));
+            assertEquals("Hello, world!\n", new String(contents, StandardCharsets.UTF_8));
             assertNull(sevenZFile.getNextEntry());
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
@@ -33,6 +33,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         final TarArchiveInputStream tais = new TarArchiveInputStream(is);
         final Map<String, String> headers = tais
             .parsePaxHeaders(new ByteArrayInputStream("30 atime=1321711775.972059463\n"
-                                                      .getBytes(CharsetNames.UTF_8)), null);
+                                                      .getBytes(StandardCharsets.UTF_8)), null);
         assertEquals(1, headers.size());
         assertEquals("1321711775.972059463", headers.get("atime"));
         tais.close();
@@ -67,7 +68,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         final TarArchiveInputStream tais = new TarArchiveInputStream(is);
         final Map<String, String> headers = tais
             .parsePaxHeaders(new ByteArrayInputStream("11 foo=bar\n11 foo=baz\n"
-                                                      .getBytes(CharsetNames.UTF_8)), null);
+                                                      .getBytes(StandardCharsets.UTF_8)), null);
         assertEquals(1, headers.size());
         assertEquals("baz", headers.get("foo"));
         tais.close();
@@ -79,7 +80,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         final TarArchiveInputStream tais = new TarArchiveInputStream(is);
         final Map<String, String> headers = tais
             .parsePaxHeaders(new ByteArrayInputStream("11 foo=bar\n7 foo=\n"
-                                                      .getBytes(CharsetNames.UTF_8)), null);
+                                                      .getBytes(StandardCharsets.UTF_8)), null);
         assertEquals(0, headers.size());
         tais.close();
     }
@@ -90,7 +91,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         final TarArchiveInputStream tais = new TarArchiveInputStream(is);
         final Map<String, String> headers = tais
             .parsePaxHeaders(new ByteArrayInputStream("28 comment=line1\nline2\nand3\n"
-                                                      .getBytes(CharsetNames.UTF_8)), null);
+                                                      .getBytes(StandardCharsets.UTF_8)), null);
         assertEquals(1, headers.size());
         assertEquals("line1\nline2\nand3", headers.get("comment"));
         tais.close();
@@ -100,11 +101,11 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
     public void readNonAsciiPaxHeader() throws Exception {
         final String ae = "\u00e4";
         final String line = "11 path="+ ae + "\n";
-        assertEquals(11, line.getBytes(CharsetNames.UTF_8).length);
+        assertEquals(11, line.getBytes(StandardCharsets.UTF_8).length);
         final InputStream is = new ByteArrayInputStream(new byte[1]);
         final TarArchiveInputStream tais = new TarArchiveInputStream(is);
         final Map<String, String> headers = tais
-            .parsePaxHeaders(new ByteArrayInputStream(line.getBytes(CharsetNames.UTF_8)), null);
+            .parsePaxHeaders(new ByteArrayInputStream(line.getBytes(StandardCharsets.UTF_8)), null);
         assertEquals(1, headers.size());
         assertEquals(ae, headers.get("path"));
         tais.close();

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Calendar;
 import java.util.Date;
@@ -147,7 +148,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
                     + TarConstants.MODELEN
                     + TarConstants.UIDLEN
                     + TarConstants.GIDLEN, 12,
-                CharsetNames.UTF_8));
+                    StandardCharsets.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -168,8 +169,8 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
                 + TarConstants.MODELEN
                 + TarConstants.UIDLEN
                 + TarConstants.GIDLEN, 12,
-                CharsetNames.UTF_8));
-        assertEquals("6 a=b\n", new String(data, 512, 6, CharsetNames.UTF_8));
+                    StandardCharsets.UTF_8));
+        assertEquals("6 a=b\n", new String(data, 512, 6, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -185,10 +186,10 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
                 + TarConstants.MODELEN
                 + TarConstants.UIDLEN
                 + TarConstants.GIDLEN, 12,
-                CharsetNames.UTF_8));
+                    StandardCharsets.UTF_8));
         assertEquals("99 a=0123456789012345678901234567890123456789"
             + "01234567890123456789012345678901234567890123456789"
-            + "012\n", new String(data, 512, 99, CharsetNames.UTF_8));
+            + "012\n", new String(data, 512, 99, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -204,10 +205,10 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
                 + TarConstants.MODELEN
                 + TarConstants.UIDLEN
                 + TarConstants.GIDLEN, 12,
-                CharsetNames.UTF_8));
+                    StandardCharsets.UTF_8));
         assertEquals("101 a=0123456789012345678901234567890123456789"
             + "01234567890123456789012345678901234567890123456789"
-            + "0123\n", new String(data, 512, 101, CharsetNames.UTF_8));
+            + "0123\n", new String(data, 512, 101, StandardCharsets.UTF_8));
     }
 
     private byte[] writePaxHeader(final Map<String, String> m) throws Exception {
@@ -242,7 +243,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.closeArchiveEntry();
         final byte[] data = bos.toByteArray();
         assertEquals("160 path=" + n + "\n",
-            new String(data, 512, 160, CharsetNames.UTF_8));
+            new String(data, 512, 160, StandardCharsets.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -301,7 +302,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
                     + TarConstants.UIDLEN
                     + TarConstants.GIDLEN
                     + TarConstants.SIZELEN, 12,
-                CharsetNames.UTF_8));
+                    StandardCharsets.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -344,7 +345,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.close();
         final byte[] data = bos.toByteArray();
         assertEquals("11 path=" + n + "\n",
-            new String(data, 512, 11, CharsetNames.UTF_8));
+            new String(data, 512, 11, StandardCharsets.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();
@@ -367,7 +368,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         tos.close();
         final byte[] data = bos.toByteArray();
         assertEquals("15 linkpath=" + n + "\n",
-            new String(data, 512, 15, CharsetNames.UTF_8));
+            new String(data, 512, 15, StandardCharsets.UTF_8));
         final TarArchiveInputStream tin =
             new TarArchiveInputStream(new ByteArrayInputStream(data));
         final TarArchiveEntry e = tin.getNextTarEntry();

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -28,6 +28,8 @@ import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
 import org.apache.commons.compress.utils.CharsetNames;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 public class TarUtilsTest {
 
 
@@ -58,7 +60,7 @@ public class TarUtilsTest {
         final long MAX_OCTAL  = 077777777777L; // Allowed 11 digits
         final long MAX_OCTAL_OVERFLOW  = 0777777777777L; // in fact 12 for some implementations
         final String maxOctal = "777777777777"; // Maximum valid octal
-        buffer = maxOctal.getBytes(CharsetNames.UTF_8);
+        buffer = maxOctal.getBytes(StandardCharsets.UTF_8);
         value = TarUtils.parseOctal(buffer,0, buffer.length);
         assertEquals(MAX_OCTAL_OVERFLOW, value);
         buffer[buffer.length - 1] = ' ';
@@ -93,19 +95,19 @@ public class TarUtilsTest {
             fail("Expected IllegalArgumentException - should be at least 2 bytes long");
         } catch (final IllegalArgumentException expected) {
         }
-        buffer = "abcdef ".getBytes(CharsetNames.UTF_8); // Invalid input
+        buffer = "abcdef ".getBytes(StandardCharsets.UTF_8); // Invalid input
         try {
             TarUtils.parseOctal(buffer,0, buffer.length);
             fail("Expected IllegalArgumentException");
         } catch (final IllegalArgumentException expected) {
         }
-        buffer = " 0 07 ".getBytes(CharsetNames.UTF_8); // Invalid - embedded space
+        buffer = " 0 07 ".getBytes(StandardCharsets.UTF_8); // Invalid - embedded space
         try {
             TarUtils.parseOctal(buffer,0, buffer.length);
             fail("Expected IllegalArgumentException - embedded space");
         } catch (final IllegalArgumentException expected) {
         }
-        buffer = " 0\00007 ".getBytes(CharsetNames.UTF_8); // Invalid - embedded NUL
+        buffer = " 0\00007 ".getBytes(StandardCharsets.UTF_8); // Invalid - embedded NUL
         try {
             TarUtils.parseOctal(buffer,0, buffer.length);
             fail("Expected IllegalArgumentException - embedded NUL");
@@ -188,14 +190,14 @@ public class TarUtilsTest {
     public void testNegative() throws Exception {
         final byte [] buffer = new byte[22];
         TarUtils.formatUnsignedOctalString(-1, buffer, 0, buffer.length);
-        assertEquals("1777777777777777777777", new String(buffer, CharsetNames.UTF_8));
+        assertEquals("1777777777777777777777", new String(buffer, StandardCharsets.UTF_8));
     }
 
     @Test
     public void testOverflow() throws Exception {
         final byte [] buffer = new byte[8-1]; // a lot of the numbers have 8-byte buffers (nul term)
         TarUtils.formatUnsignedOctalString(07777777L, buffer, 0, buffer.length);
-        assertEquals("7777777", new String(buffer, CharsetNames.UTF_8));
+        assertEquals("7777777", new String(buffer, StandardCharsets.UTF_8));
         try {
             TarUtils.formatUnsignedOctalString(017777777L, buffer, 0, buffer.length);
             fail("Should have cause IllegalArgumentException");

--- a/src/test/java/org/apache/commons/compress/archivers/zip/DataDescriptorTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/DataDescriptorTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.commons.compress.utils.IOUtils;
@@ -54,7 +55,7 @@ public class DataDescriptorTest {
         ByteArrayOutputStream o = new ByteArrayOutputStream();
         try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(o)) {
             zos.putArchiveEntry(new ZipArchiveEntry("test1.txt"));
-            zos.write("foo".getBytes("UTF-8"));
+            zos.write("foo".getBytes(StandardCharsets.UTF_8));
             zos.closeArchiveEntry();
         }
         byte[] data = o.toByteArray();
@@ -94,7 +95,7 @@ public class DataDescriptorTest {
         File f = new File(dir, "test.zip");
         try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(f)) {
             zos.putArchiveEntry(new ZipArchiveEntry("test1.txt"));
-            zos.write("foo".getBytes("UTF-8"));
+            zos.write("foo".getBytes(StandardCharsets.UTF_8));
             zos.closeArchiveEntry();
         }
 
@@ -136,7 +137,7 @@ public class DataDescriptorTest {
         ByteArrayOutputStream init = new ByteArrayOutputStream();
         try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(init)) {
             zos.putArchiveEntry(new ZipArchiveEntry("test1.txt"));
-            zos.write("foo".getBytes("UTF-8"));
+            zos.write("foo".getBytes(StandardCharsets.UTF_8));
             zos.closeArchiveEntry();
         }
 

--- a/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.zip.CRC32;
 
@@ -310,7 +311,7 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
             }
 
             zos.putArchiveEntry(ze);
-            zos.write("Hello, world!".getBytes(CharsetNames.US_ASCII));
+            zos.write("Hello, world!".getBytes(StandardCharsets.US_ASCII));
             zos.closeArchiveEntry();
 
             ze = new ZipArchiveEntry(EURO_FOR_DOLLAR_TXT);
@@ -327,7 +328,7 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
             }
 
             zos.putArchiveEntry(ze);
-            zos.write("Give me your money!".getBytes(CharsetNames.US_ASCII));
+            zos.write("Give me your money!".getBytes(StandardCharsets.US_ASCII));
             zos.closeArchiveEntry();
 
             ze = new ZipArchiveEntry(ASCII_TXT);
@@ -345,7 +346,7 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
             }
 
             zos.putArchiveEntry(ze);
-            zos.write("ascii".getBytes(CharsetNames.US_ASCII));
+            zos.write("ascii".getBytes(StandardCharsets.US_ASCII));
             zos.closeArchiveEntry();
 
             zos.finish();
@@ -405,7 +406,7 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
 
             assertEquals(crc.getValue(), ucpf.getNameCRC32());
             assertEquals(expectedName, new String(ucpf.getUnicodeName(),
-                                                  CharsetNames.UTF_8));
+                    StandardCharsets.UTF_8));
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -490,14 +491,14 @@ public class ZipFileTest {
             inflatedEntry.setMethod(ZipEntry.DEFLATED);
             inflatedEntry.setAlignment(1024);
             zipOutput.putArchiveEntry(inflatedEntry);
-            zipOutput.write("Hello Deflated\n".getBytes(Charset.forName("UTF-8")));
+            zipOutput.write("Hello Deflated\n".getBytes(StandardCharsets.UTF_8));
             zipOutput.closeArchiveEntry();
 
             ZipArchiveEntry storedEntry = new ZipArchiveEntry("stored.txt");
             storedEntry.setMethod(ZipEntry.STORED);
             storedEntry.setAlignment(1024);
             zipOutput.putArchiveEntry(storedEntry);
-            zipOutput.write("Hello Stored\n".getBytes(Charset.forName("UTF-8")));
+            zipOutput.write("Hello Stored\n".getBytes(StandardCharsets.UTF_8));
             zipOutput.closeArchiveEntry();
 
             ZipArchiveEntry storedEntry2 = new ZipArchiveEntry("stored2.txt");
@@ -505,14 +506,14 @@ public class ZipFileTest {
             storedEntry2.setAlignment(1024);
             storedEntry2.addExtraField(new ResourceAlignmentExtraField(1));
             zipOutput.putArchiveEntry(storedEntry2);
-            zipOutput.write("Hello overload-alignment Stored\n".getBytes(Charset.forName("UTF-8")));
+            zipOutput.write("Hello overload-alignment Stored\n".getBytes(StandardCharsets.UTF_8));
             zipOutput.closeArchiveEntry();
 
             ZipArchiveEntry storedEntry3 = new ZipArchiveEntry("stored3.txt");
             storedEntry3.setMethod(ZipEntry.STORED);
             storedEntry3.addExtraField(new ResourceAlignmentExtraField(1024));
             zipOutput.putArchiveEntry(storedEntry3);
-            zipOutput.write("Hello copy-alignment Stored\n".getBytes(Charset.forName("UTF-8")));
+            zipOutput.write("Hello copy-alignment Stored\n".getBytes(StandardCharsets.UTF_8));
             zipOutput.closeArchiveEntry();
 
         }
@@ -531,7 +532,7 @@ public class ZipFileTest {
             assertFalse(inflatedAlignmentEx.allowMethodChange());
             try (InputStream stream = zf.getInputStream(inflatedEntry)) {
                 Assert.assertEquals("Hello Deflated\n",
-                                new String(IOUtils.toByteArray(stream), Charset.forName("UTF-8")));
+                                new String(IOUtils.toByteArray(stream), StandardCharsets.UTF_8));
             }
             ZipArchiveEntry storedEntry = zf.getEntry("stored.txt");
             ResourceAlignmentExtraField storedAlignmentEx =
@@ -544,7 +545,7 @@ public class ZipFileTest {
             assertFalse(storedAlignmentEx.allowMethodChange());
             try (InputStream stream = zf.getInputStream(storedEntry)) {
                 Assert.assertEquals("Hello Stored\n",
-                                new String(IOUtils.toByteArray(stream), Charset.forName("UTF-8")));
+                                new String(IOUtils.toByteArray(stream), StandardCharsets.UTF_8));
             }
 
             ZipArchiveEntry storedEntry2 = zf.getEntry("stored2.txt");
@@ -558,7 +559,7 @@ public class ZipFileTest {
             assertFalse(stored2AlignmentEx.allowMethodChange());
             try (InputStream stream = zf.getInputStream(storedEntry2)) {
                 Assert.assertEquals("Hello overload-alignment Stored\n",
-                                new String(IOUtils.toByteArray(stream), Charset.forName("UTF-8")));
+                                new String(IOUtils.toByteArray(stream), StandardCharsets.UTF_8));
             }
 
             ZipArchiveEntry storedEntry3 = zf.getEntry("stored3.txt");
@@ -572,7 +573,7 @@ public class ZipFileTest {
             assertFalse(stored3AlignmentEx.allowMethodChange());
             try (InputStream stream = zf.getInputStream(storedEntry3)) {
                 Assert.assertEquals("Hello copy-alignment Stored\n",
-                                new String(IOUtils.toByteArray(stream), Charset.forName("UTF-8")));
+                                new String(IOUtils.toByteArray(stream), StandardCharsets.UTF_8));
             }
         }
     }
@@ -893,8 +894,8 @@ public class ZipFileTest {
     }
 
     private void assertFileEqualIgnoreEndOfLine(File file1, File file2) throws IOException {
-        List<String> linesOfFile1 = Files.readAllLines(Paths.get(file1.getCanonicalPath()), Charset.forName("UTF-8"));
-        List<String> linesOfFile2 = Files.readAllLines(Paths.get(file2.getCanonicalPath()), Charset.forName("UTF-8"));
+        List<String> linesOfFile1 = Files.readAllLines(Paths.get(file1.getCanonicalPath()), StandardCharsets.UTF_8);
+        List<String> linesOfFile2 = Files.readAllLines(Paths.get(file2.getCanonicalPath()), StandardCharsets.UTF_8);
 
         if(linesOfFile1.size() != linesOfFile2.size()) {
             fail("files not equal : " + file1.getName() + " , " + file2.getName());

--- a/src/test/java/org/apache/commons/compress/compressors/CompressorStreamFactoryRoundtripTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/CompressorStreamFactoryRoundtripTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.compress.compressors;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.Assert;
@@ -59,7 +60,7 @@ public class CompressorStreamFactoryRoundtripTest {
         final CompressorOutputStream compressorOutputStream = factory.createCompressorOutputStream(compressorName,
                 compressedOs);
         final String fixture = "The quick brown fox jumps over the lazy dog";
-        compressorOutputStream.write(fixture.getBytes("UTF-8"));
+        compressorOutputStream.write(fixture.getBytes(StandardCharsets.UTF_8));
         compressorOutputStream.flush();
         compressorOutputStream.close();
         final ByteArrayInputStream is = new ByteArrayInputStream(compressedOs.toByteArray());

--- a/src/test/java/org/apache/commons/compress/compressors/lz77support/LZ77CompressorTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/lz77support/LZ77CompressorTest.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.compressors.lz77support;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,34 +34,30 @@ public class LZ77CompressorTest {
     private static final byte[] BLA, SAM, ONE_TO_TEN;
 
     static {
-        try {
-            /*
-             * Example from "An Explanation of the Deflate Algorithm" by "Antaeus Feldspar".
-             * @see "http://zlib.net/feldspar.html"
-             */
-            BLA = "Blah blah blah blah blah!".getBytes("ASCII");
+        /*
+         * Example from "An Explanation of the Deflate Algorithm" by "Antaeus Feldspar".
+         * @see "http://zlib.net/feldspar.html"
+         */
+        BLA = "Blah blah blah blah blah!".getBytes(StandardCharsets.US_ASCII);
 
-            /*
-             * Example from Wikipedia article about LZSS.
-             * Note the example uses indices instead of offsets.
-             * @see "https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Storer%E2%80%93Szymanski"
-             */
-            SAM = ("I am Sam\n"
-                   + "\n"
-                   + "Sam I am\n"
-                   + "\n"
-                   + "That Sam-I-am!\n"
-                   + "That Sam-I-am!\n"
-                   + "I do not like\n"
-                   + "that Sam-I-am!\n"
-                   + "\n"
-                   + "Do you like green eggs and ham?\n"
-                   + "\n"
-                   + "I do not like them, Sam-I-am.\n"
-                   + "I do not like green eggs and ham.").getBytes("ASCII");
-        } catch (IOException ex) {
-            throw new RuntimeException("ASCII not supported");
-        }
+        /*
+         * Example from Wikipedia article about LZSS.
+         * Note the example uses indices instead of offsets.
+         * @see "https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Storer%E2%80%93Szymanski"
+         */
+        SAM = ("I am Sam\n"
+               + "\n"
+               + "Sam I am\n"
+               + "\n"
+               + "That Sam-I-am!\n"
+               + "That Sam-I-am!\n"
+               + "I do not like\n"
+               + "that Sam-I-am!\n"
+               + "\n"
+               + "Do you like green eggs and ham?\n"
+               + "\n"
+               + "I do not like them, Sam-I-am.\n"
+               + "I do not like green eggs and ham.").getBytes(StandardCharsets.US_ASCII);
         ONE_TO_TEN = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
     }
 
@@ -312,7 +309,7 @@ public class LZ77CompressorTest {
 
     private static final void assertLiteralBlock(String expectedContent, LZ77Compressor.Block block)
         throws IOException {
-        assertLiteralBlock(expectedContent.getBytes("ASCII"), block);
+        assertLiteralBlock(expectedContent.getBytes(StandardCharsets.US_ASCII), block);
     }
 
     private static final void assertLiteralBlock(byte[] expectedContent, LZ77Compressor.Block block) {

--- a/src/test/java/org/apache/commons/compress/utils/CharsetsTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/CharsetsTest.java
@@ -18,6 +18,7 @@
 package org.apache.commons.compress.utils;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 
@@ -35,6 +36,7 @@ public class CharsetsTest {
         Assert.assertEquals(Charset.defaultCharset(), Charsets.toCharset((Charset) null));
         Assert.assertEquals(Charset.defaultCharset(), Charsets.toCharset(Charset.defaultCharset()));
         Assert.assertEquals(Charset.forName("UTF-8"), Charsets.toCharset(Charset.forName("UTF-8")));
+        Assert.assertEquals(Charset.forName("UTF-8"), StandardCharsets.UTF_8);
     }
 
 }

--- a/src/test/java/org/apache/commons/compress/utils/SeekableInMemoryByteChannelTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/SeekableInMemoryByteChannelTest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
@@ -35,7 +36,7 @@ import static org.junit.Assert.assertFalse;
 
 public class SeekableInMemoryByteChannelTest {
 
-    private final byte[] testData = "Some data".getBytes(Charset.forName(UTF_8));
+    private final byte[] testData = "Some data".getBytes(StandardCharsets.UTF_8);
 
     @Test
     public void shouldReadContentsProperly() throws IOException {
@@ -75,7 +76,7 @@ public class SeekableInMemoryByteChannelTest {
         int readCount = c.read(readBuffer);
         //then
         assertEquals(4L, readCount);
-        assertEquals("data", new String(readBuffer.array(), Charset.forName(UTF_8)));
+        assertEquals("data", new String(readBuffer.array(), StandardCharsets.UTF_8));
         assertEquals(testData.length, c.position());
         c.close();
     }
@@ -153,7 +154,7 @@ public class SeekableInMemoryByteChannelTest {
         c.truncate(4);
         //then
         byte[] bytes = Arrays.copyOf(c.array(), (int) c.size());
-        assertEquals("Some", new String(bytes, Charset.forName(UTF_8)));
+        assertEquals("Some", new String(bytes, StandardCharsets.UTF_8));
         c.close();
     }
 


### PR DESCRIPTION
In most cases using StandardCharsets is faster.
You can get more information at `decode(String charsetName, byte[] ba, int off, int len)` and `decode(Charset cs, byte[] ba, int off, int len)` in class java.lang.StringCoding