### PR TITLE
COMPRESS-565 : add a new AlwaysWithCompatibility in Zip64Mode

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/Zip64Mode.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/Zip64Mode.java
@@ -43,5 +43,15 @@ public enum Zip64Mode {
      * Use Zip64 extensions for all entries where they are required,
      * don't use them for entries that clearly don't require them.
      */
-    AsNeeded
+    AsNeeded,
+    /**
+     * Always use Zip64 extensions for LFH and central directory as
+     * {@link Zip64Mode#Always} did, and at the meantime encode
+     * the relative offset of LFH and disk number start as needed in
+     * CFH as {@link Zip64Mode#AsNeeded} did.
+     * <p>
+     * This is a compromise for some libraries including 7z and
+     * Expand-Archive Powershell utility(and likely Excel).
+     */
+    AlwaysWithCompatibility
 }


### PR DESCRIPTION
Add a new AlwaysWithComestibles in Zip64Mode, this is a compromise for some libraries including 7z and Expand-Archive Powershell utility(and likely Excel).

With `Zip64Mode.AlwaysWithComestibles`, the following fields in Central File Header will be set as needed:
1. disk number offset in split zip
2. relative offset of LFH
3. relative header offset in zip64 extra
4. disk number start in zip64 extra

These changes are consistent with commit `2b7281`.

It would be good if the generated file in test could tested by Expand-Archive or 7z, but I didn't find a way to detect them in Java.

It's welcome for suggestions about the name `Zip64Mode.AlwaysWithComestibles`  :)

See [COMPRESS-565](https://issues.apache.org/jira/projects/COMPRESS/issues/COMPRESS-565?filter=allissues&orderby=created+DESC%2C+priority+DESC%2C+updated+DESC) for more detailed information.