### PR TITLE
COMPRESS-602 - Migrate zip package to use NIO

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ParallelScatterZipCreator.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ParallelScatterZipCreator.java
@@ -22,8 +22,9 @@ import org.apache.commons.compress.parallel.InputStreamSupplier;
 import org.apache.commons.compress.parallel.ScatterGatherBackingStore;
 import org.apache.commons.compress.parallel.ScatterGatherBackingStoreSupplier;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Deque;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -66,7 +67,7 @@ public class ParallelScatterZipCreator {
 
         @Override
         public ScatterGatherBackingStore get() throws IOException {
-            final File tempFile = File.createTempFile("parallelscatter", "n" + storeNum.incrementAndGet());
+            final Path tempFile = Files.createTempFile("parallelscatter", "n" + storeNum.incrementAndGet());
             return new FileBasedScatterGatherBackingStore(tempFile);
         }
     }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ScatterZipOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ScatterZipOutputStream.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -186,7 +187,18 @@ public class ScatterZipOutputStream implements Closeable {
      * @throws FileNotFoundException if the file cannot be found
      */
     public static ScatterZipOutputStream fileBased(final File file) throws FileNotFoundException {
-        return fileBased(file, Deflater.DEFAULT_COMPRESSION);
+        return pathBased(file.toPath(), Deflater.DEFAULT_COMPRESSION);
+    }
+
+    /**
+     * Create a {@link ScatterZipOutputStream} with default compression level that is backed by a file
+     * @param path The path to offload compressed data into.
+     * @return A ScatterZipOutputStream that is ready for use.
+     * @throws FileNotFoundException if the path cannot be found
+     * @since 1.22
+     */
+    public static ScatterZipOutputStream pathBased(final Path path) throws FileNotFoundException {
+        return pathBased(path, Deflater.DEFAULT_COMPRESSION);
     }
 
     /**
@@ -198,7 +210,19 @@ public class ScatterZipOutputStream implements Closeable {
      * @throws FileNotFoundException if the file cannot be found
      */
     public static ScatterZipOutputStream fileBased(final File file, final int compressionLevel) throws FileNotFoundException {
-        final ScatterGatherBackingStore bs = new FileBasedScatterGatherBackingStore(file);
+        return pathBased(file.toPath(), compressionLevel);
+    }
+
+    /**
+     * Create a {@link ScatterZipOutputStream} that is backed by a file
+     * @param path The path to offload compressed data into.
+     * @param compressionLevel The compression level to use, @see #Deflater
+     * @return A ScatterZipOutputStream that is ready for use.
+     * @throws FileNotFoundException if the path cannot be found
+     * @since 1.22
+     */
+    public static ScatterZipOutputStream pathBased(final Path path, final int compressionLevel) throws FileNotFoundException {
+        final ScatterGatherBackingStore bs = new FileBasedScatterGatherBackingStore(path);
         // lifecycle is bound to the ScatterZipOutputStream returned
         final StreamCompressor sc = StreamCompressor.create(compressionLevel, bs); //NOSONAR
         return new ScatterZipOutputStream(bs, sc);

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitOutputStream.java
@@ -23,6 +23,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
 
 /**
  * Used internally by {@link ZipArchiveOutputStream} when creating a split archive.
@@ -31,7 +34,7 @@ import java.nio.file.Files;
  */
 class ZipSplitOutputStream extends OutputStream {
     private OutputStream outputStream;
-    private File zipFile;
+    private Path zipFile;
     private final long splitSize;
     private int currentSplitSegmentIndex;
     private long currentSplitSegmentBytesWritten;
@@ -53,19 +56,28 @@ class ZipSplitOutputStream extends OutputStream {
      * Create a split zip. If the zip file is smaller than the split size,
      * then there will only be one split zip, and its suffix is .zip,
      * otherwise the split segments should be like .z01, .z02, ... .z(N-1), .zip
-     *
      * @param zipFile   the zip file to write to
      * @param splitSize the split size
      */
     public ZipSplitOutputStream(final File zipFile, final long splitSize) throws IllegalArgumentException, IOException {
+        this(zipFile.toPath(), splitSize);
+    }
+
+    /**
+     * Create a split zip. If the zip file is smaller than the split size,
+     * then there will only be one split zip, and its suffix is .zip,
+     * otherwise the split segments should be like .z01, .z02, ... .z(N-1), .zip
+     * @param zipFile   the path to zip file to write to
+     * @param splitSize the split size
+     * @since 1.22
+     */
+    public ZipSplitOutputStream(final Path zipFile, final long splitSize) throws IllegalArgumentException, IOException {
         if (splitSize < ZIP_SEGMENT_MIN_SIZE || splitSize > ZIP_SEGMENT_MAX_SIZE) {
             throw new IllegalArgumentException("zip split segment size should between 64K and 4,294,967,295");
         }
-
         this.zipFile = zipFile;
         this.splitSize = splitSize;
-
-        this.outputStream = Files.newOutputStream(zipFile.toPath());
+        this.outputStream = Files.newOutputStream(zipFile);
         // write the zip split signature 0x08074B50 to the zip file
         writeZipSplitSignature();
     }
@@ -149,12 +161,9 @@ class ZipSplitOutputStream extends OutputStream {
             throw new IOException("This archive has already been finished");
         }
 
-        final String zipFileBaseName = FileNameUtils.getBaseName(zipFile.getName());
-        final File lastZipSplitSegmentFile = new File(zipFile.getParentFile(), zipFileBaseName + ".zip");
+        final String zipFileBaseName = FileNameUtils.getBaseName(zipFile.getFileName().toString());
         outputStream.close();
-        if (!zipFile.renameTo(lastZipSplitSegmentFile)) {
-            throw new IOException("Failed to rename " + zipFile + " to " + lastZipSplitSegmentFile);
-        }
+        Files.move(zipFile, zipFile.resolveSibling(zipFileBaseName + ".zip"), StandardCopyOption.ATOMIC_MOVE);
         finished = true;
     }
 
@@ -164,19 +173,17 @@ class ZipSplitOutputStream extends OutputStream {
      * @throws IOException
      */
     private void openNewSplitSegment() throws IOException {
-        File newFile;
+        Path newFile;
         if (currentSplitSegmentIndex == 0) {
             outputStream.close();
             newFile = createNewSplitSegmentFile(1);
-            if (!zipFile.renameTo(newFile)) {
-                throw new IOException("Failed to rename " + zipFile + " to " + newFile);
-            }
+            Files.move(zipFile, newFile, StandardCopyOption.ATOMIC_MOVE);
         }
 
         newFile = createNewSplitSegmentFile(null);
 
         outputStream.close();
-        outputStream = Files.newOutputStream(newFile.toPath());
+        outputStream = Files.newOutputStream(newFile);
         currentSplitSegmentBytesWritten = 0;
         zipFile = newFile;
         currentSplitSegmentIndex++;
@@ -215,9 +222,9 @@ class ZipSplitOutputStream extends OutputStream {
      * @return
      * @throws IOException
      */
-    private File createNewSplitSegmentFile(final Integer zipSplitSegmentSuffixIndex) throws IOException {
+    private Path createNewSplitSegmentFile(final Integer zipSplitSegmentSuffixIndex) throws IOException {
         final int newZipSplitSegmentSuffixIndex = zipSplitSegmentSuffixIndex == null ? (currentSplitSegmentIndex + 2) : zipSplitSegmentSuffixIndex;
-        final String baseName = FileNameUtils.getBaseName(zipFile.getName());
+        final String baseName = FileNameUtils.getBaseNameFrom(zipFile);
         String extension = ".z";
         if (newZipSplitSegmentSuffixIndex <= 9) {
             extension += "0" + newZipSplitSegmentSuffixIndex;
@@ -225,9 +232,10 @@ class ZipSplitOutputStream extends OutputStream {
             extension += newZipSplitSegmentSuffixIndex;
         }
 
-        final File newFile = new File(zipFile.getParent(), baseName + extension);
+        String dir = Objects.nonNull(zipFile.getParent()) ? zipFile.getParent().toAbsolutePath().toString() : ".";
+        final Path newFile = zipFile.getFileSystem().getPath(dir, baseName + extension);
 
-        if (newFile.exists()) {
+        if (Files.exists(newFile)) {
             throw new IOException("split zip segment " + baseName + extension + " already exists");
         }
         return newFile;

--- a/src/main/java/org/apache/commons/compress/utils/FileNameUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/FileNameUtils.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.utils;
 
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Generic file name utilities.
@@ -51,6 +52,29 @@ public class FileNameUtils {
     }
 
     /**
+     * Returns the extension (i.e. the part after the last ".") of a file.
+     * <p>Will return an empty string if the file name doesn't contain
+     * any dots. Only the last segment of a the file name is consulted
+     * - i.e. all leading directories of the {@code filename}
+     * parameter are skipped.</p>
+     * @return the extension of filename
+     * @param path the path of the file to obtain the extension of.
+     * @since 1.22
+     */
+    public static String getExtensionFrom(final Path path) {
+        if (path == null) {
+            return null;
+        }
+
+        final String name = path.getFileName().toString();
+        final int extensionPosition = name.lastIndexOf('.');
+        if (extensionPosition <= 0 || extensionPosition == name.length() - 1) {
+            return "";
+        }
+        return name.substring(extensionPosition + 1);
+    }
+
+    /**
      * Returns the basename (i.e. the part up to and not including the
      * last ".") of the last path segment of a filename.
      *
@@ -67,6 +91,31 @@ public class FileNameUtils {
         }
 
         final String name = new File(filename).getName();
+
+        final int extensionPosition = name.lastIndexOf('.');
+        if (extensionPosition < 0) {
+            return name;
+        }
+
+        return name.substring(0, extensionPosition);
+    }
+
+    /**
+     * Returns the basename (i.e. the part up to and not including the
+     * last ".") of the last path segment of a filename.
+     * <p>Will return the file name itself if it doesn't contain any
+     * dots. All leading directories of the {@code filename} parameter
+     * are skipped.</p>
+     * @return the basename of filename
+     * @param path the path of the file to obtain the basename of.
+     * @since 1.22
+     */
+    public static String getBaseNameFrom(final Path path) {
+        if (path == null) {
+            return null;
+        }
+
+        final String name = path.getFileName().toString();
 
         final int extensionPosition = name.lastIndexOf('.');
         if (extensionPosition < 0) {

--- a/src/main/java/org/apache/commons/compress/utils/MultiReadOnlySeekableByteChannel.java
+++ b/src/main/java/org/apache/commons/compress/utils/MultiReadOnlySeekableByteChannel.java
@@ -25,6 +25,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonWritableChannelException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -241,9 +242,29 @@ public class MultiReadOnlySeekableByteChannel implements SeekableByteChannel {
      * @return SeekableByteChannel that concatenates all provided files
      */
     public static SeekableByteChannel forFiles(final File... files) throws IOException {
-        final List<SeekableByteChannel> channels = new ArrayList<>();
+        final List<Path> paths = new ArrayList<>();
         for (final File f : Objects.requireNonNull(files, "files must not be null")) {
-            channels.add(Files.newByteChannel(f.toPath(), StandardOpenOption.READ));
+            paths.add(f.toPath());
+        }
+
+        return forPaths(paths.toArray(new Path[0]));
+    }
+
+    /**
+     * Concatenates the given file paths.
+     * @param paths the file paths to concatenate, note that the LAST FILE of files should be the LAST SEGMENT(.zip)
+     * and these files should be added in correct order (e.g.: .z01, .z02... .z99, .zip)
+     * @return SeekableByteChannel that concatenates all provided files
+     * @throws NullPointerException if files is null
+     * @throws IOException if opening a channel for one of the files fails
+     * @throws IOException if the first channel doesn't seem to hold
+     * the beginning of a split archive
+     * @since 1.22
+     */
+    public static SeekableByteChannel forPaths(final Path... paths) throws IOException {
+        final List<SeekableByteChannel> channels = new ArrayList<>();
+        for (final Path path : Objects.requireNonNull(paths, "paths must not be null")) {
+            channels.add(Files.newByteChannel(path, StandardOpenOption.READ));
         }
         if (channels.size() == 1) {
             return channels.get(0);

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipMemoryFileSystemTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipMemoryFileSystemTest.java
@@ -1,0 +1,503 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.commons.compress.archivers.zip;
+
+import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.apache.commons.compress.parallel.InputStreamSupplier;
+import org.apache.commons.compress.utils.IOUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.Deflater;
+import java.util.zip.ZipEntry;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.compress.AbstractTestCase.getPath;
+import static org.apache.commons.compress.archivers.zip.ZipArchiveEntryRequest.createZipArchiveEntryRequest;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+
+public class ZipMemoryFileSystemTest {
+    private Path dir;
+
+    @Before
+    public void setup() throws IOException {
+        dir = Files.createTempDirectory(UUID.randomUUID().toString());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder())
+                    .peek(path -> System.out.println("Deleting: " + path.toAbsolutePath()))
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException ignore) {
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void zipFromMemoryFileSystemOutputStream() throws IOException, ArchiveException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path p = fileSystem.getPath("test.txt");
+            Files.write(p, "Test".getBytes(UTF_8));
+
+            final Path f = Files.createTempFile(dir, "commons-compress-memoryfs", ".zip");
+            try (final OutputStream out = Files.newOutputStream(f);
+                 final ArchiveOutputStream zipOut = ArchiveStreamFactory.DEFAULT.createArchiveOutputStream(ArchiveStreamFactory.ZIP, out)) {
+                final ZipArchiveEntry entry = new ZipArchiveEntry(p, p.getFileName().toString());
+                entry.setSize(Files.size(p));
+                zipOut.putArchiveEntry(entry);
+
+                Files.copy(p, zipOut);
+                zipOut.closeArchiveEntry();
+                assertEquals(Files.size(f), zipOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void zipFromMemoryFileSystemSplitFile() throws IOException, NoSuchAlgorithmException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path textFileInMemSys = fileSystem.getPath("test.txt");
+            byte[] bytes = new byte[100 * 1024];
+            SecureRandom.getInstanceStrong().nextBytes(bytes);
+            Files.write(textFileInMemSys, bytes);
+
+            final Path zipInLocalSys = Files.createTempFile(dir, "commons-compress-memoryfs", ".zip");
+            try (final ArchiveOutputStream zipOut = new ZipArchiveOutputStream(zipInLocalSys.toFile(), 64 * 1024L)) {
+                final ZipArchiveEntry entry = new ZipArchiveEntry(textFileInMemSys, textFileInMemSys.getFileName().toString());
+                entry.setSize(Files.size(textFileInMemSys));
+                zipOut.putArchiveEntry(entry);
+
+                Files.copy(textFileInMemSys, zipOut);
+                zipOut.closeArchiveEntry();
+                zipOut.finish();
+                List<Path> splitZips;
+                try (Stream<Path> paths = Files.walk(dir, 1)) {
+                    splitZips = paths
+                            .filter(Files::isRegularFile)
+                            .peek(path -> System.out.println("Found: " + path.toAbsolutePath()))
+                            .collect(Collectors.toList());
+                }
+                assertEquals(splitZips.size(), 2);
+                assertEquals(Files.size(splitZips.get(0)) +
+                        Files.size(splitZips.get(1)) - 4, zipOut.getBytesWritten());
+            }
+        }
+
+    }
+
+    @Test
+    public void zipFromMemoryFileSystemFile() throws IOException, NoSuchAlgorithmException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path textFileInMemSys = fileSystem.getPath("test.txt");
+            byte[] bytes = new byte[100 * 1024];
+            SecureRandom.getInstanceStrong().nextBytes(bytes);
+            Files.write(textFileInMemSys, bytes);
+
+            final Path zipInLocalSys = Files.createTempFile(dir, "commons-compress-memoryfs", ".zip");
+            try (final ArchiveOutputStream zipOut = new ZipArchiveOutputStream(zipInLocalSys.toFile())) {
+                final ZipArchiveEntry entry = new ZipArchiveEntry(textFileInMemSys, textFileInMemSys.getFileName().toString());
+                entry.setSize(Files.size(textFileInMemSys));
+                zipOut.putArchiveEntry(entry);
+
+                Files.copy(textFileInMemSys, zipOut);
+                zipOut.closeArchiveEntry();
+                zipOut.finish();
+                assertEquals(Files.size(zipInLocalSys), zipOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void zipFromMemoryFileSystemPath() throws IOException, NoSuchAlgorithmException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path textFileInMemSys = fileSystem.getPath("test.txt");
+            byte[] bytes = new byte[100 * 1024];
+            SecureRandom.getInstanceStrong().nextBytes(bytes);
+            Files.write(textFileInMemSys, bytes);
+
+            final Path zipInLocalSys = Files.createTempFile(dir, "commons-compress-memoryfs", ".zip");
+            try (final ArchiveOutputStream zipOut = new ZipArchiveOutputStream(zipInLocalSys)) {
+                final ZipArchiveEntry entry = new ZipArchiveEntry(textFileInMemSys, textFileInMemSys.getFileName().toString());
+                entry.setSize(Files.size(textFileInMemSys));
+                zipOut.putArchiveEntry(entry);
+
+                Files.copy(textFileInMemSys, zipOut);
+                zipOut.closeArchiveEntry();
+                zipOut.finish();
+                assertEquals(Files.size(zipInLocalSys), zipOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void zipFromMemoryFileSystemSeekableByteChannel() throws IOException, NoSuchAlgorithmException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path textFileInMemSys = fileSystem.getPath("test.txt");
+            byte[] bytes = new byte[100 * 1024];
+            SecureRandom.getInstanceStrong().nextBytes(bytes);
+            Files.write(textFileInMemSys, bytes);
+
+            final Path zipInLocalSys = Files.createTempFile(dir, "commons-compress-memoryfs", ".zip");
+            try (final SeekableByteChannel byteChannel = Files.newByteChannel(zipInLocalSys,
+                    EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING));
+                 final ArchiveOutputStream zipOut = new ZipArchiveOutputStream(byteChannel)) {
+                final ZipArchiveEntry entry = new ZipArchiveEntry(textFileInMemSys, textFileInMemSys.getFileName().toString());
+                entry.setSize(Files.size(textFileInMemSys));
+                zipOut.putArchiveEntry(entry);
+
+                Files.copy(textFileInMemSys, zipOut);
+                zipOut.closeArchiveEntry();
+                zipOut.finish();
+                assertEquals(Files.size(zipInLocalSys), zipOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void zipToMemoryFileSystemOutputStream() throws IOException, ArchiveException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path p = fileSystem.getPath("target.zip");
+
+            try (final OutputStream out = Files.newOutputStream(p);
+                 final ArchiveOutputStream zipOut = ArchiveStreamFactory.DEFAULT.createArchiveOutputStream(ArchiveStreamFactory.ZIP, out)) {
+                final String content = "Test";
+                final ZipArchiveEntry entry = new ZipArchiveEntry("test.txt");
+                entry.setSize(content.length());
+                zipOut.putArchiveEntry(entry);
+
+                zipOut.write("Test".getBytes(UTF_8));
+                zipOut.closeArchiveEntry();
+
+                assertTrue(Files.exists(p));
+                assertEquals(Files.size(p), zipOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void zipToMemoryFileSystemPath() throws IOException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path zipInMemSys = fileSystem.getPath("target.zip");
+
+            try (final ArchiveOutputStream zipOut = new ZipArchiveOutputStream(zipInMemSys)) {
+                final String content = "Test";
+                final ZipArchiveEntry entry = new ZipArchiveEntry("test.txt");
+                entry.setSize(content.length());
+                zipOut.putArchiveEntry(entry);
+
+                zipOut.write("Test".getBytes(UTF_8));
+                zipOut.closeArchiveEntry();
+
+                assertTrue(Files.exists(zipInMemSys));
+                assertEquals(Files.size(zipInMemSys), zipOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void zipToMemoryFileSystemSeekableByteChannel() throws IOException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path zipInMemSys = fileSystem.getPath("target.zip");
+
+            try (final SeekableByteChannel byteChannel = Files.newByteChannel(zipInMemSys,
+                    EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE,
+                            StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE_NEW));
+                 final ArchiveOutputStream zipOut = new ZipArchiveOutputStream(byteChannel)) {
+                final String content = "Test";
+                final ZipArchiveEntry entry = new ZipArchiveEntry("test.txt");
+                entry.setSize(content.length());
+                zipOut.putArchiveEntry(entry);
+
+                zipOut.write("Test".getBytes(UTF_8));
+                zipOut.closeArchiveEntry();
+
+                assertTrue(Files.exists(zipInMemSys));
+                assertEquals(Files.size(zipInMemSys), zipOut.getBytesWritten());
+            }
+        }
+    }
+
+    @Test
+    public void zipToMemoryFileSystemSplitPath() throws IOException, NoSuchAlgorithmException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            final Path zipInMemSys = fileSystem.getPath("target.zip");
+            byte[] bytes = new byte[100 * 1024];
+            SecureRandom.getInstanceStrong().nextBytes(bytes);
+
+            try (final ArchiveOutputStream zipOut = new ZipArchiveOutputStream(zipInMemSys, 64 * 1024L)) {
+                final ZipArchiveEntry entry = new ZipArchiveEntry("test.txt");
+                entry.setSize(bytes.length);
+                zipOut.putArchiveEntry(entry);
+
+                zipOut.write(bytes);
+
+                zipOut.closeArchiveEntry();
+                zipOut.finish();
+
+                List<Path> splitZips;
+                try (Stream<Path> paths = Files.walk(fileSystem.getPath("."), 1)) {
+                    splitZips = paths
+                            .filter(Files::isRegularFile)
+                            .peek(path -> System.out.println("Found: " + path.toAbsolutePath()))
+                            .collect(Collectors.toList());
+                }
+                assertEquals(splitZips.size(), 2);
+                assertEquals(Files.size(splitZips.get(0)) +
+                        Files.size(splitZips.get(1)) - 4, zipOut.getBytesWritten());
+            }
+        }
+
+    }
+
+    @Test
+    public void scatterFileInMemory() throws IOException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Path scatterFile = fileSystem.getPath("scattertest.notzip");
+            final ScatterZipOutputStream scatterZipOutputStream = ScatterZipOutputStream.pathBased(scatterFile);
+            final byte[] B_PAYLOAD = "RBBBBBBS".getBytes();
+            final byte[] A_PAYLOAD = "XAAY".getBytes();
+
+            final ZipArchiveEntry zab = new ZipArchiveEntry("b.txt");
+            zab.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload = new ByteArrayInputStream(B_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zab, createPayloadSupplier(payload)));
+
+            final ZipArchiveEntry zae = new ZipArchiveEntry("a.txt");
+            zae.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload1 = new ByteArrayInputStream(A_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zae, createPayloadSupplier(payload1)));
+
+            Path target = Files.createTempFile(dir, "scattertest", ".zip");
+            final ZipArchiveOutputStream outputStream = new ZipArchiveOutputStream(target);
+            scatterZipOutputStream.writeTo(outputStream);
+            outputStream.close();
+            scatterZipOutputStream.close();
+
+            final ZipFile zf = new ZipFile(target.toFile());
+            final ZipArchiveEntry b_entry = zf.getEntries("b.txt").iterator().next();
+            assertEquals(8, b_entry.getSize());
+            assertArrayEquals(B_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(b_entry)));
+
+            final ZipArchiveEntry a_entry = zf.getEntries("a.txt").iterator().next();
+            assertEquals(4, a_entry.getSize());
+            assertArrayEquals(A_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(a_entry)));
+            zf.close();
+        }
+
+    }
+
+    @Test
+    public void scatterFileWithCompressionInMemory() throws IOException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Path scatterFile = fileSystem.getPath("scattertest.notzip");
+            final ScatterZipOutputStream scatterZipOutputStream = ScatterZipOutputStream.pathBased(scatterFile,
+                    Deflater.BEST_COMPRESSION);
+            final byte[] B_PAYLOAD = "RBBBBBBS".getBytes();
+            final byte[] A_PAYLOAD = "XAAY".getBytes();
+
+            final ZipArchiveEntry zab = new ZipArchiveEntry("b.txt");
+            zab.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload = new ByteArrayInputStream(B_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zab, createPayloadSupplier(payload)));
+
+            final ZipArchiveEntry zae = new ZipArchiveEntry("a.txt");
+            zae.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload1 = new ByteArrayInputStream(A_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zae, createPayloadSupplier(payload1)));
+
+            Path target = Files.createTempFile(dir, "scattertest", ".zip");
+            final ZipArchiveOutputStream outputStream = new ZipArchiveOutputStream(target);
+            scatterZipOutputStream.writeTo(outputStream);
+            outputStream.close();
+            scatterZipOutputStream.close();
+
+            final ZipFile zf = new ZipFile(target.toFile());
+            final ZipArchiveEntry b_entry = zf.getEntries("b.txt").iterator().next();
+            assertEquals(8, b_entry.getSize());
+            assertArrayEquals(B_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(b_entry)));
+
+            final ZipArchiveEntry a_entry = zf.getEntries("a.txt").iterator().next();
+            assertEquals(4, a_entry.getSize());
+            assertArrayEquals(A_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(a_entry)));
+            zf.close();
+        }
+
+    }
+
+    @Test
+    public void scatterFileWithCompressionAndTargetInMemory() throws IOException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Path scatterFile = fileSystem.getPath("scattertest.notzip");
+            final ScatterZipOutputStream scatterZipOutputStream = ScatterZipOutputStream.pathBased(scatterFile,
+                    Deflater.BEST_COMPRESSION);
+            final byte[] B_PAYLOAD = "RBBBBBBS".getBytes();
+            final byte[] A_PAYLOAD = "XAAY".getBytes();
+
+            final ZipArchiveEntry zab = new ZipArchiveEntry("b.txt");
+            zab.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload = new ByteArrayInputStream(B_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zab, createPayloadSupplier(payload)));
+
+            final ZipArchiveEntry zae = new ZipArchiveEntry("a.txt");
+            zae.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload1 = new ByteArrayInputStream(A_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zae, createPayloadSupplier(payload1)));
+
+            Path target = fileSystem.getPath("scattertest.zip");
+            final ZipArchiveOutputStream outputStream = new ZipArchiveOutputStream(target);
+            scatterZipOutputStream.writeTo(outputStream);
+            outputStream.close();
+            scatterZipOutputStream.close();
+
+            try (final ZipFile zf = new ZipFile(Files.newByteChannel(target, StandardOpenOption.READ),
+                    target.getFileName().toString(), ZipEncodingHelper.UTF8, true)) {
+                final ZipArchiveEntry b_entry = zf.getEntries("b.txt").iterator().next();
+                assertEquals(8, b_entry.getSize());
+                assertArrayEquals(B_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(b_entry)));
+
+                final ZipArchiveEntry a_entry = zf.getEntries("a.txt").iterator().next();
+                assertEquals(4, a_entry.getSize());
+                assertArrayEquals(A_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(a_entry)));
+            }
+        }
+    }
+
+    @Test
+    public void zipFileInMemory() throws IOException {
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Path scatterFile = fileSystem.getPath("scattertest.notzip");
+            final ScatterZipOutputStream scatterZipOutputStream = ScatterZipOutputStream.pathBased(scatterFile,
+                    Deflater.BEST_COMPRESSION);
+            final byte[] B_PAYLOAD = "RBBBBBBS".getBytes();
+            final byte[] A_PAYLOAD = "XAAY".getBytes();
+
+            final ZipArchiveEntry zab = new ZipArchiveEntry("b.txt");
+            zab.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload = new ByteArrayInputStream(B_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zab, createPayloadSupplier(payload)));
+
+            final ZipArchiveEntry zae = new ZipArchiveEntry("a.txt");
+            zae.setMethod(ZipEntry.DEFLATED);
+            final ByteArrayInputStream payload1 = new ByteArrayInputStream(A_PAYLOAD);
+            scatterZipOutputStream.addArchiveEntry(createZipArchiveEntryRequest(zae, createPayloadSupplier(payload1)));
+
+            Path target = fileSystem.getPath("scattertest.zip");
+            final ZipArchiveOutputStream outputStream = new ZipArchiveOutputStream(target);
+            scatterZipOutputStream.writeTo(outputStream);
+            outputStream.close();
+            scatterZipOutputStream.close();
+
+            try (final ZipFile zf = new ZipFile(target)) {
+                final ZipArchiveEntry b_entry = zf.getEntries("b.txt").iterator().next();
+                assertEquals(8, b_entry.getSize());
+                assertArrayEquals(B_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(b_entry)));
+
+                final ZipArchiveEntry a_entry = zf.getEntries("a.txt").iterator().next();
+                assertEquals(4, a_entry.getSize());
+                assertArrayEquals(A_PAYLOAD, IOUtils.toByteArray(zf.getInputStream(a_entry)));
+            }
+        }
+    }
+
+    private InputStreamSupplier createPayloadSupplier(final ByteArrayInputStream payload) {
+        return () -> payload;
+    }
+
+    @Test
+    public void forPathsReturnCorrectClassInMemory() throws IOException {
+        final Path firstFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z01");
+        final Path secondFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z02");
+        final Path lastFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.zip");
+        byte[] firstBytes = Files.readAllBytes(firstFile);
+        byte[] secondBytes = Files.readAllBytes(secondFile);
+        byte[] lastBytes = Files.readAllBytes(lastFile);
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Files.write(fileSystem.getPath("split_zip_created_by_zip.z01"), firstBytes);
+            Files.write(fileSystem.getPath("split_zip_created_by_zip.z02"), secondBytes);
+            Files.write(fileSystem.getPath("split_zip_created_by_zip.zip"), lastBytes);
+            final ArrayList<Path> list = new ArrayList<>();
+            list.add(firstFile);
+            list.add(secondFile);
+
+            SeekableByteChannel channel = ZipSplitReadOnlySeekableByteChannel.forPaths(lastFile, list);
+            Assert.assertTrue(channel instanceof ZipSplitReadOnlySeekableByteChannel);
+
+            channel = ZipSplitReadOnlySeekableByteChannel.forPaths(firstFile, secondFile, lastFile);
+            Assert.assertTrue(channel instanceof ZipSplitReadOnlySeekableByteChannel);
+        }
+    }
+
+    @Test
+    public void positionToSomeZipSplitSegmentInMemory() throws IOException {
+        final Path firstFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z01");
+        final Path secondFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z02");
+        final Path lastFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.zip");
+        byte[] firstBytes = Files.readAllBytes(firstFile);
+        byte[] secondBytes = Files.readAllBytes(secondFile);
+        byte[] lastBytes = Files.readAllBytes(lastFile);
+        final int firstFileSize = firstBytes.length;
+        final int secondFileSize = secondBytes.length;
+        final int lastFileSize = lastBytes.length;
+
+        try (FileSystem fileSystem = MemoryFileSystemBuilder.newLinux().build()) {
+            Path lastMemoryPath = fileSystem.getPath("split_zip_created_by_zip.zip");
+            Files.write(fileSystem.getPath("split_zip_created_by_zip.z01"), firstBytes);
+            Files.write(fileSystem.getPath("split_zip_created_by_zip.z02"), secondBytes);
+            Files.write(lastMemoryPath, lastBytes);
+            final Random random = new Random();
+            final int randomDiskNumber = random.nextInt(3);
+            final int randomOffset = randomDiskNumber < 2 ? random.nextInt(firstFileSize) : random.nextInt(lastFileSize);
+
+            final ZipSplitReadOnlySeekableByteChannel channel = (ZipSplitReadOnlySeekableByteChannel)
+                    ZipSplitReadOnlySeekableByteChannel.buildFromLastSplitSegment(lastMemoryPath);
+            channel.position(randomDiskNumber, randomOffset);
+            long expectedPosition = randomOffset;
+
+            expectedPosition += randomDiskNumber > 0 ? firstFileSize : 0;
+            expectedPosition += randomDiskNumber > 1 ? secondFileSize : 0;
+
+            Assert.assertEquals(expectedPosition, channel.position());
+        }
+
+    }
+}

--- a/src/test/java/org/apache/commons/compress/utils/ZipSplitReadOnlySeekableByteChannelTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ZipSplitReadOnlySeekableByteChannelTest.java
@@ -28,12 +28,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import static org.apache.commons.compress.AbstractTestCase.getFile;
+import static org.apache.commons.compress.AbstractTestCase.getPath;
 
 public class ZipSplitReadOnlySeekableByteChannelTest {
     @Rule
@@ -177,5 +179,32 @@ public class ZipSplitReadOnlySeekableByteChannelTest {
         channels.add(Files.newByteChannel(lastFile.toPath(), StandardOpenOption.READ));
 
         return channels;
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void forPathsThrowsOnNullArg() throws IOException {
+        ZipSplitReadOnlySeekableByteChannel.forPaths(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void forPathsOfTwoParametersThrowsOnNullArg() throws IOException {
+        ZipSplitReadOnlySeekableByteChannel.forPaths(null, null);
+    }
+
+    @Test
+    public void forPathsReturnCorrectClass() throws IOException {
+        final Path firstFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z01");
+        final Path secondFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z02");
+        final Path lastFile = getPath("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.zip");
+
+        final ArrayList<Path> list = new ArrayList<>();
+        list.add(firstFile);
+        list.add(secondFile);
+
+        SeekableByteChannel channel = ZipSplitReadOnlySeekableByteChannel.forPaths(lastFile, list);
+        Assert.assertTrue(channel instanceof ZipSplitReadOnlySeekableByteChannel);
+
+        channel = ZipSplitReadOnlySeekableByteChannel.forPaths(firstFile, secondFile, lastFile);
+        Assert.assertTrue(channel instanceof ZipSplitReadOnlySeekableByteChannel);
     }
 }


### PR DESCRIPTION
Implementation of: https://issues.apache.org/jira/browse/COMPRESS-602
This is a continuation of the story to Use java.nio.file.Path instead of java.io.File throughout commons-compress project.
I would like to highlight that these 2 constructors to be marked as deprecated or prepared for removal because we cannot know what the FileSystem of the caller is and we could only create in the default one.

```java
    public ZipFile(final String name) throws IOException {
        this(new File(name).toPath(), ZipEncodingHelper.UTF8);
    }


    public ZipFile(final String name, final String encoding) throws IOException {
        this(new File(name).toPath(), encoding, true);
    }
```