### PR TITLE
remove `== null` as it is covered by `instance of`

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
@@ -212,7 +212,7 @@ public final class ZipEightByteInteger implements Serializable {
      */
     @Override
     public boolean equals(final Object o) {
-        if (o == null || !(o instanceof ZipEightByteInteger)) {
+        if (!(o instanceof ZipEightByteInteger)) {
             return false;
         }
         return value.equals(((ZipEightByteInteger) o).getValue());

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipLong.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipLong.java
@@ -184,7 +184,7 @@ public final class ZipLong implements Cloneable, Serializable {
      */
     @Override
     public boolean equals(final Object o) {
-        if (o == null || !(o instanceof ZipLong)) {
+        if (!(o instanceof ZipLong)) {
             return false;
         }
         return value == ((ZipLong) o).getValue();

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipShort.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipShort.java
@@ -129,7 +129,7 @@ public final class ZipShort implements Cloneable, Serializable {
      */
     @Override
     public boolean equals(final Object o) {
-        if (o == null || !(o instanceof ZipShort)) {
+        if (!(o instanceof ZipShort)) {
             return false;
         }
         return value == ((ZipShort) o).getValue();


### PR DESCRIPTION
Or, is it for special optimization strategy? 