### PR TITLE
Remove empty loop in X0017_StrongEncryptionHeader

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0017_StrongEncryptionHeader.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0017_StrongEncryptionHeader.java
@@ -317,12 +317,6 @@ public class X0017_StrongEncryptionHeader extends PKWareExtraHeader {
             assertMinimalLength(16, length);
             this.hashAlg = HashAlgorithm.getAlgorithmByCode(ZipShort.getValue(data, offset + 12));
             this.hashSize = ZipShort.getValue(data, offset + 14);
-            // srlist... hashed public keys
-            for (long i = 0; i < this.rcount; i++) {
-                for (int j = 0; j < this.hashSize; j++) {
-                    //  ZipUtil.signedByteToUnsignedInt(data[offset + 16 + (i * this.hashSize) + j]));
-                }
-            }
         }
     }
 


### PR DESCRIPTION
An empty loop in `X0017_StrongEncryptionHeader#parseCentralDirectoryFormat` can be made to run through 2^48 iterations, taking about 4 seconds on my machine, on crafted input. Since it has no side effects, it can be safely removed.