### PR TITLE
COMPRESS-604: Ensure compatibility with Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ Apache Commons Compress
 [![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-compress/1.21.svg)](https://javadoc.io/doc/org.apache.commons/commons-compress/1.21)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/apache-commons.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:apache-commons)
 
-**Note: Commons Compress currently doesn't build on JDK 14+, we will
-address this before releasing Compress 1.21**.
-
 Apache Commons Compress software defines an API for working with
 compression and archive formats.  These include: bzip2, gzip, pack200,
 lzma, xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,

--- a/pom.xml
+++ b/pom.xml
@@ -621,7 +621,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
         <jdk>[9,)</jdk>
       </activation>
       <properties>
-        <maven.compiler.release>9</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
         <animal.sniffer.skip>true</animal.sniffer.skip>
         <!-- coverall version 4.3.0 does not work with java 9, see https://github.com/trautonen/coveralls-maven-plugin/issues/112 -->
         <coveralls.skip>true</coveralls.skip>


### PR DESCRIPTION
COMPRESS-604 might be related to this.
I wasn't able to reproduce it, but I can confirm the build is currently not compatible with Java 8 when building on Java 9+ because the --release compiler option is set to 9, but not because of the reason pointed in COMPRESS-604.

Let me know if that doesn't work for some reason.

The build seems to work fine on JDK 17, so I removed the message about it not working on JDK 14+ from the README.