### PR TITLE
unitized array styles.

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -75,7 +75,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream implements
 
     private boolean entryEOF = false;
 
-    private final byte tmpbuf[] = new byte[4096];
+    private final byte[] tmpbuf = new byte[4096];
 
     private long crc = 0;
 
@@ -355,14 +355,14 @@ public class CpioArchiveInputStream extends ArchiveInputStream implements
 
     private long readBinaryLong(final int length, final boolean swapHalfWord)
             throws IOException {
-        final byte tmp[] = new byte[length];
+        final byte[] tmp = new byte[length];
         readFully(tmp, 0, tmp.length);
         return CpioUtil.byteArray2long(tmp, swapHalfWord);
     }
 
     private long readAsciiLong(final int length, final int radix)
             throws IOException {
-        final byte tmpBuffer[] = new byte[length];
+        final byte[] tmpBuffer = new byte[length];
         readFully(tmpBuffer, 0, tmpBuffer.length);
         return Long.parseLong(ArchiveUtils.toAsciiString(tmpBuffer), radix);
     }
@@ -480,7 +480,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream implements
 
     private String readCString(final int length) throws IOException {
         // don't include trailing NUL in file name to decode
-        final byte tmpBuffer[] = new byte[length - 1];
+        final byte[] tmpBuffer = new byte[length - 1];
         readFully(tmpBuffer, 0, tmpBuffer.length);
         if (this.in.read() == -1) {
             throw new EOFException();

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStream.java
@@ -500,7 +500,7 @@ public class CpioArchiveOutputStream extends ArchiveOutputStream implements
 
     private void pad(final int count) throws IOException{
         if (count > 0){
-            final byte buff[] = new byte[count];
+            final byte[] buff = new byte[count];
             out.write(buff);
             count(count);
         }
@@ -508,7 +508,7 @@ public class CpioArchiveOutputStream extends ArchiveOutputStream implements
 
     private void writeBinaryLong(final long number, final int length,
             final boolean swapHalfWord) throws IOException {
-        final byte tmp[] = CpioUtil.long2byteArray(number, length, swapHalfWord);
+        final byte[] tmp = CpioUtil.long2byteArray(number, length, swapHalfWord);
         out.write(tmp);
         count(tmp.length);
     }

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioUtil.java
@@ -50,7 +50,7 @@ class CpioUtil {
 
         long ret = 0;
         int pos = 0;
-        final byte tmp_number[] = new byte[number.length];
+        final byte[] tmp_number = new byte[number.length];
         System.arraycopy(number, 0, tmp_number, 0, number.length);
 
         if (!swapHalfWord) {

--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
@@ -881,7 +881,7 @@ public class SevenZFile implements Closeable {
         }
         final long numPackedStreams = totalInStreams - numBindPairs;
         assertFitsIntoInt("numPackedStreams", numPackedStreams);
-        final long packedStreams[] = new long[(int)numPackedStreams];
+        final long[] packedStreams = new long[(int)numPackedStreams];
         if (numPackedStreams == 1) {
             int i;
             for (i = 0; i < (int)totalInStreams; i++) {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0017_StrongEncryptionHeader.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0017_StrongEncryptionHeader.java
@@ -260,16 +260,16 @@ public class X0017_StrongEncryptionHeader extends PKWareExtraHeader {
     private int hashSize;
 
     // encryption data
-    private byte ivData[];
-    private byte erdData[];
+    private byte[] ivData;
+    private byte[] erdData;
 
     // encryption key
-    private byte recipientKeyHash[];
-    private byte keyBlob[];
+    private byte[] recipientKeyHash;
+    private byte[] keyBlob;
 
     // password verification data
-    private byte vData[];
-    private byte vCRC32[];
+    private byte[] vData;
+    private byte[] vCRC32;
 
     /**
      * Get record count.

--- a/src/main/java/org/apache/commons/compress/compressors/bzip2/CRC.java
+++ b/src/main/java/org/apache/commons/compress/compressors/bzip2/CRC.java
@@ -24,7 +24,7 @@ package org.apache.commons.compress.compressors.bzip2;
  * @NotThreadSafe
  */
 class CRC {
-    private static final int crc32Table[] = {
+    private static final int[] crc32Table = {
             0x00000000, 0x04c11db7, 0x09823b6e, 0x0d4326d9,
             0x130476dc, 0x17c56b6b, 0x1a864db2, 0x1e475005,
             0x2608edb8, 0x22c9f00f, 0x2f8ad6d6, 0x2b4bcb61,

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -218,13 +218,13 @@ public class TarUtilsTest {
         // COMPRESS-114
         final ZipEncoding enc = ZipEncodingHelper.getZipEncoding(CharsetNames.ISO_8859_1);
         final String s = "0302-0601-3\u00b1\u00b1\u00b1F06\u00b1W220\u00b1ZB\u00b1LALALA\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1CAN\u00b1\u00b1DC\u00b1\u00b1\u00b104\u00b1060302\u00b1MOE.model";
-        final byte buff[] = new byte[100];
+        final byte[] buff = new byte[100];
         final int len = TarUtils.formatNameBytes(s, buff, 0, buff.length, enc);
         assertEquals(s, TarUtils.parseName(buff, 0, len, enc));
     }
 
     private void checkName(final String string) {
-        final byte buff[] = new byte[100];
+        final byte[] buff = new byte[100];
         final int len = TarUtils.formatNameBytes(string, buff, 0, buff.length);
         assertEquals(string, TarUtils.parseName(buff, 0, len));
     }

--- a/src/test/java/org/apache/commons/compress/compressors/bzip2/PythonTruncatedBzip2Test.java
+++ b/src/test/java/org/apache/commons/compress/compressors/bzip2/PythonTruncatedBzip2Test.java
@@ -113,7 +113,7 @@ public class PythonTruncatedBzip2Test {
     // Does not check parameters, so may fail if they are incompatible
     private static byte[] copyOfRange(final byte[] original, final int from, final int to) {
         final int length = to - from;
-        final byte buff[] = new byte[length];
+        final byte[] buff = new byte[length];
         System.arraycopy(original, from, buff, 0, length);
         return buff;
     }

--- a/src/test/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/FixedLengthBlockOutputStreamTest.java
@@ -65,7 +65,7 @@ public class FixedLengthBlockOutputStreamTest {
         MockWritableByteChannel mock = new MockWritableByteChannel(blockSize, false);
         ByteArrayOutputStream bos = mock.bos;
         String text = "hello world avengers";
-        byte msg[] = text.getBytes();
+        byte[] msg = text.getBytes();
         int len = msg.length;
         try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
             for (int i = 0; i < len; i++) {
@@ -92,7 +92,7 @@ public class FixedLengthBlockOutputStreamTest {
         int blockSize = 13;
         MockWritableByteChannel mock = new MockWritableByteChannel(blockSize, false);
         String testString = "hello world";
-        byte msg[] = testString.getBytes();
+        byte[] msg = testString.getBytes();
         int reps = 17;
 
         try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
@@ -228,7 +228,7 @@ public class FixedLengthBlockOutputStreamTest {
         MockWritableByteChannel mock = new MockWritableByteChannel(blockSize, false);
 
         ByteArrayOutputStream bos = mock.bos;
-        byte msg[] = text.getBytes();
+        byte[] msg = text.getBytes();
         ByteBuffer buf = getByteBuffer(msg);
         try (FixedLengthBlockOutputStream out = new FixedLengthBlockOutputStream(mock, blockSize)) {
             out.write(buf);


### PR DESCRIPTION
from both `byte a[]` and `byte[] a` to only `byte[] a`