### PR TITLE
COMPRESS-559: Extract sparsefile-0.1 also on Linux

### DIFF
--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -189,11 +189,9 @@ public class SparseFilesTest extends AbstractTestCase {
                         IOUtils.toByteArray(sparseFileInputStream));
             }
 
-            // TODO : it's wired that I can only get a 0 size sparsefile-0.1 on my Ubuntu 16.04
-            //        using "tar -xf pax_gnu_sparse.tar"
             paxGNUEntry = tin.getNextTarEntry();
             assertTrue(tin.canReadEntryData(paxGNUEntry));
-            try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile-0.0")) {
+            try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile-0.1")) {
                 assertArrayEquals(IOUtils.toByteArray(tin),
                         IOUtils.toByteArray(sparseFileInputStream));
             }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -178,6 +178,8 @@ public class SparseFilesTest extends AbstractTestCase {
     @Test
     public void testExtractPaxGNU() throws IOException, InterruptedException {
         assumeFalse("This test should be ignored on Windows", isOnWindows);
+        assumeFalse("This test should be ignored if GNU tar is version 1.28",
+                getTarBinaryHelp().startsWith("tar (GNU tar) 1.28"));
 
         final File file = getFile("pax_gnu_sparse.tar");
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file))) {
@@ -240,6 +242,14 @@ public class SparseFilesTest extends AbstractTestCase {
         }
         fail("didn't find " + sparseFileName + " after extracting " + tarFile);
         return null;
+    }
+
+    private String getTarBinaryHelp() throws IOException {
+        final ProcessBuilder pb = new ProcessBuilder("tar", "--version");
+        pb.redirectErrorStream(true);
+        final Process process = pb.start();
+        // wait until the help is shown
+        return new String(IOUtils.toByteArray(process.getInputStream()));
     }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/apache/commons-compress/pull/113 the problem can no longer be seen in newer Ubuntu versions