### PR TITLE
bzip2: calculate median-of-3 on unsigned values

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/bzip2/BlockSort.java
+++ b/src/main/java/org/apache/commons/compress/compressors/bzip2/BlockSort.java
@@ -790,7 +790,7 @@ class BlockSort {
         }
     }
 
-    private static byte med3(final byte a, final byte b, final byte c) {
+    private static int med3(final int a, final int b, final int c) {
         return (a < b) ? (b < c ? b : a < c ? c : a) : (b > c ? b : a > c ? c
                                                         : a);
     }
@@ -826,8 +826,9 @@ class BlockSort {
                 }
             } else {
                 final int d1 = d + 1;
-                final int med = med3(block[fmap[lo] + d1],
-                                     block[fmap[hi] + d1], block[fmap[(lo + hi) >>> 1] + d1]) & 0xff;
+                final int med = med3(block[fmap[lo] + d1] & 0xff,
+                                     block[fmap[hi] + d1] & 0xff,
+                                     block[fmap[(lo + hi) >>> 1] + d1] & 0xff);
 
                 int unLo = lo;
                 int unHi = hi;


### PR DESCRIPTION
The existing `BlockSort#med3`  function is comparing byte values, which are signed. This seems off to me, since the main calling loop appears to be handling these bytes as (non-negative) 8-bit ints. Also the original C code appears to use unsigned char values (e.g. https://github.com/centricular/bzip2/blob/35e7280360320787d09a2419e0f5a1863feb8a34/blocksort.c#L583).

This PR changes `BlockSort#med3` to accept int arguments and the caller to pass non-negative 8-bit values. I'm not really familiar enough with bzip2 to judge the impact, or to select a sample input for which this might matter. Hopefully someone more knowledgeable can weigh in.
