### PR TITLE
[COMPRESS-584] Fix IOUtils.readRange() can read more from a channel than asked for

### DIFF
--- a/src/main/java/org/apache/commons/compress/utils/IOUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/IOUtils.java
@@ -367,6 +367,8 @@ public final class IOUtils {
         final ByteBuffer b = ByteBuffer.allocate(Math.min(len, COPY_BUF_SIZE));
         int read = 0;
         while (read < len) {
+            // Make sure we never read more than len bytes
+            b.limit(Math.min(len - read, b.capacity()));
             final int readNow = input.read(b);
             if (readNow <= 0) {
                 break;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/COMPRESS-584