### PR TITLE
OMPRESS-565 : add BufferPool support in zstd

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
@@ -21,6 +21,7 @@ package org.apache.commons.compress.compressors.zstandard;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.github.luben.zstd.BufferPool;
 import com.github.luben.zstd.ZstdInputStream;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.utils.CountingInputStream;
@@ -41,6 +42,22 @@ public class ZstdCompressorInputStream extends CompressorInputStream
 
     public ZstdCompressorInputStream(final InputStream in) throws IOException {
         this.decIS = new ZstdInputStream(countingStream = new CountingInputStream(in));
+    }
+
+    /**
+     * Creates a new input stream that decompresses zstd-compressed data from
+     * the specific input stream
+     *
+     * @param in the input stream of compressed data
+     * @param bufferPool a configuration of zstd-jni that allows users to customize
+     *                   how buffers are recycled. Either a
+     *                   {@link com.github.luben.zstd.NoPool} or a
+     *                   {@link com.github.luben.zstd.RecyclingBufferPool} is
+     *                   allowed here.
+     * @throws IOException if an IO error occurs.
+     */
+    public ZstdCompressorInputStream(final InputStream in, final BufferPool bufferPool) throws IOException {
+        this.decIS = new ZstdInputStream(countingStream = new CountingInputStream(in), bufferPool);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStreamTest.java
@@ -27,6 +27,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.github.luben.zstd.NoPool;
+import com.github.luben.zstd.RecyclingBufferPool;
 import org.apache.commons.compress.AbstractTestCase;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
@@ -47,6 +49,40 @@ public class ZstdCompressorInputStreamTest extends AbstractTestCase {
         final File expected = getFile("zstandard.testdata");
         try (InputStream inputStream = new FileInputStream(input);
             ZstdCompressorInputStream zstdInputStream = new ZstdCompressorInputStream(inputStream)) {
+            final byte[] b = new byte[97];
+            IOUtils.read(expected, b);
+            final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            int readByte = -1;
+            while((readByte = zstdInputStream.read()) != -1) {
+                bos.write(readByte);
+            }
+            Assert.assertArrayEquals(b, bos.toByteArray());
+        }
+    }
+
+    @Test
+    public void testZstdDecodeWithNoPool() throws IOException {
+        final File input = getFile("zstandard.testdata.zst");
+        final File expected = getFile("zstandard.testdata");
+        try (InputStream inputStream = new FileInputStream(input);
+             ZstdCompressorInputStream zstdInputStream = new ZstdCompressorInputStream(inputStream, NoPool.INSTANCE)) {
+            final byte[] b = new byte[97];
+            IOUtils.read(expected, b);
+            final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            int readByte = -1;
+            while((readByte = zstdInputStream.read()) != -1) {
+                bos.write(readByte);
+            }
+            Assert.assertArrayEquals(b, bos.toByteArray());
+        }
+    }
+
+    @Test
+    public void testZstdDecodeWithRecyclingBufferPool() throws IOException {
+        final File input = getFile("zstandard.testdata.zst");
+        final File expected = getFile("zstandard.testdata");
+        try (InputStream inputStream = new FileInputStream(input);
+             ZstdCompressorInputStream zstdInputStream = new ZstdCompressorInputStream(inputStream, RecyclingBufferPool.INSTANCE)) {
             final byte[] b = new byte[97];
             IOUtils.read(expected, b);
             final ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
Add `BufferPool` as a configuration of `ZstdCompressorInputStream`