### PR TITLE
Use Boolean constants instead of Boolean.valueOf

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/BcBands.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/BcBands.java
@@ -189,12 +189,12 @@ public class BcBands extends BandSet {
                             bcLabelCount++;
                             break;
                         case 170: // tableswitch
-                            switchIsTableSwitch.add(Boolean.valueOf(true));
+                            switchIsTableSwitch.add(Boolean.TRUE);
                             bcCaseCountCount++;
                             bcLabelCount++;
                             break;
                         case 171: // lookupswitch
-                            switchIsTableSwitch.add(Boolean.valueOf(false));
+                            switchIsTableSwitch.add(Boolean.FALSE);
                             bcCaseCountCount++;
                             bcLabelCount++;
                             break;


### PR DESCRIPTION
Boolean.TRUE and Boolean.FALSE are shorter and easier to read. It also
fixes a PMD violation.