### PR TITLE
Compress-555 allow reading of stored entries in zips by default

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -198,7 +198,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream implements InputSt
      * Extra Fields (if present) to set the file names.
      */
     public ZipArchiveInputStream(final InputStream inputStream, final String encoding, final boolean useUnicodeExtraFields) {
-        this(inputStream, encoding, useUnicodeExtraFields, false);
+        this(inputStream, encoding, useUnicodeExtraFields, true);
     }
 
     /**

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -557,7 +557,7 @@ public class ZipArchiveInputStreamTest {
     @Test
     public void properlyReadsStoredEntryWithDataDescriptorWithoutSignature() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd-nosig.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, true)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -573,7 +573,7 @@ public class ZipArchiveInputStreamTest {
     @Test
     public void throwsIfStoredDDIsInconsistent() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd-sizes-differ.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, true)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -581,14 +581,14 @@ public class ZipArchiveInputStreamTest {
             assertEquals(-1, e.getSize());
             thrown.expect(ZipException.class);
             thrown.expectMessage("compressed and uncompressed size don't match");
-            IOUtils.toByteArray(archive);
+            final byte[] data = IOUtils.toByteArray(archive);
         }
     }
 
     @Test
     public void throwsIfStoredDDIsDifferentFromLengthRead() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd-contradicts-actualsize.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, true)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -596,7 +596,7 @@ public class ZipArchiveInputStreamTest {
             assertEquals(-1, e.getSize());
             thrown.expect(ZipException.class);
             thrown.expectMessage("actual and claimed size don't match");
-            IOUtils.toByteArray(archive);
+            final byte[] data = IOUtils.toByteArray(archive);
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -524,9 +524,9 @@ public class ZipArchiveInputStreamTest {
     }
 
     @Test
-    public void rejectsStoredEntriesWithDataDescriptorByDefault() throws IOException {
+    public void rejectStoredEntriesWithDataDescriptorWhenSupportDisabled() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, false)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -534,14 +534,14 @@ public class ZipArchiveInputStreamTest {
             assertEquals(-1, e.getSize());
             thrown.expect(UnsupportedZipFeatureException.class);
             thrown.expectMessage("Unsupported feature data descriptor used in entry test1.xml");
-            final byte[] data = IOUtils.toByteArray(archive);
+            IOUtils.toByteArray(archive);
         }
     }
 
     @Test
-    public void properlyReadsStoredEntryWithDataDescriptorWithSignature() throws IOException {
+    public void properlyReadsStoredEntryWithDataDescriptorWithSignatureByDefault() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, true)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -557,7 +557,7 @@ public class ZipArchiveInputStreamTest {
     @Test
     public void properlyReadsStoredEntryWithDataDescriptorWithoutSignature() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd-nosig.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, true)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -573,7 +573,7 @@ public class ZipArchiveInputStreamTest {
     @Test
     public void throwsIfStoredDDIsInconsistent() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd-sizes-differ.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, true)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -581,14 +581,14 @@ public class ZipArchiveInputStreamTest {
             assertEquals(-1, e.getSize());
             thrown.expect(ZipException.class);
             thrown.expectMessage("compressed and uncompressed size don't match");
-            final byte[] data = IOUtils.toByteArray(archive);
+            IOUtils.toByteArray(archive);
         }
     }
 
     @Test
     public void throwsIfStoredDDIsDifferentFromLengthRead() throws IOException {
         try (FileInputStream fs = new FileInputStream(getFile("bla-stored-dd-contradicts-actualsize.zip"));
-             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs, "UTF-8", true, true)) {
+             ZipArchiveInputStream archive = new ZipArchiveInputStream(fs)) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
             assertEquals("test1.xml", e.getName());
@@ -596,7 +596,7 @@ public class ZipArchiveInputStreamTest {
             assertEquals(-1, e.getSize());
             thrown.expect(ZipException.class);
             thrown.expectMessage("actual and claimed size don't match");
-            final byte[] data = IOUtils.toByteArray(archive);
+            IOUtils.toByteArray(archive);
         }
     }
 


### PR DESCRIPTION
We are currently using tika for text extraction which uses commons-compress for handling zips. Currently some sites are returning zips that have entries with stored data descriptors which fail to extract due to the ZipArchiveInputStream defaulting to false for 'allowStoredEntriesWithDataDescriptor'. 

This PR adjusts the ZipArchiveInputStream to allow reading of stored entries with data descriptor by default.

https://issues.apache.org/jira/browse/COMPRESS-555