### PR TITLE
COMPRESS-560: Do not return false if the entry is a tar sparse entry

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -1006,15 +1006,11 @@ public class TarArchiveInputStream extends ArchiveInputStream {
     /**
      * Whether this class is able to read the given entry.
      *
-     * <p>May return false if the current entry is a sparse file.</p>
+     * @return The implementation will return true if the {@link ArchiveEntry} is an instance of {@link TarArchiveEntry}
      */
     @Override
     public boolean canReadEntryData(final ArchiveEntry ae) {
-        if (ae instanceof TarArchiveEntry) {
-            final TarArchiveEntry te = (TarArchiveEntry) ae;
-            return !te.isSparse();
-        }
-        return false;
+        return ae instanceof TarArchiveEntry;
     }
 
     /**

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -75,7 +75,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractSparseTarsOnWindows() throws IOException {
-        assumeTrue(isOnWindows);
+        assumeTrue("This test should be ignored if not running on Windows", isOnWindows);
 
         final File oldGNUSparseTar = getFile("oldgnu_sparse.tar");
         final File paxGNUSparseTar = getFile("pax_gnu_sparse.tar");
@@ -115,7 +115,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractOldGNU() throws IOException, InterruptedException {
-        assumeFalse(isOnWindows);
+        assumeFalse("This test should be ignored on Windows", isOnWindows);
 
         try {
             final File file = getFile("oldgnu_sparse.tar");
@@ -134,7 +134,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractExtendedOldGNU() throws IOException, InterruptedException {
-        assumeFalse(isOnWindows);
+        assumeFalse("This test should be ignored on Windows", isOnWindows);
 
         final File file = getFile("oldgnu_extended_sparse.tar");
         try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparse6");
@@ -173,7 +173,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractPaxGNU() throws IOException, InterruptedException {
-        assumeFalse(isOnWindows);
+        assumeFalse("This test should be ignored on Windows", isOnWindows);
 
         final File file = getFile("pax_gnu_sparse.tar");
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file))) {

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -19,6 +19,8 @@
 package org.apache.commons.compress.archivers.tar;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.apache.commons.compress.AbstractTestCase;
 import org.apache.commons.compress.utils.IOUtils;
@@ -73,9 +75,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractSparseTarsOnWindows() throws IOException {
-        if (!isOnWindows) {
-            return;
-        }
+        assumeTrue(isOnWindows);
 
         final File oldGNUSparseTar = getFile("oldgnu_sparse.tar");
         final File paxGNUSparseTar = getFile("pax_gnu_sparse.tar");
@@ -115,9 +115,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractOldGNU() throws IOException, InterruptedException {
-        if (isOnWindows) {
-            return;
-        }
+        assumeFalse(isOnWindows);
 
         try {
             final File file = getFile("oldgnu_sparse.tar");
@@ -136,9 +134,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractExtendedOldGNU() throws IOException, InterruptedException {
-        if (isOnWindows) {
-            return;
-        }
+        assumeFalse(isOnWindows);
 
         final File file = getFile("oldgnu_extended_sparse.tar");
         try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparse6");
@@ -177,9 +173,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     @Test
     public void testExtractPaxGNU() throws IOException, InterruptedException {
-        if (isOnWindows) {
-            return;
-        }
+        assumeFalse(isOnWindows);
 
         final File file = getFile("pax_gnu_sparse.tar");
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file))) {

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -45,7 +45,7 @@ public class SparseFilesTest extends AbstractTestCase {
             assertTrue(ae.isOldGNUSparse());
             assertTrue(ae.isGNUSparse());
             assertFalse(ae.isPaxGNUSparse());
-            assertFalse(tin.canReadEntryData(ae));
+            assertTrue(tin.canReadEntryData(ae));
 
             final List<TarArchiveStructSparse> sparseHeaders = ae.getSparseHeaders();
             assertEquals(3, sparseHeaders.size());
@@ -82,27 +82,33 @@ public class SparseFilesTest extends AbstractTestCase {
         try (TarArchiveInputStream paxGNUSparseInputStream = new TarArchiveInputStream(new FileInputStream(paxGNUSparseTar))) {
 
             // compare between old GNU and PAX 0.0
-            paxGNUSparseInputStream.getNextTarEntry();
+            TarArchiveEntry paxGNUEntry = paxGNUSparseInputStream.getNextTarEntry();
+            assertTrue(paxGNUSparseInputStream.canReadEntryData(paxGNUEntry));
             try (TarArchiveInputStream oldGNUSparseInputStream = new TarArchiveInputStream(new FileInputStream(oldGNUSparseTar))) {
-                oldGNUSparseInputStream.getNextTarEntry();
+                final TarArchiveEntry oldGNUEntry = oldGNUSparseInputStream.getNextTarEntry();
+                assertTrue(oldGNUSparseInputStream.canReadEntryData(oldGNUEntry));
                 assertArrayEquals(IOUtils.toByteArray(oldGNUSparseInputStream),
-                    IOUtils.toByteArray(paxGNUSparseInputStream));
+                        IOUtils.toByteArray(paxGNUSparseInputStream));
             }
 
             // compare between old GNU and PAX 0.1
-            paxGNUSparseInputStream.getNextTarEntry();
+            paxGNUEntry = paxGNUSparseInputStream.getNextTarEntry();
+            assertTrue(paxGNUSparseInputStream.canReadEntryData(paxGNUEntry));
             try (TarArchiveInputStream oldGNUSparseInputStream = new TarArchiveInputStream(new FileInputStream(oldGNUSparseTar))) {
-                oldGNUSparseInputStream.getNextTarEntry();
+                final TarArchiveEntry oldGNUEntry = oldGNUSparseInputStream.getNextTarEntry();
+                assertTrue(oldGNUSparseInputStream.canReadEntryData(oldGNUEntry));
                 assertArrayEquals(IOUtils.toByteArray(oldGNUSparseInputStream),
-                    IOUtils.toByteArray(paxGNUSparseInputStream));
+                        IOUtils.toByteArray(paxGNUSparseInputStream));
             }
 
             // compare between old GNU and PAX 1.0
-            paxGNUSparseInputStream.getNextTarEntry();
+            paxGNUEntry = paxGNUSparseInputStream.getNextTarEntry();
+            assertTrue(paxGNUSparseInputStream.canReadEntryData(paxGNUEntry));
             try (TarArchiveInputStream oldGNUSparseInputStream = new TarArchiveInputStream(new FileInputStream(oldGNUSparseTar))) {
-                oldGNUSparseInputStream.getNextTarEntry();
+                final TarArchiveEntry oldGNUEntry = oldGNUSparseInputStream.getNextTarEntry();
+                assertTrue(oldGNUSparseInputStream.canReadEntryData(oldGNUEntry));
                 assertArrayEquals(IOUtils.toByteArray(oldGNUSparseInputStream),
-                    IOUtils.toByteArray(paxGNUSparseInputStream));
+                        IOUtils.toByteArray(paxGNUSparseInputStream));
             }
         }
     }
@@ -114,13 +120,14 @@ public class SparseFilesTest extends AbstractTestCase {
         }
 
         try {
-        final File file = getFile("oldgnu_sparse.tar");
-        try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile");
-             TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file))) {
-            tin.getNextTarEntry();
-            assertArrayEquals(IOUtils.toByteArray(tin),
-                IOUtils.toByteArray(sparseFileInputStream));
-        }
+            final File file = getFile("oldgnu_sparse.tar");
+            try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile");
+                 TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file))) {
+                final TarArchiveEntry entry = tin.getNextTarEntry();
+                assertTrue(tin.canReadEntryData(entry));
+                assertArrayEquals(IOUtils.toByteArray(tin),
+                        IOUtils.toByteArray(sparseFileInputStream));
+            }
         } catch (RuntimeException | IOException ex) {
             ex.printStackTrace();
             throw ex;
@@ -137,6 +144,7 @@ public class SparseFilesTest extends AbstractTestCase {
         try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparse6");
              TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file))) {
             final TarArchiveEntry ae = tin.getNextTarEntry();
+            assertTrue(tin.canReadEntryData(ae));
 
             assertArrayEquals(IOUtils.toByteArray(tin),
                 IOUtils.toByteArray(sparseFileInputStream));
@@ -176,24 +184,27 @@ public class SparseFilesTest extends AbstractTestCase {
         final File file = getFile("pax_gnu_sparse.tar");
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file))) {
 
-            tin.getNextTarEntry();
+            TarArchiveEntry paxGNUEntry = tin.getNextTarEntry();
+            assertTrue(tin.canReadEntryData(paxGNUEntry));
             try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile-0.0")) {
                 assertArrayEquals(IOUtils.toByteArray(tin),
-                    IOUtils.toByteArray(sparseFileInputStream));
+                        IOUtils.toByteArray(sparseFileInputStream));
             }
 
             // TODO : it's wired that I can only get a 0 size sparsefile-0.1 on my Ubuntu 16.04
             //        using "tar -xf pax_gnu_sparse.tar"
-            tin.getNextTarEntry();
+            paxGNUEntry = tin.getNextTarEntry();
+            assertTrue(tin.canReadEntryData(paxGNUEntry));
             try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile-0.0")) {
                 assertArrayEquals(IOUtils.toByteArray(tin),
-                    IOUtils.toByteArray(sparseFileInputStream));
+                        IOUtils.toByteArray(sparseFileInputStream));
             }
 
-            tin.getNextTarEntry();
+            paxGNUEntry = tin.getNextTarEntry();
+            assertTrue(tin.canReadEntryData(paxGNUEntry));
             try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile-1.0")) {
                 assertArrayEquals(IOUtils.toByteArray(tin),
-                    IOUtils.toByteArray(sparseFileInputStream));
+                        IOUtils.toByteArray(sparseFileInputStream));
             }
         }
     }
@@ -204,7 +215,7 @@ public class SparseFilesTest extends AbstractTestCase {
         assertTrue(ae.isGNUSparse());
         assertTrue(ae.isPaxGNUSparse());
         assertFalse(ae.isOldGNUSparse());
-        assertFalse(tin.canReadEntryData(ae));
+        assertTrue(tin.canReadEntryData(ae));
 
         final List<TarArchiveStructSparse> sparseHeaders = ae.getSparseHeaders();
         assertEquals(3, sparseHeaders.size());


### PR DESCRIPTION
Also some unit test cleanup to use assumeTrue/assumeFalse with the OS check. Now tests will be shown as skipped instead of success when they are not run.