### PR TITLE
COMPRESS-623: Speed up ZipFile's raw stream copying by not seeking for local headers until they're needed

### DIFF
--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileIgnoringLocalFileHeaderTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileIgnoringLocalFileHeaderTest.java
@@ -83,10 +83,10 @@ public class ZipFileIgnoringLocalFileHeaderTest {
     }
 
     @Test
-    public void getRawInputStreamReturnsNull() throws IOException {
+    public void getRawInputStreamReturnsNotNull() throws IOException {
         try (final ZipFile zf = openZipWithoutLFH("bla.zip")) {
             final ZipArchiveEntry ze = zf.getEntry("test1.xml");
-            Assert.assertNull(zf.getRawInputStream(ze));
+            Assert.assertNotNull(zf.getRawInputStream(ze));
         }
     }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/COMPRESS-623