### PR TITLE
Ignore Pack200 tests for JDK 14+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ jdk:
   - openjdk-ea
 
 matrix:
-  allow_failures:
-    - jdk: openjdk-ea
-    - jdk: openjdk14
 # Remove the outdated OpenJDK 11.0.2 which Travis image grabbed from java.net in
 # https://github.com/travis-ci/travis-cookbooks/blob/master/cookbooks/travis_jdk/files/install-jdk.sh#L200
 # (which has 11.0.2 hard-coded!), and instead replace it with the latest openjdk-11-jdk-headless Ubuntu package.

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,26 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       </build>
     </profile>
     <profile>
+      <id>java14+</id>
+      <activation>
+        <jdk>[14,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/DetectCompressorTestCase.java</exclude>
+                <exclude>**/Pack200TestCase.java</exclude>
+                <exclude>**/Pack200UtilsTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>java11+</id>
       <activation>
         <jdk>[11,)</jdk>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -208,6 +208,10 @@ The <action> type attribute can be add,update,fix,remove.
         ZipArchiveInputStream should throw an exception if a corrputed
         zip64 extra field is met.
       </action>
+      <action type="fix" date="2020-08-22" dev="PeterLee">
+        Add a new maven profile in pom.xml for JDK14+ to ignore the
+        failing tests about Pack200.
+      </action>
     </release>
     <release version="1.20" date="2020-02-08"
              description="Release 1.20 (Java 7)">

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveEntry.java
@@ -56,7 +56,7 @@ import org.apache.commons.compress.archivers.ArchiveEntry;
  * CPIO 2.5 knows also about tar, but it is not recognized here.</p>
  *
  *
- * <h3>OLD FORMAT</h3>
+ * <h2>OLD FORMAT</h2>
  *
  * <p>Each file has a 76 (ascii) / 26 (binary) byte header, a variable
  * length, NUL terminated file name, and variable length file data. A


### PR DESCRIPTION
Add a new maven profile for JDK14+ to ignore the failing Pack200 test classes.
The tests are failing because the JDK14+ have removed pack200.