### PR TITLE
Fix thread safety issues when encoding 7z password

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
@@ -30,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.charset.CharsetEncoder;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -2056,13 +2055,11 @@ public class SevenZFile implements Closeable {
         return lastSegment + "~";
     }
 
-    private static final CharsetEncoder PASSWORD_ENCODER = UTF_16LE.newEncoder();
-
     private static byte[] utf16Decode(final char[] chars) throws IOException {
         if (chars == null) {
             return null;
         }
-        final ByteBuffer encoded = PASSWORD_ENCODER.encode(CharBuffer.wrap(chars));
+        final ByteBuffer encoded = UTF_16LE.encode(CharBuffer.wrap(chars));
         if (encoded.hasArray()) {
             return encoded.array();
         }


### PR DESCRIPTION
`CharsetEncoder` is not thread safe. Due to shared `PASSWORD_ENCODER`, problems may occur when encoding 7z file passwords in parallel. The UTF-16LE encoder rarely changes the state, so problems are rare, but the problem is real: When processing unicode surrogate pairs, the Encoder needs to store the state internally.

`Charset.encode` will cache a thread local encoder, so it is reasonable to use it directly.