### PR TITLE
use System.currentTimeMillis instead of new Date().getTime

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -294,7 +294,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants {
         this.name = name;
         this.mode = isDir ? DEFAULT_DIR_MODE : DEFAULT_FILE_MODE;
         this.linkFlag = isDir ? LF_DIR : LF_NORMAL;
-        this.modTime = new Date().getTime() / MILLIS_PER_SECOND;
+        this.modTime = System.currentTimeMillis() / MILLIS_PER_SECOND;
         this.userName = "";
     }
 


### PR DESCRIPTION
to avoid Date() object creation thus faster.