### PR TITLE
Replace JUnit 3 with JUnit 5

### DIFF
--- a/src/test/java/org/apache/commons/compress/archivers/LongPathTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/LongPathTest.java
@@ -41,8 +41,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import junit.framework.AssertionFailedError;
-
 /**
  * Test that can read various tar file examples.
  *
@@ -142,7 +140,7 @@ public class LongPathTest extends AbstractTestCase {
         }
         try {
             checkArchiveContent(ais, expected);
-        } catch (final AssertionFailedError e) {
+        } catch (final Exception e) {
             fail("Error processing "+file.getName()+" "+e);
         } finally {
             ais.close();

--- a/src/test/java/org/apache/commons/compress/archivers/LongPathTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/LongPathTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.compress.archivers;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -139,9 +140,7 @@ public class LongPathTest extends AbstractTestCase {
             fail("Unexpected file type: "+name);
         }
         try {
-            checkArchiveContent(ais, expected);
-        } catch (final Exception e) {
-            fail("Error processing "+file.getName()+" "+e);
+            assertDoesNotThrow(() -> checkArchiveContent(ais, expected), "Error processing " + file.getName());
         } finally {
             ais.close();
         }

--- a/src/test/java/org/apache/commons/compress/archivers/LongSymLinkTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/LongSymLinkTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.compress.archivers;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -140,9 +141,7 @@ public class LongSymLinkTest extends AbstractTestCase {
             fail("Unexpected file type: "+name);
         }
         try {
-            checkArchiveContent(ais, expected);
-        } catch (final Exception e) {
-            fail("Error processing "+file.getName()+" "+e);
+            assertDoesNotThrow(() -> checkArchiveContent(ais, expected), "Error processing " + file.getName());
         } finally {
             ais.close();
         }

--- a/src/test/java/org/apache/commons/compress/archivers/LongSymLinkTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/LongSymLinkTest.java
@@ -41,8 +41,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import junit.framework.AssertionFailedError;
-
 /**
  * Test that can read various tar file examples.
  *
@@ -143,7 +141,7 @@ public class LongSymLinkTest extends AbstractTestCase {
         }
         try {
             checkArchiveContent(ais, expected);
-        } catch (final AssertionFailedError e) {
+        } catch (final Exception e) {
             fail("Error processing "+file.getName()+" "+e);
         } finally {
             ais.close();

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/BHSDCodecTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/BHSDCodecTest.java
@@ -16,22 +16,31 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.apache.commons.compress.harmony.pack200.BHSDCodec;
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.CodecEncoding;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for BHSDCodec
  */
-public class BHSDCodecTest extends TestCase {
+public class BHSDCodecTest {
 
+    @Test
     public void testDeltaEncodings() throws IOException, Pack200Exception {
         Codec c = Codec.UDELTA5;
         int[] sequence = {0, 2, 4, 2, 2, 4};
@@ -42,43 +51,46 @@ public class BHSDCodecTest extends TestCase {
         }
     }
 
-    public void testEncodeDecode() throws IOException, Pack200Exception {
-        for (int i = 1; i < 116; i++) {
+    static Stream<Arguments> encodeDecodeRange() {
+        return IntStream.range(1, 116).mapToObj(Arguments::of);
+    }
 
-            BHSDCodec codec = (BHSDCodec) CodecEncoding.getCodec(i, null, null);
+    @ParameterizedTest
+    @MethodSource("encodeDecodeRange")
+    public void testEncodeDecode(final int i) throws IOException, Pack200Exception {
+        BHSDCodec codec = (BHSDCodec) CodecEncoding.getCodec(i, null, null);
 
-            if (!codec.isDelta()) {
-                // Test encode-decode with a selection of numbers within the
-                // range of the codec
-                long largest = codec.largest();
-                long smallest = codec.isSigned() ? codec.smallest() : 0;
-                if(smallest < Integer.MIN_VALUE) {
-                    smallest = Integer.MIN_VALUE;
+        if (!codec.isDelta()) {
+            // Test encode-decode with a selection of numbers within the
+            // range of the codec
+            long largest = codec.largest();
+            long smallest = codec.isSigned() ? codec.smallest() : 0;
+            if (smallest < Integer.MIN_VALUE) {
+                smallest = Integer.MIN_VALUE;
+            }
+            long difference = (largest - smallest) / 4;
+            for (long j = smallest; j <= largest; j += difference) {
+                if (j > Integer.MAX_VALUE) {
+                    break;
                 }
-                long difference = (largest - smallest) / 4;
-                for (long j = smallest; j <= largest; j += difference) {
-                    if(j > Integer.MAX_VALUE) {
-                        break;
-                    }
-                    byte[] encoded = codec.encode((int)j, 0);
-                    long decoded = 0;
-                    try {
-                        decoded = codec.decode(
-                                new ByteArrayInputStream(encoded), 0);
-                    } catch (EOFException e) {
-                        System.out.println(e);
-                    }
-                    if (j != decoded) {
-                        fail("Failed with codec: " + i + ", " + codec
-                                + " expected: " + j + ", got: " + decoded);
-                    }
+                byte[] encoded = codec.encode((int) j, 0);
+                long decoded = 0;
+                try {
+                    decoded = codec.decode(
+                            new ByteArrayInputStream(encoded), 0);
+                } catch (EOFException e) {
+                    System.out.println(e);
+                }
+                if (j != decoded) {
+                    fail("Failed with codec: " + i + ", " + codec
+                            + " expected: " + j + ", got: " + decoded);
                 }
             }
-
-            // Test encode-decode with 0
-            assertEquals(0, codec.decode(new ByteArrayInputStream(codec.encode(
-                    0, 0)), 0));
         }
+
+        // Test encode-decode with 0
+        assertEquals(0, codec.decode(new ByteArrayInputStream(codec.encode(
+                0, 0)), 0));
     }
 
 }

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecEncodingTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecEncodingTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,26 +31,27 @@ import org.apache.commons.compress.harmony.pack200.CodecEncoding;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.PopulationCodec;
 import org.apache.commons.compress.harmony.pack200.RunCodec;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
-public class CodecEncodingTest extends TestCase {
+public class CodecEncodingTest {
 
+    @Test
     public void testArbitraryCodec() throws IOException, Pack200Exception {
-        assertEquals("(1,256)", CodecEncoding.getCodec(116,
+        assertEquals(CodecEncoding.getCodec(116,
                 new ByteArrayInputStream(new byte[] { 0x00, (byte) 0xFF }),
-                null).toString());
-        assertEquals("(5,128,2,1)", CodecEncoding.getCodec(116,
+                null).toString(), "(1,256)");
+        assertEquals(CodecEncoding.getCodec(116,
                 new ByteArrayInputStream(new byte[] { 0x25, (byte) 0x7F }),
-                null).toString());
-        assertEquals("(2,128,1,1)", CodecEncoding.getCodec(116,
+                null).toString(), "(5,128,2,1)");
+        assertEquals(CodecEncoding.getCodec(116,
                 new ByteArrayInputStream(new byte[] { 0x0B, (byte) 0x7F }),
-                null).toString());
+                null).toString(), "(2,128,1,1)");
     }
 
+    @Test
     public void testCanonicalEncodings() throws IOException, Pack200Exception {
         Codec defaultCodec = new BHSDCodec(2, 16, 0, 0);
         assertEquals(defaultCodec, CodecEncoding
@@ -175,6 +179,7 @@ public class CodecEncodingTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetSpeciferForPopulationCodec() throws IOException, Pack200Exception {
         PopulationCodec pCodec = new PopulationCodec(Codec.BYTE1, Codec.CHAR3, Codec.UNSIGNED5);
         int[] specifiers = CodecEncoding.getSpecifier(pCodec, null);
@@ -191,6 +196,7 @@ public class CodecEncodingTest extends TestCase {
         assertEquals(pCodec.getUnfavouredCodec(), pCodec2.getUnfavouredCodec());
     }
 
+    @Test
     public void testGetSpeciferForRunCodec() throws Pack200Exception, IOException {
         RunCodec runCodec = new RunCodec(25, Codec.DELTA5, Codec.BYTE1);
         int[] specifiers = CodecEncoding.getSpecifier(runCodec, null);
@@ -260,6 +266,7 @@ public class CodecEncodingTest extends TestCase {
         assertEquals(bCodec.getBCodec(), bCodec2.getBCodec());
     }
 
+    @Test
     public void testGetSpecifier() throws IOException, Pack200Exception {
         // Test canonical codecs
         for (int i = 1; i <= 115; i++) {

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecEncodingTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecEncodingTest.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.apache.commons.compress.harmony.pack200.BHSDCodec;
 import org.apache.commons.compress.harmony.pack200.Codec;
@@ -32,151 +32,160 @@ import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.PopulationCodec;
 import org.apache.commons.compress.harmony.pack200.RunCodec;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  *
  */
 public class CodecEncodingTest {
 
-    @Test
-    public void testArbitraryCodec() throws IOException, Pack200Exception {
-        assertEquals(CodecEncoding.getCodec(116,
-                new ByteArrayInputStream(new byte[] { 0x00, (byte) 0xFF }),
-                null).toString(), "(1,256)");
-        assertEquals(CodecEncoding.getCodec(116,
-                new ByteArrayInputStream(new byte[] { 0x25, (byte) 0x7F }),
-                null).toString(), "(5,128,2,1)");
-        assertEquals(CodecEncoding.getCodec(116,
-                new ByteArrayInputStream(new byte[] { 0x0B, (byte) 0x7F }),
-                null).toString(), "(2,128,1,1)");
+    static Stream<Arguments> arbitraryCodec() {
+        return Stream.of(
+                Arguments.of("(1,256)", new byte[] { 0x00, (byte) 0xFF }),
+                Arguments.of("(5,128,2,1)", new byte[] { 0x25, (byte) 0x7F }),
+                Arguments.of("(2,128,1,1)", new byte[] { 0x0B, (byte) 0x7F })
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("arbitraryCodec")
+    public void testArbitraryCodec(final String expected, final byte[] bytes) throws IOException, Pack200Exception {
+        assertEquals(expected, CodecEncoding.getCodec(116, new ByteArrayInputStream(bytes), null).toString());
     }
 
     @Test
-    public void testCanonicalEncodings() throws IOException, Pack200Exception {
+    public void testDefaultCodec() throws Pack200Exception, IOException {
         Codec defaultCodec = new BHSDCodec(2, 16, 0, 0);
-        assertEquals(defaultCodec, CodecEncoding
-                .getCodec(0, null, defaultCodec));
-        Map<Integer, String> map = new HashMap<>();
-        // These are the canonical encodings specified by the Pack200 spec
-        map.put(Integer.valueOf(1), "(1,256)");
-        map.put(Integer.valueOf(2), "(1,256,1)");
-        map.put(Integer.valueOf(3), "(1,256,0,1)");
-        map.put(Integer.valueOf(4), "(1,256,1,1)");
-        map.put(Integer.valueOf(5), "(2,256)");
-        map.put(Integer.valueOf(6), "(2,256,1)");
-        map.put(Integer.valueOf(7), "(2,256,0,1)");
-        map.put(Integer.valueOf(8), "(2,256,1,1)");
-        map.put(Integer.valueOf(9), "(3,256)");
-        map.put(Integer.valueOf(10), "(3,256,1)");
-        map.put(Integer.valueOf(11), "(3,256,0,1)");
-        map.put(Integer.valueOf(12), "(3,256,1,1)");
-        map.put(Integer.valueOf(13), "(4,256)");
-        map.put(Integer.valueOf(14), "(4,256,1)");
-        map.put(Integer.valueOf(15), "(4,256,0,1)");
-        map.put(Integer.valueOf(16), "(4,256,1,1)");
-        map.put(Integer.valueOf(17), "(5,4)");
-        map.put(Integer.valueOf(18), "(5,4,1)");
-        map.put(Integer.valueOf(19), "(5,4,2)");
-        map.put(Integer.valueOf(20), "(5,16)");
-        map.put(Integer.valueOf(21), "(5,16,1)");
-        map.put(Integer.valueOf(22), "(5,16,2)");
-        map.put(Integer.valueOf(23), "(5,32)");
-        map.put(Integer.valueOf(24), "(5,32,1)");
-        map.put(Integer.valueOf(25), "(5,32,2)");
-        map.put(Integer.valueOf(26), "(5,64)");
-        map.put(Integer.valueOf(27), "(5,64,1)");
-        map.put(Integer.valueOf(28), "(5,64,2)");
-        map.put(Integer.valueOf(29), "(5,128)");
-        map.put(Integer.valueOf(30), "(5,128,1)");
-        map.put(Integer.valueOf(31), "(5,128,2)");
-        map.put(Integer.valueOf(32), "(5,4,0,1)");
-        map.put(Integer.valueOf(33), "(5,4,1,1)");
-        map.put(Integer.valueOf(34), "(5,4,2,1)");
-        map.put(Integer.valueOf(35), "(5,16,0,1)");
-        map.put(Integer.valueOf(36), "(5,16,1,1)");
-        map.put(Integer.valueOf(37), "(5,16,2,1)");
-        map.put(Integer.valueOf(38), "(5,32,0,1)");
-        map.put(Integer.valueOf(39), "(5,32,1,1)");
-        map.put(Integer.valueOf(40), "(5,32,2,1)");
-        map.put(Integer.valueOf(41), "(5,64,0,1)");
-        map.put(Integer.valueOf(42), "(5,64,1,1)");
-        map.put(Integer.valueOf(43), "(5,64,2,1)");
-        map.put(Integer.valueOf(44), "(5,128,0,1)");
-        map.put(Integer.valueOf(45), "(5,128,1,1)");
-        map.put(Integer.valueOf(46), "(5,128,2,1)");
-        map.put(Integer.valueOf(47), "(2,192)");
-        map.put(Integer.valueOf(48), "(2,224)");
-        map.put(Integer.valueOf(49), "(2,240)");
-        map.put(Integer.valueOf(50), "(2,248)");
-        map.put(Integer.valueOf(51), "(2,252)");
-        map.put(Integer.valueOf(52), "(2,8,0,1)");
-        map.put(Integer.valueOf(53), "(2,8,1,1)");
-        map.put(Integer.valueOf(54), "(2,16,0,1)");
-        map.put(Integer.valueOf(55), "(2,16,1,1)");
-        map.put(Integer.valueOf(56), "(2,32,0,1)");
-        map.put(Integer.valueOf(57), "(2,32,1,1)");
-        map.put(Integer.valueOf(58), "(2,64,0,1)");
-        map.put(Integer.valueOf(59), "(2,64,1,1)");
-        map.put(Integer.valueOf(60), "(2,128,0,1)");
-        map.put(Integer.valueOf(61), "(2,128,1,1)");
-        map.put(Integer.valueOf(62), "(2,192,0,1)");
-        map.put(Integer.valueOf(63), "(2,192,1,1)");
-        map.put(Integer.valueOf(64), "(2,224,0,1)");
-        map.put(Integer.valueOf(65), "(2,224,1,1)");
-        map.put(Integer.valueOf(66), "(2,240,0,1)");
-        map.put(Integer.valueOf(67), "(2,240,1,1)");
-        map.put(Integer.valueOf(68), "(2,248,0,1)");
-        map.put(Integer.valueOf(69), "(2,248,1,1)");
-        map.put(Integer.valueOf(70), "(3,192)");
-        map.put(Integer.valueOf(71), "(3,224)");
-        map.put(Integer.valueOf(72), "(3,240)");
-        map.put(Integer.valueOf(73), "(3,248)");
-        map.put(Integer.valueOf(74), "(3,252)");
-        map.put(Integer.valueOf(75), "(3,8,0,1)");
-        map.put(Integer.valueOf(76), "(3,8,1,1)");
-        map.put(Integer.valueOf(77), "(3,16,0,1)");
-        map.put(Integer.valueOf(78), "(3,16,1,1)");
-        map.put(Integer.valueOf(79), "(3,32,0,1)");
-        map.put(Integer.valueOf(80), "(3,32,1,1)");
-        map.put(Integer.valueOf(81), "(3,64,0,1)");
-        map.put(Integer.valueOf(82), "(3,64,1,1)");
-        map.put(Integer.valueOf(83), "(3,128,0,1)");
-        map.put(Integer.valueOf(84), "(3,128,1,1)");
-        map.put(Integer.valueOf(85), "(3,192,0,1)");
-        map.put(Integer.valueOf(86), "(3,192,1,1)");
-        map.put(Integer.valueOf(87), "(3,224,0,1)");
-        map.put(Integer.valueOf(88), "(3,224,1,1)");
-        map.put(Integer.valueOf(89), "(3,240,0,1)");
-        map.put(Integer.valueOf(90), "(3,240,1,1)");
-        map.put(Integer.valueOf(91), "(3,248,0,1)");
-        map.put(Integer.valueOf(92), "(3,248,1,1)");
-        map.put(Integer.valueOf(93), "(4,192)");
-        map.put(Integer.valueOf(94), "(4,224)");
-        map.put(Integer.valueOf(95), "(4,240)");
-        map.put(Integer.valueOf(96), "(4,248)");
-        map.put(Integer.valueOf(97), "(4,252)");
-        map.put(Integer.valueOf(98), "(4,8,0,1)");
-        map.put(Integer.valueOf(99), "(4,8,1,1)");
-        map.put(Integer.valueOf(100), "(4,16,0,1)");
-        map.put(Integer.valueOf(101), "(4,16,1,1)");
-        map.put(Integer.valueOf(102), "(4,32,0,1)");
-        map.put(Integer.valueOf(103), "(4,32,1,1)");
-        map.put(Integer.valueOf(104), "(4,64,0,1)");
-        map.put(Integer.valueOf(105), "(4,64,1,1)");
-        map.put(Integer.valueOf(106), "(4,128,0,1)");
-        map.put(Integer.valueOf(107), "(4,128,1,1)");
-        map.put(Integer.valueOf(108), "(4,192,0,1)");
-        map.put(Integer.valueOf(109), "(4,192,1,1)");
-        map.put(Integer.valueOf(110), "(4,224,0,1)");
-        map.put(Integer.valueOf(111), "(4,224,1,1)");
-        map.put(Integer.valueOf(112), "(4,240,0,1)");
-        map.put(Integer.valueOf(113), "(4,240,1,1)");
-        map.put(Integer.valueOf(114), "(4,248,0,1)");
-        map.put(Integer.valueOf(115), "(4,248,1,1)");
-        for (int i = 1; i <= 115; i++) {
-            assertEquals(map.get(Integer.valueOf(i)), CodecEncoding.getCodec(i,
-                    null, null).toString());
-        }
+        assertEquals(defaultCodec, CodecEncoding.getCodec(0, null, defaultCodec));
+    }
+
+    // These are the canonical encodings specified by the Pack200 spec
+    static Stream<Arguments> canonicalEncodings() {
+        return Stream.of(
+                Arguments.of(1, "(1,256)"),
+                Arguments.of(2, "(1,256,1)"),
+                Arguments.of(3, "(1,256,0,1)"),
+                Arguments.of(4, "(1,256,1,1)"),
+                Arguments.of(5, "(2,256)"),
+                Arguments.of(6, "(2,256,1)"),
+                Arguments.of(7, "(2,256,0,1)"),
+                Arguments.of(8, "(2,256,1,1)"),
+                Arguments.of(9, "(3,256)"),
+                Arguments.of(10, "(3,256,1)"),
+                Arguments.of(11, "(3,256,0,1)"),
+                Arguments.of(12, "(3,256,1,1)"),
+                Arguments.of(13, "(4,256)"),
+                Arguments.of(14, "(4,256,1)"),
+                Arguments.of(15, "(4,256,0,1)"),
+                Arguments.of(16, "(4,256,1,1)"),
+                Arguments.of(17, "(5,4)"),
+                Arguments.of(18, "(5,4,1)"),
+                Arguments.of(19, "(5,4,2)"),
+                Arguments.of(20, "(5,16)"),
+                Arguments.of(21, "(5,16,1)"),
+                Arguments.of(22, "(5,16,2)"),
+                Arguments.of(23, "(5,32)"),
+                Arguments.of(24, "(5,32,1)"),
+                Arguments.of(25, "(5,32,2)"),
+                Arguments.of(26, "(5,64)"),
+                Arguments.of(27, "(5,64,1)"),
+                Arguments.of(28, "(5,64,2)"),
+                Arguments.of(29, "(5,128)"),
+                Arguments.of(30, "(5,128,1)"),
+                Arguments.of(31, "(5,128,2)"),
+                Arguments.of(32, "(5,4,0,1)"),
+                Arguments.of(33, "(5,4,1,1)"),
+                Arguments.of(34, "(5,4,2,1)"),
+                Arguments.of(35, "(5,16,0,1)"),
+                Arguments.of(36, "(5,16,1,1)"),
+                Arguments.of(37, "(5,16,2,1)"),
+                Arguments.of(38, "(5,32,0,1)"),
+                Arguments.of(39, "(5,32,1,1)"),
+                Arguments.of(40, "(5,32,2,1)"),
+                Arguments.of(41, "(5,64,0,1)"),
+                Arguments.of(42, "(5,64,1,1)"),
+                Arguments.of(43, "(5,64,2,1)"),
+                Arguments.of(44, "(5,128,0,1)"),
+                Arguments.of(45, "(5,128,1,1)"),
+                Arguments.of(46, "(5,128,2,1)"),
+                Arguments.of(47, "(2,192)"),
+                Arguments.of(48, "(2,224)"),
+                Arguments.of(49, "(2,240)"),
+                Arguments.of(50, "(2,248)"),
+                Arguments.of(51, "(2,252)"),
+                Arguments.of(52, "(2,8,0,1)"),
+                Arguments.of(53, "(2,8,1,1)"),
+                Arguments.of(54, "(2,16,0,1)"),
+                Arguments.of(55, "(2,16,1,1)"),
+                Arguments.of(56, "(2,32,0,1)"),
+                Arguments.of(57, "(2,32,1,1)"),
+                Arguments.of(58, "(2,64,0,1)"),
+                Arguments.of(59, "(2,64,1,1)"),
+                Arguments.of(60, "(2,128,0,1)"),
+                Arguments.of(61, "(2,128,1,1)"),
+                Arguments.of(62, "(2,192,0,1)"),
+                Arguments.of(63, "(2,192,1,1)"),
+                Arguments.of(64, "(2,224,0,1)"),
+                Arguments.of(65, "(2,224,1,1)"),
+                Arguments.of(66, "(2,240,0,1)"),
+                Arguments.of(67, "(2,240,1,1)"),
+                Arguments.of(68, "(2,248,0,1)"),
+                Arguments.of(69, "(2,248,1,1)"),
+                Arguments.of(70, "(3,192)"),
+                Arguments.of(71, "(3,224)"),
+                Arguments.of(72, "(3,240)"),
+                Arguments.of(73, "(3,248)"),
+                Arguments.of(74, "(3,252)"),
+                Arguments.of(75, "(3,8,0,1)"),
+                Arguments.of(76, "(3,8,1,1)"),
+                Arguments.of(77, "(3,16,0,1)"),
+                Arguments.of(78, "(3,16,1,1)"),
+                Arguments.of(79, "(3,32,0,1)"),
+                Arguments.of(80, "(3,32,1,1)"),
+                Arguments.of(81, "(3,64,0,1)"),
+                Arguments.of(82, "(3,64,1,1)"),
+                Arguments.of(83, "(3,128,0,1)"),
+                Arguments.of(84, "(3,128,1,1)"),
+                Arguments.of(85, "(3,192,0,1)"),
+                Arguments.of(86, "(3,192,1,1)"),
+                Arguments.of(87, "(3,224,0,1)"),
+                Arguments.of(88, "(3,224,1,1)"),
+                Arguments.of(89, "(3,240,0,1)"),
+                Arguments.of(90, "(3,240,1,1)"),
+                Arguments.of(91, "(3,248,0,1)"),
+                Arguments.of(92, "(3,248,1,1)"),
+                Arguments.of(93, "(4,192)"),
+                Arguments.of(94, "(4,224)"),
+                Arguments.of(95, "(4,240)"),
+                Arguments.of(96, "(4,248)"),
+                Arguments.of(97, "(4,252)"),
+                Arguments.of(98, "(4,8,0,1)"),
+                Arguments.of(99, "(4,8,1,1)"),
+                Arguments.of(100, "(4,16,0,1)"),
+                Arguments.of(101, "(4,16,1,1)"),
+                Arguments.of(102, "(4,32,0,1)"),
+                Arguments.of(103, "(4,32,1,1)"),
+                Arguments.of(104, "(4,64,0,1)"),
+                Arguments.of(105, "(4,64,1,1)"),
+                Arguments.of(106, "(4,128,0,1)"),
+                Arguments.of(107, "(4,128,1,1)"),
+                Arguments.of(108, "(4,192,0,1)"),
+                Arguments.of(109, "(4,192,1,1)"),
+                Arguments.of(110, "(4,224,0,1)"),
+                Arguments.of(111, "(4,224,1,1)"),
+                Arguments.of(112, "(4,240,0,1)"),
+                Arguments.of(113, "(4,240,1,1)"),
+                Arguments.of(114, "(4,248,0,1)"),
+                Arguments.of(115, "(4,248,1,1)")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("canonicalEncodings")
+    void testCanonicalEncodings(final int i, final String expectedCodec) throws IOException, Pack200Exception {
+        assertEquals(expectedCodec, CodecEncoding.getCodec(i, null, null).toString());
     }
 
     @Test
@@ -266,52 +275,35 @@ public class CodecEncodingTest {
         assertEquals(bCodec.getBCodec(), bCodec2.getBCodec());
     }
 
-    @Test
-    public void testGetSpecifier() throws IOException, Pack200Exception {
-        // Test canonical codecs
-        for (int i = 1; i <= 115; i++) {
-            assertEquals(i, CodecEncoding.getSpecifier(CodecEncoding.getCodec(i, null, null), null)[0]);
-        }
+    // Test canonical codecs
+    static Stream<Arguments> canonicalGetSpecifier() {
+        return IntStream.range(1, 115).mapToObj(Arguments::of);
+    }
 
-        // Test a range of non-canonical codecs
-        Codec c1 = new BHSDCodec(2, 125, 0, 1);
+    @ParameterizedTest
+    @MethodSource("canonicalGetSpecifier")
+    public void testCanonicalGetSpecifier(final int i) throws Pack200Exception, IOException {
+        assertEquals(i, CodecEncoding.getSpecifier(CodecEncoding.getCodec(i, null, null), null)[0]);
+    }
+
+    static Stream<Arguments> specifier() {
+        return Stream.of(
+                Arguments.of(new BHSDCodec(2, 125, 0, 1)),
+                Arguments.of(new BHSDCodec(3, 125, 2, 1)),
+                Arguments.of(new BHSDCodec(4, 125)),
+                Arguments.of(new BHSDCodec(5, 125, 2, 0)),
+                Arguments.of(new BHSDCodec(3, 5, 2, 1))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("specifier")
+    void testGetSpecifier(final Codec c1) throws IOException, Pack200Exception {
         int[] specifiers = CodecEncoding.getSpecifier(c1, null);
         assertEquals(3, specifiers.length);
         assertEquals(116, specifiers[0]);
         byte[] bytes = {(byte) specifiers[1], (byte) specifiers[2]};
         InputStream in = new ByteArrayInputStream(bytes);
-        assertEquals(c1, CodecEncoding.getCodec(116, in, null));
-
-        c1 = new BHSDCodec(3, 125, 2, 1);
-        specifiers = CodecEncoding.getSpecifier(c1, null);
-        assertEquals(3, specifiers.length);
-        assertEquals(116, specifiers[0]);
-        bytes = new byte[] {(byte) specifiers[1], (byte) specifiers[2]};
-        in = new ByteArrayInputStream(bytes);
-        assertEquals(c1, CodecEncoding.getCodec(116, in, null));
-
-        c1 = new BHSDCodec(4, 125);
-        specifiers = CodecEncoding.getSpecifier(c1, null);
-        assertEquals(3, specifiers.length);
-        assertEquals(116, specifiers[0]);
-        bytes = new byte[] {(byte) specifiers[1], (byte) specifiers[2]};
-        in = new ByteArrayInputStream(bytes);
-        assertEquals(c1, CodecEncoding.getCodec(116, in, null));
-
-        c1 = new BHSDCodec(5, 125, 2, 0);
-        specifiers = CodecEncoding.getSpecifier(c1, null);
-        assertEquals(3, specifiers.length);
-        assertEquals(116, specifiers[0]);
-        bytes = new byte[] {(byte) specifiers[1], (byte) specifiers[2]};
-        in = new ByteArrayInputStream(bytes);
-        assertEquals(c1, CodecEncoding.getCodec(116, in, null));
-
-        c1 = new BHSDCodec(3, 5, 2, 1);
-        specifiers = CodecEncoding.getSpecifier(c1, null);
-        assertEquals(3, specifiers.length);
-        assertEquals(116, specifiers[0]);
-        bytes = new byte[] {(byte) specifiers[1], (byte) specifiers[2]};
-        in = new ByteArrayInputStream(bytes);
         assertEquals(c1, CodecEncoding.getCodec(116, in, null));
     }
 

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -24,13 +29,12 @@ import org.apache.commons.compress.harmony.pack200.BHSDCodec;
 import org.apache.commons.compress.harmony.pack200.CanonicalCodecFamilies;
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
-public class CodecTest extends TestCase {
+public class CodecTest {
 
     private void checkAscendingCardinalities(final BHSDCodec[] family) {
         for (int i = 1; i < family.length; i++) {
@@ -59,12 +63,14 @@ public class CodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testByte1() throws Exception {
         for (int i = 0; i < 255; i++) {
             decode(Codec.BYTE1, new byte[] { (byte) i }, i, 0);
         }
     }
 
+    @Test
     public void testByte1Delta() throws Exception {
         Codec BYTE1D = new BHSDCodec(1, 256, 0, 1);
         long last = 0;
@@ -73,6 +79,7 @@ public class CodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testByte1DeltaException() throws Exception {
         Codec BYTE1D = new BHSDCodec(1, 256, 0, 1);
         try {
@@ -83,6 +90,7 @@ public class CodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testByte1Signed() throws Exception {
         Codec BYTE1S2 = new BHSDCodec(1, 256, 2);
         decode(BYTE1S2, new byte[] { 0 }, 0, 0);
@@ -99,6 +107,7 @@ public class CodecTest extends TestCase {
         decode(BYTE1S2, new byte[] { 11 }, -3, 0);
     }
 
+    @Test
     public void testCardinality() {
         BHSDCodec byte1 = Codec.BYTE1;
         assertEquals(256, byte1.cardinality());
@@ -155,6 +164,7 @@ public class CodecTest extends TestCase {
         assertFalse(byte2s.encodes(192));
         assertFalse(byte2s.encodes(256));
     }
+    @Test
     public void testCodecFamilies() {
         checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaUnsignedCodecs1);
         checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaUnsignedCodecs2);
@@ -177,6 +187,7 @@ public class CodecTest extends TestCase {
         checkAscendingCardinalities(CanonicalCodecFamilies.deltaDoubleSignedCodecs1);
     }
 
+    @Test
     public void testCodecToString() {
         assertEquals("(1,256)", Codec.BYTE1.toString());
         assertEquals("(3,128)", Codec.CHAR3.toString());
@@ -193,6 +204,7 @@ public class CodecTest extends TestCase {
         assertEquals("(5,64,2,1)", Codec.MDELTA5.toString());
     }
 
+    @Test
     public void testInvalidCodings() {
         for (int i = 0; i < 256; i++) {
             try {
@@ -215,6 +227,7 @@ public class CodecTest extends TestCase {
 
     }
 
+    @Test
     public void testUnsigned5() throws Exception {
         decode(Codec.UNSIGNED5, new byte[] { 1 }, 1, 0);
         decode(Codec.UNSIGNED5, new byte[] { (byte) 191 }, 191, 0);

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/CodecTest.java
@@ -16,34 +16,32 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.apache.commons.compress.harmony.pack200.BHSDCodec;
 import org.apache.commons.compress.harmony.pack200.CanonicalCodecFamilies;
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  *
  */
 public class CodecTest {
-
-    private void checkAscendingCardinalities(final BHSDCodec[] family) {
-        for (int i = 1; i < family.length; i++) {
-            BHSDCodec previous = family[i-1];
-            BHSDCodec codec = family[i];
-            assertTrue(codec.largest() >= previous.largest());
-            assertTrue(codec.smallest() <= previous.smallest());
-        }
-    }
 
     private long decode(final Codec codec, final byte[] data, final long value,
             final long last) throws IOException, Pack200Exception {
@@ -55,12 +53,7 @@ public class CodecTest {
 
     private void decodeFail(final Codec codec, final byte[] data)
             throws IOException, Pack200Exception {
-        try {
-            decode(codec, data, 0, 0);
-            fail("Should have detected an EOFException");
-        } catch (EOFException e) {
-            assertTrue(true);
-        }
+        assertThrowsExactly(EOFException.class, () -> decode(codec, data, 0, 0), "Should have detected an EOFException");
     }
 
     @Test
@@ -82,12 +75,8 @@ public class CodecTest {
     @Test
     public void testByte1DeltaException() throws Exception {
         Codec BYTE1D = new BHSDCodec(1, 256, 0, 1);
-        try {
-            BYTE1D.decode(new ByteArrayInputStream(new byte[] { (byte) 1 }));
-            fail("Decoding with a delta stream and not passing a last value should throw exception");
-        } catch (Pack200Exception e) {
-            assertTrue(true);
-        }
+        assertThrows(Pack200Exception.class, () -> BYTE1D.decode(new ByteArrayInputStream(new byte[]{(byte) 1})),
+                "Decoding with a delta stream and not passing a last value should throw an exception");
     }
 
     @Test
@@ -164,27 +153,40 @@ public class CodecTest {
         assertFalse(byte2s.encodes(192));
         assertFalse(byte2s.encodes(256));
     }
-    @Test
-    public void testCodecFamilies() {
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaUnsignedCodecs1);
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaUnsignedCodecs2);
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaUnsignedCodecs3);
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaUnsignedCodecs4);
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaUnsignedCodecs5);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaUnsignedCodecs1);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaUnsignedCodecs2);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaUnsignedCodecs3);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaUnsignedCodecs4);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaUnsignedCodecs5);
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaSignedCodecs1);
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaSignedCodecs2);
-        checkAscendingCardinalities(CanonicalCodecFamilies.nonDeltaDoubleSignedCodecs1);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaSignedCodecs1);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaSignedCodecs2);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaSignedCodecs3);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaSignedCodecs4);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaSignedCodecs5);
-        checkAscendingCardinalities(CanonicalCodecFamilies.deltaDoubleSignedCodecs1);
+
+    static Stream<Arguments> codecFamily() {
+        return Stream.of(
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaUnsignedCodecs1),
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaUnsignedCodecs2),
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaUnsignedCodecs3),
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaUnsignedCodecs4),
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaUnsignedCodecs5),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaUnsignedCodecs1),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaUnsignedCodecs2),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaUnsignedCodecs3),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaUnsignedCodecs4),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaUnsignedCodecs5),
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaSignedCodecs1),
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaSignedCodecs2),
+                Arguments.of((Object) CanonicalCodecFamilies.nonDeltaDoubleSignedCodecs1),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaSignedCodecs1),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaSignedCodecs2),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaSignedCodecs3),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaSignedCodecs4),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaSignedCodecs5),
+                Arguments.of((Object) CanonicalCodecFamilies.deltaDoubleSignedCodecs1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("codecFamily")
+    public void testCodecFamilies(final BHSDCodec[] family) {
+        for (int i = 1; i < family.length; i++) {
+            BHSDCodec previous = family[i-1];
+            BHSDCodec codec = family[i];
+            assertTrue(codec.largest() >= previous.largest());
+            assertTrue(codec.smallest() <= previous.smallest());
+        }
     }
 
     @Test
@@ -204,27 +206,28 @@ public class CodecTest {
         assertEquals("(5,64,2,1)", Codec.MDELTA5.toString());
     }
 
-    @Test
-    public void testInvalidCodings() {
-        for (int i = 0; i < 256; i++) {
-            try {
-                new BHSDCodec(1, i);
-                fail("b=1 -> h=256");
-            } catch (IllegalArgumentException e) {
-                assertTrue(true);
-            }
-        }
-        for (int i = 1; i <= 5; i++) {
-            try {
-                new BHSDCodec(i, 256);
-                if (i == 5) {
-                    fail("h=256 -> b!=5");
-                }
-            } catch (IllegalArgumentException e) {
-                assertTrue(true);
-            }
-        }
+    static Stream<Arguments> hCodings() {
+        return IntStream.range(0, 256).mapToObj(Arguments::of);
+    }
 
+    @ParameterizedTest
+    @MethodSource("hCodings")
+    public void testInvalidHCodings(final int i) {
+        assertThrows(IllegalArgumentException.class, () -> new BHSDCodec(1, i), "b=1 -> h=256");
+    }
+
+    static Stream<Arguments> bCodings(){
+        return IntStream.rangeClosed(1, 5).mapToObj(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("bCodings")
+    public void testBCodings(final int i) {
+        if (i == 5) {
+            assertThrows(IllegalArgumentException.class, () -> new BHSDCodec(i, 256));
+        } else {
+            assertDoesNotThrow(() -> new BHSDCodec(i, 256));
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/NewAttributeBandsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/NewAttributeBandsTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -39,13 +43,14 @@ import org.apache.commons.compress.harmony.pack200.NewAttributeBands.Union;
 import org.apache.commons.compress.harmony.pack200.NewAttributeBands.UnionCase;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.SegmentHeader;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for pack200 support for non-predefined attributes
  */
-public class NewAttributeBandsTest extends TestCase {
+public class NewAttributeBandsTest {
 
     private class MockNewAttributeBands extends NewAttributeBands {
 
@@ -60,6 +65,7 @@ public class NewAttributeBandsTest extends TestCase {
         }
     }
 
+    @Test
     public void testAddAttributes() throws IOException, Pack200Exception {
         CPUTF8 name = new CPUTF8("TestAttribute");
         CPUTF8 layout = new CPUTF8("B");
@@ -83,6 +89,7 @@ public class NewAttributeBandsTest extends TestCase {
         assertEquals(3, bytes[2]);
     }
 
+    @Test
     public void testAddAttributesWithReplicationLayout() throws IOException,
             Pack200Exception {
         CPUTF8 name = new CPUTF8("TestAttribute");
@@ -113,6 +120,7 @@ public class NewAttributeBandsTest extends TestCase {
         assertEquals(-50, decoded[3]);
     }
 
+    @Test
     public void testEmptyLayout() throws IOException {
         CPUTF8 name = new CPUTF8("TestAttribute");
         CPUTF8 layout = new CPUTF8("");
@@ -123,30 +131,24 @@ public class NewAttributeBandsTest extends TestCase {
         assertEquals(0, layoutElements.size());
     }
 
-    public void testIntegralLayouts() throws IOException {
-        tryIntegral("B");
-        tryIntegral("FB");
-        tryIntegral("SB");
-        tryIntegral("H");
-        tryIntegral("FH");
-        tryIntegral("SH");
-        tryIntegral("I");
-        tryIntegral("FI");
-        tryIntegral("SI");
-        tryIntegral("PB");
-        tryIntegral("OB");
-        tryIntegral("OSB");
-        tryIntegral("POB");
-        tryIntegral("PH");
-        tryIntegral("OH");
-        tryIntegral("OSH");
-        tryIntegral("POH");
-        tryIntegral("PI");
-        tryIntegral("OI");
-        tryIntegral("OSI");
-        tryIntegral("POI");
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "B", "FB", "SB", "H", "FH", "SH", "I", "FI", "SI", "PB", "OB", "OSB",
+            "POB", "PH", "OH", "OSH", "POH", "PI", "OI", "OSI", "POI"
+    })
+    public void testIntegralLayouts(final String layoutStr) throws IOException {
+        CPUTF8 name = new CPUTF8("TestAttribute");
+        CPUTF8 layout = new CPUTF8(layoutStr);
+        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(1,
+                null, null, new AttributeDefinition(35,
+                        AttributeDefinitionBands.CONTEXT_CLASS, name, layout));
+        List<AttributeLayoutElement> layoutElements = newAttributeBands.getLayoutElements();
+        assertEquals(1, layoutElements.size());
+        Integral element = (Integral) layoutElements.get(0);
+        assertEquals(layoutStr, element.getTag());
     }
 
+    @Test
     public void testLayoutWithBackwardsCalls() throws Exception {
         CPUTF8 name = new CPUTF8("TestAttribute");
         CPUTF8 layout = new CPUTF8("[NH[(1)]][KIH][(-1)]");
@@ -203,6 +205,7 @@ public class NewAttributeBandsTest extends TestCase {
         assertFalse(secondCallable.isBackwardsCallable());
     }
 
+    @Test
     public void testLayoutWithCalls() throws IOException {
         CPUTF8 name = new CPUTF8("TestAttribute");
         CPUTF8 layout = new CPUTF8(
@@ -228,27 +231,24 @@ public class NewAttributeBandsTest extends TestCase {
         assertFalse(thirdCallable.isBackwardsCallable());
     }
 
-    public void testReferenceLayouts() throws IOException {
-        tryReference("KIB");
-        tryReference("KIH");
-        tryReference("KII");
-        tryReference("KINH");
-        tryReference("KJH");
-        tryReference("KDH");
-        tryReference("KSH");
-        tryReference("KQH");
-        tryReference("RCH");
-        tryReference("RSH");
-        tryReference("RDH");
-        tryReference("RFH");
-        tryReference("RMH");
-        tryReference("RIH");
-        tryReference("RUH");
-        tryReference("RQH");
-        tryReference("RQNH");
-        tryReference("RQNI");
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "KIB", "KIH", "KII", "KINH", "KJH", "KDH", "KSH", "KQH", "RCH",
+            "RSH", "RDH", "RFH", "RMH", "RIH", "RUH", "RQH", "RQNH", "RQNI"
+    })
+    public void testReferenceLayouts(final String layoutStr) throws IOException {
+        CPUTF8 name = new CPUTF8("TestAttribute");
+        CPUTF8 layout = new CPUTF8(layoutStr);
+        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(1,
+                null, null, new AttributeDefinition(35,
+                        AttributeDefinitionBands.CONTEXT_CLASS, name, layout));
+        List<AttributeLayoutElement> layoutElements = newAttributeBands.getLayoutElements();
+        assertEquals(1, layoutElements.size());
+        Reference element = (Reference) layoutElements.get(0);
+        assertEquals(layoutStr, element.getTag());
     }
 
+    @Test
     public void testReplicationLayouts() throws IOException {
         CPUTF8 name = new CPUTF8("TestAttribute");
         CPUTF8 layout = new CPUTF8("NH[PHOHRUHRSHH]");
@@ -274,6 +274,7 @@ public class NewAttributeBandsTest extends TestCase {
         assertEquals("H", fifthElement.getTag());
     }
 
+    @Test
     public void testUnionLayout() throws IOException {
         CPUTF8 name = new CPUTF8("TestAttribute");
         CPUTF8 layout = new CPUTF8("TB(55)[FH](23)[]()[RSH]");
@@ -303,30 +304,6 @@ public class NewAttributeBandsTest extends TestCase {
         assertEquals(1, defaultBody.size());
         Reference ref = (Reference) defaultBody.get(0);
         assertEquals("RSH", ref.getTag());
-    }
-
-    private void tryIntegral(final String layoutStr) throws IOException {
-        CPUTF8 name = new CPUTF8("TestAttribute");
-        CPUTF8 layout = new CPUTF8(layoutStr);
-        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(1,
-                null, null, new AttributeDefinition(35,
-                        AttributeDefinitionBands.CONTEXT_CLASS, name, layout));
-        List<AttributeLayoutElement> layoutElements = newAttributeBands.getLayoutElements();
-        assertEquals(1, layoutElements.size());
-        Integral element = (Integral) layoutElements.get(0);
-        assertEquals(layoutStr, element.getTag());
-    }
-
-    private void tryReference(final String layoutStr) throws IOException {
-        CPUTF8 name = new CPUTF8("TestAttribute");
-        CPUTF8 layout = new CPUTF8(layoutStr);
-        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(1,
-                null, null, new AttributeDefinition(35,
-                        AttributeDefinitionBands.CONTEXT_CLASS, name, layout));
-        List<AttributeLayoutElement> layoutElements = newAttributeBands.getLayoutElements();
-        assertEquals(1, layoutElements.size());
-        Reference element = (Reference) layoutElements.get(0);
-        assertEquals(layoutStr, element.getTag());
     }
 
 }

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PackingOptionsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PackingOptionsTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -115,12 +115,8 @@ public class PackingOptionsTest {
         assertEquals("true", options.getDeflateHint());
         options.setDeflateHint("false");
         assertEquals("false", options.getDeflateHint());
-        try {
-            options.setDeflateHint("hello");
-            fail("Should throw IllegalArgumentException for incorrect deflate hint");
-        } catch (IllegalArgumentException iae) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> options.setDeflateHint("hello"),
+                "Should throw IllegalArgumentException for incorrect deflate hint");
     }
 
     @Test
@@ -157,15 +153,12 @@ public class PackingOptionsTest {
         PackingOptions options = new PackingOptions();
         options.addClassAttributeAction("Pack200", "error");
         Archive ar = new Archive(in, out, options);
-        try {
+        Error error = assertThrows(Error.class, () -> {
             ar.pack();
             in.close();
             out.close();
-            fail("fail");
-        } catch (Error e) {
-            // pass
-            assertEquals("Attribute Pack200 was found", e.getMessage());
-        }
+        });
+        assertEquals("Attribute Pack200 was found", error.getMessage());
     }
 
     @Test
@@ -318,12 +311,11 @@ public class PackingOptionsTest {
         assertEquals("keep", options.getModificationTime());
         options.setModificationTime("latest");
         assertEquals("latest", options.getModificationTime());
-        try {
-            options.setModificationTime("true");
-            fail("Should throw IllegalArgumentException for incorrect mod time");
-        } catch (IllegalArgumentException iae) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> {
+                    PackingOptions illegalOption = new PackingOptions();
+                    illegalOption.setModificationTime("true");
+                },
+                "Should throw IllegalArgumentException for incorrect mod time");
 
         // Test option works correctly. Test 'keep'.
         in = new JarFile(new File(Archive.class.getResource(

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PackingOptionsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PackingOptionsTest.java
@@ -16,6 +16,13 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -34,13 +41,12 @@ import java.util.jar.JarOutputStream;
 import org.apache.commons.compress.harmony.pack200.Archive;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.PackingOptions;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test different options for packing a Jar file
  */
-public class PackingOptionsTest extends TestCase {
+public class PackingOptionsTest {
 
     JarFile in;
     OutputStream out;
@@ -56,7 +62,7 @@ public class PackingOptionsTest extends TestCase {
 
             String name = entry.getName();
             JarEntry entry2 = jarFile2.getJarEntry(name);
-            assertNotNull("Missing Entry: " + name, entry2);
+            assertNotNull(entry2, "Missing Entry: " + name);
             // assertEquals(entry.getTime(), entry2.getTime());
             if (!name.equals("META-INF/MANIFEST.MF")) { // Manifests aren't
                                                         // necessarily
@@ -74,8 +80,7 @@ public class PackingOptionsTest extends TestCase {
                 String line2 = reader2.readLine();
                 int i = 1;
                 while (line1 != null || line2 != null) {
-                    assertEquals("Unpacked files differ for " + name, line2,
-                            line1);
+                    assertEquals(line2, line1, "Unpacked files differ for " + name);
                     line1 = reader1.readLine();
                     line2 = reader2.readLine();
                     i++;
@@ -97,10 +102,11 @@ public class PackingOptionsTest extends TestCase {
 
             String name = entry.getName();
             JarEntry entry2 = jarFile2.getJarEntry(name);
-            assertNotNull("Missing Entry: " + name, entry2);
+            assertNotNull(entry2, "Missing Entry: " + name);
         }
     }
 
+    @Test
     public void testDeflateHint() {
         // Test default first
         PackingOptions options = new PackingOptions();
@@ -117,6 +123,7 @@ public class PackingOptionsTest extends TestCase {
         }
     }
 
+    @Test
     public void testE0() throws Pack200Exception, IOException,
             URISyntaxException {
         File f1 = new File(Archive.class.getResource(
@@ -136,6 +143,7 @@ public class PackingOptionsTest extends TestCase {
 
     }
 
+    @Test
     public void testErrorAttributes() throws Exception {
         in = new JarFile(
                 new File(
@@ -160,6 +168,7 @@ public class PackingOptionsTest extends TestCase {
         }
     }
 
+    @Test
     public void testKeepFileOrder() throws Exception {
         // Test default first
         PackingOptions options = new PackingOptions();
@@ -252,10 +261,11 @@ public class PackingOptionsTest extends TestCase {
                 break;
             }
         }
-        assertFalse("Files are not expected to be in order", inOrder);
+        assertFalse(inOrder, "Files are not expected to be in order");
     }
 
     // Test verbose, quiet and log file options.
+    @Test
     public void testLoggingOptions() throws Exception {
         // Test defaults
         PackingOptions options = new PackingOptions();
@@ -301,6 +311,7 @@ public class PackingOptionsTest extends TestCase {
         reader.close();
     }
 
+    @Test
     public void testModificationTime() throws Exception {
         // Test default first
         PackingOptions options = new PackingOptions();
@@ -404,9 +415,10 @@ public class PackingOptionsTest extends TestCase {
                 sameAsOriginal = false;
             }
         }
-        assertFalse("Some modtimes should have changed", sameAsOriginal);
+        assertFalse(sameAsOriginal, "Some modtimes should have changed");
     }
 
+    @Test
     public void testNewAttributes() throws Exception {
         in = new JarFile(
                 new File(
@@ -444,6 +456,7 @@ public class PackingOptionsTest extends TestCase {
 //        compareFiles(jarFile, jarFile2);
     }
 
+    @Test
     public void testNewAttributes2() throws Exception {
         in = new JarFile(
                 new File(
@@ -482,6 +495,7 @@ public class PackingOptionsTest extends TestCase {
         compareJarEntries(jarFile, jarFile2);
     }
 
+    @Test
     public void testPassAttributes() throws Exception {
         in = new JarFile(
                 new File(
@@ -518,6 +532,7 @@ public class PackingOptionsTest extends TestCase {
         compareJarEntries(jarFile, jarFile2);
     }
 
+    @Test
     public void testPassFiles() throws IOException, URISyntaxException,
             Pack200Exception {
         // Don't pass any
@@ -567,11 +582,10 @@ public class PackingOptionsTest extends TestCase {
         in.close();
         out.close();
 
-        assertTrue("If files are passed then the pack file should be larger",
-                file.length() > file0.length());
-        assertTrue(
-                "If more files are passed then the pack file should be larger",
-                file2.length() > file.length());
+        assertTrue(file.length() > file0.length(),
+                "If files are passed then the pack file should be larger");
+        assertTrue(file2.length() > file.length(),
+                "If more files are passed then the pack file should be larger");
 
         // now unpack
         InputStream in2 = new FileInputStream(file);
@@ -618,6 +632,7 @@ public class PackingOptionsTest extends TestCase {
     // compareFiles(in, new JarFile(file));
     // }
 
+    @Test
     public void testSegmentLimits() throws IOException, Pack200Exception,
             URISyntaxException {
         in = new JarFile(new File(Archive.class.getResource(
@@ -657,6 +672,7 @@ public class PackingOptionsTest extends TestCase {
         out.close();
     }
 
+    @Test
     public void testStripDebug() throws IOException, Pack200Exception,
             URISyntaxException {
         in = new JarFile(new File(Archive.class.getResource(

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PopulationCodecTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PopulationCodecTest.java
@@ -17,22 +17,53 @@
 package org.apache.commons.compress.harmony.pack200.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.stream.Stream;
 
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.PopulationCodec;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class PopulationCodecTest {
 
-    private void checkDecode(final byte[] data, final long[] expectedResult, final Codec codec)
-            throws IOException, Pack200Exception {
+    @Test
+    public void testEncodeSingleValue() {
+        assertThrows(Pack200Exception.class, () -> new PopulationCodec(Codec.SIGNED5, Codec.SIGNED5, Codec.UDELTA5).encode(5),
+                "Should not allow a single value to be encoded as we don't know which codec to use");
+        assertThrows(Pack200Exception.class, () -> new PopulationCodec(Codec.SIGNED5, Codec.SIGNED5, Codec.UDELTA5).encode(5, 8),
+                "Should not allow a single value to be encoded as we don't know which codec to use");
+    }
+
+    static Stream<Arguments> populationCodec() {
+        return Stream.of(
+                Arguments.of(new byte[] { 4, 5, 6, 4, 2, 1, 3, 0, 7 }, new long[] { 5, 4, 6, 7 }, Codec.BYTE1),
+                // Codec.SIGNED5 can be trivial for small n, because the encoding is 2n
+                // if even, 2n-1 if odd
+                // Therefore they're left here to explain what the values are :-)
+                Arguments.of(new byte[] { 4 * 2, 4 * 2 - 1, 6 * 2, 4 * 2, 2 * 2, 1 * 2, 3 * 2, 0, 7 * 2 }, new long[] { -4, 4, 6, 7 }, Codec.SIGNED5),
+                Arguments.of(new byte[] { 4 * 2 - 1, 4 * 2, 6 * 2, 4 * 2, 2 * 2, 1 * 2, 3 * 2, 0, 7 * 2 }, new long[] { 4, -4, 6, 7 }, Codec.SIGNED5),
+                Arguments.of(new byte[] { 1, 1, 1 }, new long[] { 1 }, Codec.BYTE1),
+                Arguments.of(new byte[] { 2, 2, 1 }, new long[] { 2 }, Codec.BYTE1),
+                Arguments.of(new byte[] { 1, 1, 2 }, new long[] { -1 }, Codec.SIGNED5),
+                Arguments.of(new byte[] { 2, 2, 0, 1, 3 }, new long[] { 3, 2 }, Codec.BYTE1),
+                Arguments.of(new byte[] { 1, 2, 3, 4, 4, 2, 3, 4, 0, 1 }, new long[] { 2, 3, 4, 1 }, Codec.BYTE1),
+                Arguments.of(new byte[] { 3, 2, 1, 4, 4, 2, 3, 4, 0, 1 }, new long[] { 2, 1, 4, 1 }, Codec.BYTE1),
+                Arguments.of(new byte[] { 3, 2, 1, 4, 1, 2, 3, 4, 0, 1 }, new long[] { 2, 1, 4, 1 }, Codec.BYTE1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("populationCodec")
+    public void testPopulationCodec(final byte[] data, final long[] expectedResult, final Codec codec) throws IOException, Pack200Exception {
         try (InputStream in = new ByteArrayInputStream(data)) {
             int[] result = new PopulationCodec(codec, codec, codec).decodeInts(
                     expectedResult.length, in);
@@ -42,46 +73,6 @@ public class PopulationCodecTest {
             }
             assertEquals(0, in.available());
         }
-    }
-
-    @Test
-    public void testEncodeSingleValue() {
-        try {
-            new PopulationCodec(Codec.SIGNED5, Codec.SIGNED5, Codec.UDELTA5).encode(5);
-            fail("Should not allow a single value to be encoded as we don't know which codec to use");
-        } catch (Pack200Exception e) {
-            // pass
-        }
-        try {
-            new PopulationCodec(Codec.SIGNED5, Codec.SIGNED5, Codec.UDELTA5).encode(5, 8);
-            fail("Should not allow a single value to be encoded as we don't know which codec to use");
-        } catch (Pack200Exception e) {
-            // pass
-        }
-    }
-
-    @Test
-    public void testPopulationCodec() throws IOException, Pack200Exception {
-        checkDecode(new byte[] { 4, 5, 6, 4, 2, 1, 3, 0, 7 }, new long[] { 5,
-                4, 6, 7 }, Codec.BYTE1);
-        // Codec.SIGNED5 can be trivial for small n, because the encoding is 2n
-        // if even, 2n-1 if odd
-        // Therefore they're left here to explain what the values are :-)
-        checkDecode(new byte[] { 4 * 2, 4 * 2 - 1, 6 * 2, 4 * 2, 2 * 2, 1 * 2,
-                3 * 2, 0, 7 * 2 }, new long[] { -4, 4, 6, 7 }, Codec.SIGNED5);
-        checkDecode(new byte[] { 4 * 2 - 1, 4 * 2, 6 * 2, 4 * 2, 2 * 2, 1 * 2,
-                3 * 2, 0, 7 * 2 }, new long[] { 4, -4, 6, 7 }, Codec.SIGNED5);
-        checkDecode(new byte[] { 1, 1, 1 }, new long[] { 1 }, Codec.BYTE1);
-        checkDecode(new byte[] { 2, 2, 1 }, new long[] { 2 }, Codec.BYTE1);
-        checkDecode(new byte[] { 1, 1, 2 }, new long[] { -1 }, Codec.SIGNED5);
-        checkDecode(new byte[] { 2, 2, 0, 1, 3 }, new long[] { 3, 2 },
-                Codec.BYTE1);
-        checkDecode(new byte[] { 1, 2, 3, 4, 4, 2, 3, 4, 0, 1 }, new long[] {
-                2, 3, 4, 1 }, Codec.BYTE1);
-        checkDecode(new byte[] { 3, 2, 1, 4, 4, 2, 3, 4, 0, 1 }, new long[] {
-                2, 1, 4, 1 }, Codec.BYTE1);
-        checkDecode(new byte[] { 3, 2, 1, 4, 1, 2, 3, 4, 0, 1 }, new long[] {
-                2, 1, 4, 1 }, Codec.BYTE1);
     }
 
 }

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PopulationCodecTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/PopulationCodecTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,23 +27,24 @@ import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.PopulationCodec;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class PopulationCodecTest extends TestCase {
+public class PopulationCodecTest {
 
     private void checkDecode(final byte[] data, final long[] expectedResult, final Codec codec)
             throws IOException, Pack200Exception {
-        InputStream in = new ByteArrayInputStream(data);
-
-        int[] result = new PopulationCodec(codec, codec, codec).decodeInts(
-                expectedResult.length, in);
-        assertEquals(expectedResult.length, result.length);
-        for (int i = 0; i < expectedResult.length; i++) {
-            assertEquals(expectedResult[i], result[i]);
+        try (InputStream in = new ByteArrayInputStream(data)) {
+            int[] result = new PopulationCodec(codec, codec, codec).decodeInts(
+                    expectedResult.length, in);
+            assertEquals(expectedResult.length, result.length);
+            for (int i = 0; i < expectedResult.length; i++) {
+                assertEquals(expectedResult[i], result[i]);
+            }
+            assertEquals(0, in.available());
         }
-        assertEquals(0, in.available());
     }
 
+    @Test
     public void testEncodeSingleValue() {
         try {
             new PopulationCodec(Codec.SIGNED5, Codec.SIGNED5, Codec.UDELTA5).encode(5);
@@ -56,6 +60,7 @@ public class PopulationCodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testPopulationCodec() throws IOException, Pack200Exception {
         checkDecode(new byte[] { 4, 5, 6, 4, 2, 1, 3, 0, 7 }, new long[] { 5,
                 4, 6, 7 }, Codec.BYTE1);

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/RunCodecTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/RunCodecTest.java
@@ -17,15 +17,19 @@
 package org.apache.commons.compress.harmony.pack200.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
+import java.util.stream.Stream;
 
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.PopulationCodec;
 import org.apache.commons.compress.harmony.pack200.RunCodec;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test for RunCodec
@@ -71,18 +75,10 @@ public class RunCodecTest {
 
     @Test
     public void testEncodeSingleValue() {
-        try {
-            new RunCodec(10, Codec.SIGNED5, Codec.UDELTA5).encode(5);
-            fail("Should not allow a single value to be encoded as we don't know which codec to use");
-        } catch (Pack200Exception e) {
-            // pass
-        }
-        try {
-            new RunCodec(10, Codec.SIGNED5, Codec.UDELTA5).encode(5, 8);
-            fail("Should not allow a single value to be encoded as we don't know which codec to use");
-        } catch (Pack200Exception e) {
-            // pass
-        }
+        assertThrows(Pack200Exception.class, () -> new RunCodec(10, Codec.SIGNED5, Codec.UDELTA5).encode(5),
+                "Should not allow a single value to be encoded as we don't know which codec to use");
+        assertThrows(Pack200Exception.class, () -> new RunCodec(10, Codec.SIGNED5, Codec.UDELTA5).encode(5, 8),
+                "Should not allow a single value to be encoded as we don't know which codec to use");
     }
 
     @Test
@@ -135,32 +131,19 @@ public class RunCodecTest {
         }
     }
 
-    @Test
-    public void testRunCodec() {
-        try {
-            new RunCodec(0, Codec.SIGNED5, Codec.UDELTA5);
-            fail("Should not allow a k value of 0");
-        } catch (Pack200Exception e) {
-            // pass
-        }
-        try {
-            new RunCodec(10, null, Codec.UDELTA5);
-            fail("Should not allow a null codec");
-        } catch (Pack200Exception e) {
-            // pass
-        }
-        try {
-            new RunCodec(10, Codec.UDELTA5, null);
-            fail("Should not allow a null codec");
-        } catch (Pack200Exception e) {
-            // pass
-        }
-        try {
-            new RunCodec(10, null, null);
-            fail("Should not allow a null codec");
-        } catch (Pack200Exception e) {
-            // pass
-        }
+    static Stream<Arguments> runCodec() {
+        return Stream.of(
+                Arguments.of(0, Codec.SIGNED5, Codec.UDELTA5, "Should not allow a k value of 0"),
+                Arguments.of(10, null, Codec.UDELTA5, "Should not allow a null codec"),
+                Arguments.of(10, Codec.UDELTA5, null, "Should not allow a null codec"),
+                Arguments.of(10, null, null, "Should not allow a null codec")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("runCodec")
+    public void testRunCodec(final int k, final Codec aCodec, final Codec bCodec, final String failureMessage) {
+        assertThrows(Pack200Exception.class, () -> new RunCodec(k, aCodec, bCodec), failureMessage);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/harmony/pack200/tests/RunCodecTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/pack200/tests/RunCodecTest.java
@@ -16,20 +16,23 @@
  */
 package org.apache.commons.compress.harmony.pack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.pack200.PopulationCodec;
 import org.apache.commons.compress.harmony.pack200.RunCodec;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for RunCodec
  */
-public class RunCodecTest extends TestCase {
+public class RunCodecTest {
 
+    @Test
     public void testDecode() throws Exception {
         RunCodec runCodec = new RunCodec(1, Codec.UNSIGNED5, Codec.BYTE1);
         ByteArrayInputStream bais = new ByteArrayInputStream(new byte[] {
@@ -47,6 +50,7 @@ public class RunCodecTest extends TestCase {
         assertEquals(0, bais.available());
     }
 
+    @Test
     public void testDecodeInts() throws Exception {
         int[] band = { 1, -2, -3, 1000, 55, 5, 10, 20 };
         // first 5 of band to be encoded with DELTA5
@@ -65,6 +69,7 @@ public class RunCodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testEncodeSingleValue() {
         try {
             new RunCodec(10, Codec.SIGNED5, Codec.UDELTA5).encode(5);
@@ -80,6 +85,7 @@ public class RunCodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testNestedPopulationCodec() throws Exception {
         int[] band = { 11, 12, 33, 4000, -555, 5, 10, 20, 10, 3, 20,
                 20, 20, 10, 10, 999, 20, 789, 10, 10, 355, 12345 };
@@ -105,6 +111,7 @@ public class RunCodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testNestedRunCodec() throws Exception {
         int[] band = { 1, 2, 3, 10, 20, 30, 100, 200, 300 };
         // first 3 of band to be encoded with UDELTA5
@@ -128,6 +135,7 @@ public class RunCodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testRunCodec() {
         try {
             new RunCodec(0, Codec.SIGNED5, Codec.UDELTA5);
@@ -155,6 +163,7 @@ public class RunCodecTest extends TestCase {
         }
     }
 
+    @Test
     public void testToString() throws Pack200Exception {
         RunCodec runCodec = new RunCodec(3, Codec.UNSIGNED5, Codec.BYTE1);
         assertEquals(

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AbstractBandsTestCase.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AbstractBandsTestCase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.unpack200.AttrDefinitionBands;
 import org.apache.commons.compress.harmony.unpack200.AttributeLayoutMap;
@@ -23,12 +25,10 @@ import org.apache.commons.compress.harmony.unpack200.Segment;
 import org.apache.commons.compress.harmony.unpack200.SegmentHeader;
 import org.apache.commons.compress.harmony.unpack200.SegmentOptions;
 
-import junit.framework.TestCase;
-
 /**
  *
  */
-public abstract class AbstractBandsTestCase extends TestCase {
+public abstract class AbstractBandsTestCase {
 
     public class MockAttributeDefinitionBands extends AttrDefinitionBands {
 

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ArchiveTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ArchiveTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -34,21 +39,21 @@ import java.util.zip.ZipEntry;
 
 import org.apache.commons.compress.harmony.unpack200.Archive;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for org.apache.commons.compress.harmony.unpack200.Archive, which is the main class for
  * unpack200.
  */
-public class ArchiveTest extends TestCase {
+public class ArchiveTest {
 
     InputStream in;
     JarOutputStream out;
     File file;
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @AfterEach
+    public void tearDown() throws Exception {
         if (in != null) {
             try {
                 in.close();
@@ -66,6 +71,7 @@ public class ArchiveTest extends TestCase {
         file.delete();
     }
 
+    @Test
     public void testAlternativeConstructor() throws Exception {
         String inputFile = new File(Archive.class
                 .getResource("/pack200/sql.pack.gz").toURI()).getPath();
@@ -76,6 +82,7 @@ public class ArchiveTest extends TestCase {
         archive.unpack();
     }
 
+    @Test
     public void testDeflateHint() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/sql.pack.gz");
@@ -101,6 +108,7 @@ public class ArchiveTest extends TestCase {
 
     }
 
+    @Test
     public void testJustResourcesGZip() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/JustResources.pack.gz");
@@ -111,6 +119,7 @@ public class ArchiveTest extends TestCase {
     }
 
     // Test verbose, quiet and log file options.
+    @Test
     public void testLoggingOptions() throws Exception {
         // test default option, which is quiet (no output at all)
         in = Archive.class
@@ -189,6 +198,7 @@ public class ArchiveTest extends TestCase {
         reader.close();
     }
 
+    @Test
     public void testRemovePackFile() throws Exception {
         File original = new File(Archive.class.getResource(
                 "/pack200/sql.pack.gz").toURI());
@@ -216,6 +226,7 @@ public class ArchiveTest extends TestCase {
     }
 
     // Test with an archive containing Annotations
+    @Test
     public void testWithAnnotations() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/annotations.pack.gz");
@@ -226,6 +237,7 @@ public class ArchiveTest extends TestCase {
     }
 
     // Test with an archive packed with the -E0 option
+    @Test
     public void testWithE0() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/simple-E0.pack.gz");
@@ -236,6 +248,7 @@ public class ArchiveTest extends TestCase {
     }
 
     // Test with an archive containing Harmony's JNDI module
+    @Test
     public void testWithJNDIE1() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/jndi-e1.pack.gz");
@@ -247,6 +260,7 @@ public class ArchiveTest extends TestCase {
 
     // Test with a class containing lots of local variables (regression test for
     // HARMONY-5470)
+    @Test
     public void testWithLargeClass() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/LargeClass.pack.gz");
@@ -259,6 +273,7 @@ public class ArchiveTest extends TestCase {
 
 
     // Test with an archive containing Harmony's Pack200 module
+    @Test
     public void testWithPack200() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/pack200.pack.gz");
@@ -269,6 +284,7 @@ public class ArchiveTest extends TestCase {
     }
 
     // Test with an archive containing Harmony's Pack200 module, packed with -E1
+    @Test
     public void testWithPack200E1() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/pack200-e1.pack.gz");
@@ -279,6 +295,7 @@ public class ArchiveTest extends TestCase {
     }
 
     // Test with an archive containing Harmony's SQL module
+    @Test
     public void testWithSql() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/sql.pack.gz");
@@ -297,8 +314,8 @@ public class ArchiveTest extends TestCase {
         long differenceInJarSizes = Math.abs(compareFile.length()
                 - file.length());
 
-        assertTrue("Expected jar files to be a similar size, difference was "
-                + differenceInJarSizes + " bytes", differenceInJarSizes < 100);
+        assertTrue(differenceInJarSizes < 100, "Expected jar files to be a similar size, difference was "
+                + differenceInJarSizes + " bytes");
 
         Enumeration<JarEntry> entries = jarFile.entries();
         Enumeration<JarEntry> entries2 = jarFile2.entries();
@@ -324,7 +341,7 @@ public class ArchiveTest extends TestCase {
             String line2 = reader2.readLine();
             int i = 1;
             while (line1 != null || line2 != null) {
-                assertEquals("Unpacked class files differ for " + name, line2, line1);
+                assertEquals(line2, line1, "Unpacked class files differ for " + name);
                 line1 = reader1.readLine();
                 line2 = reader2.readLine();
                 i++;
@@ -335,6 +352,7 @@ public class ArchiveTest extends TestCase {
     }
 
     // Test with an archive containing Harmony's SQL module, packed with -E1
+    @Test
     public void testWithSqlE1() throws Exception {
         in = Archive.class
                 .getResourceAsStream("/pack200/sql-e1.pack.gz");

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AttributeLayoutMapTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AttributeLayoutMapTest.java
@@ -16,14 +16,20 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.unpack200.AttributeLayout;
 import org.apache.commons.compress.harmony.unpack200.AttributeLayoutMap;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class AttributeLayoutMapTest extends TestCase {
+public class AttributeLayoutMapTest {
 
+    @Test
     public void testRepeatable() throws Pack200Exception {
         // Check we can retrieve a default layout
         AttributeLayoutMap a = new AttributeLayoutMap();

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AttributeLayoutTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AttributeLayoutTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.unpack200.AttributeLayout;
@@ -23,10 +27,9 @@ import org.apache.commons.compress.harmony.unpack200.Segment;
 import org.apache.commons.compress.harmony.unpack200.SegmentConstantPool;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPUTF8;
 import org.apache.commons.compress.harmony.unpack200.bytecode.ClassFileEntry;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
-
-public class AttributeLayoutTest extends TestCase {
+public class AttributeLayoutTest {
 
     public class TestSegment extends Segment {
 
@@ -66,6 +69,7 @@ public class AttributeLayoutTest extends TestCase {
         }
     }
 
+    @Test
     public void testBadData() {
         assertTrue(throwsException(null, AttributeLayout.CONTEXT_CLASS, ""));
         assertTrue(throwsException("", AttributeLayout.CONTEXT_CLASS, ""));
@@ -77,6 +81,7 @@ public class AttributeLayoutTest extends TestCase {
         assertTrue(throwsException("name", 1234, ""));
     }
 
+    @Test
     public void testGetCodec() throws Pack200Exception {
         AttributeLayout layout = new AttributeLayout("O",
                 AttributeLayout.CONTEXT_CLASS, "HOBS", 1);
@@ -98,6 +103,7 @@ public class AttributeLayoutTest extends TestCase {
         assertEquals(Codec.BYTE1, layout.getCodec());
     }
 
+    @Test
     public void testLayoutRS() throws Pack200Exception {
         AttributeLayout layout = new AttributeLayout("RS",
                 AttributeLayout.CONTEXT_CLASS, "RS", 1);
@@ -107,6 +113,7 @@ public class AttributeLayoutTest extends TestCase {
         assertEquals("Zwei", ((CPUTF8)layout.getValue(1, segment.getConstantPool())).underlyingString());
     }
 
+    @Test
     public void testLayoutRSN() throws Pack200Exception {
         AttributeLayout layout = new AttributeLayout("RSN",
                 AttributeLayout.CONTEXT_CLASS, "RSN", 1);
@@ -116,6 +123,7 @@ public class AttributeLayoutTest extends TestCase {
         assertEquals("Zwei", ((CPUTF8)layout.getValue(2, segment.getConstantPool())).underlyingString());
     }
 
+    @Test
     public void testLayoutRU() throws Pack200Exception {
         AttributeLayout layout = new AttributeLayout("RU",
                 AttributeLayout.CONTEXT_CLASS, "RU", 1);
@@ -125,6 +133,7 @@ public class AttributeLayoutTest extends TestCase {
         assertEquals("One", ((CPUTF8)layout.getValue(1, segment.getConstantPool())).underlyingString());
     }
 
+    @Test
     public void testLayoutRUN() throws Pack200Exception {
         AttributeLayout layout = new AttributeLayout("RUN",
                 AttributeLayout.CONTEXT_CLASS, "RUN", 1);
@@ -134,7 +143,7 @@ public class AttributeLayoutTest extends TestCase {
         assertEquals("One", ((CPUTF8)layout.getValue(2, segment.getConstantPool())).underlyingString());
     }
 
-    public boolean throwsException(final String name, final int context, final String layout) {
+    private boolean throwsException(final String name, final int context, final String layout) {
         try {
             new AttributeLayout(name, context, layout, -1);
             return false;

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AttributeLayoutTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/AttributeLayoutTest.java
@@ -16,9 +16,10 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
@@ -28,6 +29,11 @@ import org.apache.commons.compress.harmony.unpack200.SegmentConstantPool;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPUTF8;
 import org.apache.commons.compress.harmony.unpack200.bytecode.ClassFileEntry;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 public class AttributeLayoutTest {
 
@@ -69,38 +75,52 @@ public class AttributeLayoutTest {
         }
     }
 
-    @Test
-    public void testBadData() {
-        assertTrue(throwsException(null, AttributeLayout.CONTEXT_CLASS, ""));
-        assertTrue(throwsException("", AttributeLayout.CONTEXT_CLASS, ""));
-        assertTrue(!throwsException("name", AttributeLayout.CONTEXT_CLASS, ""));
-        assertTrue(!throwsException("name", AttributeLayout.CONTEXT_METHOD, ""));
-        assertTrue(!throwsException("name", AttributeLayout.CONTEXT_FIELD, ""));
-        assertTrue(!throwsException("name", AttributeLayout.CONTEXT_CODE, ""));
-        assertTrue(throwsException("name", -1, ""));
-        assertTrue(throwsException("name", 1234, ""));
+    static Stream<Arguments> badData() {
+        return Stream.of(
+                Arguments.of(null, AttributeLayout.CONTEXT_CLASS, ""),
+                Arguments.of("", AttributeLayout.CONTEXT_CLASS, ""),
+                Arguments.of("name", -1, ""),
+                Arguments.of("name", 1234, "")
+        );
     }
 
-    @Test
-    public void testGetCodec() throws Pack200Exception {
-        AttributeLayout layout = new AttributeLayout("O",
-                AttributeLayout.CONTEXT_CLASS, "HOBS", 1);
-        assertEquals(Codec.BRANCH5, layout.getCodec());
-        layout = new AttributeLayout("P", AttributeLayout.CONTEXT_METHOD,
-                "PIN", 1);
-        assertEquals(Codec.BCI5, layout.getCodec());
-        layout = new AttributeLayout("S", AttributeLayout.CONTEXT_FIELD, "HS",
-                1);
-        assertEquals(Codec.SIGNED5, layout.getCodec());
-        layout = new AttributeLayout("RS", AttributeLayout.CONTEXT_CODE,
-                "RRRS", 1);
-        assertEquals(Codec.UNSIGNED5, layout.getCodec());
-        layout = new AttributeLayout("KS", AttributeLayout.CONTEXT_CLASS,
-                "RKS", 1);
-        assertEquals(Codec.UNSIGNED5, layout.getCodec());
-        layout = new AttributeLayout("B", AttributeLayout.CONTEXT_CLASS,
-                "TRKSB", 1);
-        assertEquals(Codec.BYTE1, layout.getCodec());
+    @ParameterizedTest
+    @MethodSource("badData")
+    public void testBadData(final String name, final int context, final String layout) {
+        assertThrows(Pack200Exception.class, () -> new AttributeLayout(name, context, layout, -1));
+    }
+
+    static Stream<Arguments> okData() {
+        return Stream.of(
+                Arguments.of("name", AttributeLayout.CONTEXT_CLASS, ""),
+                Arguments.of("name", AttributeLayout.CONTEXT_METHOD, ""),
+                Arguments.of("name", AttributeLayout.CONTEXT_FIELD, ""),
+                Arguments.of("name", AttributeLayout.CONTEXT_CODE, "")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("okData")
+    public void testOkData(final String name, final int context, final String layout) {
+        assertDoesNotThrow(() -> new AttributeLayout(name, context, layout, -1));
+    }
+
+    static Stream<Arguments> codec() {
+        return Stream.of(
+                Arguments.of("O", AttributeLayout.CONTEXT_CLASS, "HOBS", Codec.BRANCH5),
+                Arguments.of("P", AttributeLayout.CONTEXT_METHOD, "PIN", Codec.BCI5),
+                Arguments.of("S", AttributeLayout.CONTEXT_FIELD, "HS", Codec.SIGNED5),
+                Arguments.of("RS", AttributeLayout.CONTEXT_CODE, "RRRS", Codec.UNSIGNED5),
+                Arguments.of("KS", AttributeLayout.CONTEXT_CLASS, "RKS", Codec.UNSIGNED5),
+                Arguments.of("B", AttributeLayout.CONTEXT_CLASS, "TRKSB", Codec.BYTE1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("codec")
+    public void testGetCodec(final String name, final int context, final String layout, final Codec expectedCodec) throws Pack200Exception {
+        AttributeLayout attributeLayout = new AttributeLayout(name, context, layout, 1);
+        assertEquals(expectedCodec, attributeLayout.getCodec());
     }
 
     @Test
@@ -141,14 +161,5 @@ public class AttributeLayoutTest {
         assertNull(layout.getValue(0, segment.getConstantPool()));
         assertEquals("Zero", ((CPUTF8)layout.getValue(1, segment.getConstantPool())).underlyingString());
         assertEquals("One", ((CPUTF8)layout.getValue(2, segment.getConstantPool())).underlyingString());
-    }
-
-    private boolean throwsException(final String name, final int context, final String layout) {
-        try {
-            new AttributeLayout(name, context, layout, -1);
-            return false;
-        } catch (Pack200Exception e) {
-            return true;
-        }
     }
 }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/BandSetTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/BandSetTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,9 +29,10 @@ import org.apache.commons.compress.harmony.unpack200.BandSet;
 import org.apache.commons.compress.harmony.unpack200.Segment;
 import org.apache.commons.compress.harmony.unpack200.SegmentHeader;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-public class BandSetTest extends TestCase {
+public class BandSetTest {
 
     public class MockSegment extends Segment {
 
@@ -52,32 +55,43 @@ public class BandSetTest extends TestCase {
 
     };
 
+    @Test
     public void testDecodeBandInt() throws IOException, Pack200Exception {
         BHSDCodec codec = Codec.BYTE1;
         byte[] bytes = { (byte) 3, (byte) 56, (byte) 122, (byte) 78 };
         InputStream in = new ByteArrayInputStream(bytes);
         int[] ints = bandSet.decodeBandInt("Test Band", in, codec, 4);
         for (int i = 0; i < ints.length; i++) {
-            assertEquals("Wrong value in position " + i, ints[i], bytes[i]);
+            assertEquals(ints[i], bytes[i], "Wrong value in position " + i);
         }
     }
 
+    @Test
+    @Disabled("TODO: Implement")
     public void testParseFlags1() {
 
     }
 
+    @Test
+    @Disabled("TODO: Implement")
     public void testParseFlags2() {
 
     }
 
+    @Test
+    @Disabled("TODO: Implement")
     public void testParseFlags3() {
 
     }
 
+    @Test
+    @Disabled("TODO: Implement")
     public void testParseReferences1() {
 
     }
 
+    @Test
+    @Disabled("TODO: Implement")
     public void testParseReferences2() {
 
     }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/BcBandsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/BcBandsTest.java
@@ -39,6 +39,10 @@ import org.apache.commons.compress.harmony.unpack200.bytecode.CPMethodRef;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPNameAndType;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPString;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPUTF8;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for Pack200 bytecode bands
@@ -263,6 +267,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcByteBand() throws IOException, Pack200Exception {
         byte[] bytes = { 16, (byte) 132, (byte) 188, (byte) 197,
                 (byte) 255, 8, 8, 8, 8, // bc_byte band
@@ -287,6 +292,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcCaseBands() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 170, (byte) 171, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 255, 2, 5, // bc_case_count
@@ -311,6 +317,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcClassRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 233, (byte) 236, (byte) 255, 8, 8 }; // bc_classref
         // band
@@ -327,6 +334,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcDoubleRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 239, (byte) 255, 8 }; // bc_doubleref
         // band
@@ -337,10 +345,14 @@ public class BcBandsTest extends AbstractBandsTestCase {
         assertEquals(1, bc_doubleref.length);
     }
 
+    @Test
+    @Disabled("TODO: Implement")
     public void testBcEscBands() {
         // TODO
     }
 
+    @Test
+    @Disabled("TODO: Implement")
     public void testBcEscRefBands() {
         // TODO
     }
@@ -351,6 +363,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcFieldRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 178, (byte) 179, (byte) 180,
                 (byte) 181, (byte) 255, 8, 8, 8, 8 }; // bc_fieldref band
@@ -367,6 +380,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcFloatRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 235, (byte) 238, (byte) 255, 8, 8 }; // bc_floatref
         // band
@@ -383,6 +397,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcIMethodRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 185, (byte) 255, 8 }; // bc_imethodref
         // band
@@ -399,11 +414,9 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
+    @Disabled("TODO: Need to fix this testcase so it has enough data to pass.")
     public void testBcInitRefRefBand() throws IOException, Pack200Exception {
-        // TODO: Need to fix this testcase so it has enough data to pass.
-        if (true) {
-            return;
-        }
         byte[] bytes = { (byte) 230, (byte) 231, (byte) 232,
                 (byte) 255, 8, 8, 8 }; // bc_initrefref band
         InputStream in = new ByteArrayInputStream(bytes);
@@ -419,6 +432,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcIntRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 234, (byte) 237, (byte) 255, 8, 8 }; // bc_intref
         // band
@@ -435,6 +449,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcLabelBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 159, (byte) 160, (byte) 161,
                 (byte) 162, (byte) 163, (byte) 164, (byte) 165, (byte) 166,
@@ -466,6 +481,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcLocalBand() throws IOException, Pack200Exception {
         byte[] bytes = { 21, 22, 23, 24, 25, 54, 55, 56, 57, 58,
                 (byte) 169, (byte) 255, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8 }; // bc_local
@@ -482,6 +498,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcLongRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { 20, (byte) 255, 8 }; // bc_longref band
         InputStream in = new ByteArrayInputStream(bytes);
@@ -497,6 +514,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcMethodRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 182, (byte) 183, (byte) 184,
                 (byte) 255, 8, 8, 8 }; // bc_methodref band
@@ -513,6 +531,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcShortBand() throws IOException, Pack200Exception {
         // TODO: Need to fix this testcase so it has enough data to pass.
         byte[] bytes = { 17, (byte) 196, (byte) 132, (byte) 255, 8,
@@ -531,6 +550,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcStringRefBand() throws IOException, Pack200Exception {
         byte[] bytes = { 18, 19, (byte) 255, 8, 8 }; // bc_stringref
         // band
@@ -547,6 +567,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcSuperFieldBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 216, (byte) 217, (byte) 218,
                 (byte) 219, (byte) 223, (byte) 224, (byte) 225, (byte) 226,
@@ -564,11 +585,9 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
+    @Disabled("TODO: Need to fix this testcase so it has enough data to pass.")
     public void testBcSuperMethodBand() throws IOException, Pack200Exception {
-        // TODO: Need to fix this testcase so it has enough data to pass.
-        if (true) {
-            return;
-        }
         byte[] bytes = { (byte) 220, (byte) 221, (byte) 222,
                 (byte) 227, (byte) 228, (byte) 229, (byte) 255, 8, 8, 8, 8, 8,
                 8 }; // bc_supermethod band
@@ -585,6 +604,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcThisFieldBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 202, (byte) 203, (byte) 204,
                 (byte) 205, (byte) 209, (byte) 210, (byte) 211, (byte) 212,
@@ -602,6 +622,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws Pack200Exception
      * @throws IOException
      */
+    @Test
     public void testBcThisMethodBand() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 206, (byte) 207, (byte) 208,
                 (byte) 213, (byte) 214, (byte) 215, (byte) 255, 8, 8, 8, 8, 8,
@@ -619,6 +640,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws IOException
      * @throws Pack200Exception
      */
+    @Test
     public void testMultipleClassesSimple() throws IOException,
             Pack200Exception {
         numClasses = 2;
@@ -640,6 +662,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws IOException
      * @throws Pack200Exception
      */
+    @Test
     public void testMultipleMethodsSimple() throws IOException,
             Pack200Exception {
         numClasses = 2;
@@ -662,6 +685,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
      * @throws IOException
      * @throws Pack200Exception
      */
+    @Test
     public void testSimple() throws IOException, Pack200Exception {
         byte[] bytes = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
                 13, 14, 15, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
@@ -684,6 +708,7 @@ public class BcBandsTest extends AbstractBandsTestCase {
                 bcBands.getMethodByteCodePacked()[0][0].length);
     }
 
+    @Test
     public void testWideForms() throws IOException, Pack200Exception {
         byte[] bytes = { (byte) 196, (byte) 54, // wide istore
                 (byte) 196, (byte) 132, // wide iinc

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/CPUTF8Test.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/CPUTF8Test.java
@@ -16,22 +16,25 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPUTF8;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class CPUTF8Test extends TestCase {
+public class CPUTF8Test {
 
+    @Test
     public void testEquality() {
         CPUTF8 one = new CPUTF8("(III)V", 1);
         CPUTF8 two = new CPUTF8("((I[II)V", 2);
         CPUTF8 three = new CPUTF8("([III)V", 3);
-        assertFalse(one.equals(two));
-        assertFalse(one.equals(three));
-        assertFalse(two.equals(three));
+        assertNotEquals(one, two);
+        assertNotEquals(one, three);
+        assertNotEquals(two, three);
 
-        assertFalse(two.equals(one));
-        assertFalse(three.equals(one));
-        assertFalse(three.equals(two));
+        assertNotEquals(two, one);
+        assertNotEquals(three, one);
+        assertNotEquals(three, two);
     }
 }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ClassBandsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ClassBandsTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,6 +28,7 @@ import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.unpack200.ClassBands;
 import org.apache.commons.compress.harmony.unpack200.CpBands;
 import org.apache.commons.compress.harmony.unpack200.Segment;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -91,7 +94,7 @@ public class ClassBandsTest extends AbstractBandsTestCase {
 
     ClassBands classBands = new ClassBands(new MockSegment());
 
-    public byte[] encodeBandInt(final int[] data, final BHSDCodec codec)
+    private byte[] encodeBandInt(final int[] data, final BHSDCodec codec)
             throws IOException, Pack200Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         for (int i = 0; i < data.length; i++) {
@@ -100,6 +103,7 @@ public class ClassBandsTest extends AbstractBandsTestCase {
         return baos.toByteArray();
     }
 
+    @Test
     public void testSimple() throws IOException, Pack200Exception {
         cpClasses = new String[] { "Class1", "Class2", "Class3", "Interface1",
                 "Interface2" };
@@ -139,6 +143,7 @@ public class ClassBandsTest extends AbstractBandsTestCase {
         cpClasses = null;
     }
 
+    @Test
     public void testWithMethods() throws Pack200Exception, IOException {
         cpClasses = new String[] { "Class1", "Class2", "Class3" };
         cpDescriptor = new String[] { "method1", "method2", "method3" };

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/CodeAttributeTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/CodeAttributeTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,12 +33,12 @@ import org.apache.commons.compress.harmony.unpack200.bytecode.ExceptionTableEntr
 import org.apache.commons.compress.harmony.unpack200.bytecode.LocalVariableTableAttribute;
 import org.apache.commons.compress.harmony.unpack200.bytecode.OperandManager;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for CodeAttribute
  */
-public class CodeAttributeTest extends TestCase {
+public class CodeAttributeTest {
 
 	public class MockCodeAttribute extends CodeAttribute {
 
@@ -140,6 +142,7 @@ public class CodeAttributeTest extends TestCase {
             -49, // return 4
     };
 
+    @Test
     public void testLength() {
         OperandManager operandManager = new MockOperandManager();
         operandManager.setSegment(segment);
@@ -158,6 +161,7 @@ public class CodeAttributeTest extends TestCase {
         assertEquals(37, attribute.getLength());
     }
 
+    @Test
     public void testMixedByteCodes() {
         OperandManager operandManager = new MockOperandManager();
         operandManager.setSegment(segment);
@@ -181,6 +185,7 @@ public class CodeAttributeTest extends TestCase {
         }
     }
 
+    @Test
     public void testSingleByteCodes() {
         OperandManager operandManager = new MockOperandManager();
         operandManager.setSegment(segment);

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ICTupleTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ICTupleTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.commons.compress.harmony.unpack200.IcTuple;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class ICTupleTest extends TestCase {
+public class ICTupleTest {
 
+    @Test
     public void testExplicitClassTupleParsing() {
         IcTuple tuple = new IcTuple("Foo$$2$Local", IcTuple.NESTED_CLASS_FLAG,
                 null, "$2$Local", -1, -1, -1, -1);
@@ -39,6 +42,7 @@ public class ICTupleTest extends TestCase {
         assertEquals("X$1", tuple.outerClassString());
     }
 
+    @Test
     public void testPredictedClassTupleParsing() {
         IcTuple tuple = new IcTuple(
                 "orw/SimpleHelloWorld$SimpleHelloWorldInner", 0, null, null,

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ICTupleTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/ICTupleTest.java
@@ -16,53 +16,53 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.compress.harmony.unpack200.IcTuple;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 public class ICTupleTest {
 
-    @Test
-    public void testExplicitClassTupleParsing() {
-        IcTuple tuple = new IcTuple("Foo$$2$Local", IcTuple.NESTED_CLASS_FLAG,
-                null, "$2$Local", -1, -1, -1, -1);
-        assertEquals("$2$Local", tuple.simpleClassName());
-        assertEquals("Foo$$2", tuple.outerClassString());
-
-        tuple = new IcTuple("Red$Herring", IcTuple.NESTED_CLASS_FLAG,
-                "Red$Herring", null, -1, -1, -1, -1);
-        assertEquals("Herring", tuple.simpleClassName());
-        assertEquals("Red$Herring", tuple.outerClassString());
-
-        tuple = new IcTuple("X$1$Q", IcTuple.NESTED_CLASS_FLAG, "X$1", "Q", -1,
-                -1, -1, -1);
-        assertEquals("Q", tuple.simpleClassName());
-        assertEquals("X$1", tuple.outerClassString());
+    static Stream<Arguments> explicit() {
+        return Stream.of(
+                Arguments.of("Foo$$2$Local", null, "$2$Local", "$2$Local", "Foo$$2"),
+                Arguments.of("Red$Herring", "Red$Herring", null, "Herring", "Red$Herring"),
+                Arguments.of("X$1$Q", "X$1", "Q", "Q", "X$1")
+        );
     }
 
-    @Test
-    public void testPredictedClassTupleParsing() {
-        IcTuple tuple = new IcTuple(
-                "orw/SimpleHelloWorld$SimpleHelloWorldInner", 0, null, null,
-                -1, -1, -1, -1);
-        assertEquals("SimpleHelloWorldInner", tuple.simpleClassName());
-        assertEquals("orw/SimpleHelloWorld", tuple.outerClassString());
+    @ParameterizedTest
+    @MethodSource("explicit")
+    public void testExplicitClassTupleParsing(final String c, final String c2, final String n, final String expectedSimpleClassName, final String expectedOuterClass) {
+        IcTuple tuple = new IcTuple(c, IcTuple.NESTED_CLASS_FLAG, c2, n, -1, -1, -1, -1);
+        assertAll(
+                () -> assertEquals(expectedSimpleClassName, tuple.simpleClassName()),
+                () -> assertEquals(expectedOuterClass, tuple.outerClassString())
+        );
+    }
 
-        tuple = new IcTuple("java/util/AbstractList$2$Local", 0, null, null,
-                -1, -1, -1, -1);
-        assertEquals("Local", tuple.simpleClassName());
-        assertEquals("java/util/AbstractList$2", tuple.outerClassString());
+    static Stream<Arguments> predicted() {
+        return Stream.of(
+                Arguments.of("orw/SimpleHelloWorld$SimpleHelloWorldInner", "SimpleHelloWorldInner", "orw/SimpleHelloWorld"),
+                Arguments.of("java/util/AbstractList$2$Local", "Local", "java/util/AbstractList$2"),
+                Arguments.of("java/util/AbstractList#2#Local", "Local", "java/util/AbstractList$2"),
+                Arguments.of("java/util/AbstractList$1", "1", "java/util/AbstractList")
+        );
+    }
 
-        tuple = new IcTuple("java/util/AbstractList#2#Local", 0, null, null,
-                -1, -1, -1, -1);
-        assertEquals("Local", tuple.simpleClassName());
-        assertEquals("java/util/AbstractList$2", tuple.outerClassString());
-
-        tuple = new IcTuple("java/util/AbstractList$1", 0, null, null, -1, -1,
-                -1, -1);
-        assertEquals("1", tuple.simpleClassName());
-        assertEquals("java/util/AbstractList", tuple.outerClassString());
+    @ParameterizedTest
+    @MethodSource("predicted")
+    public void testPredictedClassTupleParsing(final String c, final String expectedSimpleClass, final String expectedOuterClass) {
+        IcTuple tuple = new IcTuple(c, 0, null, null, -1, -1, -1, -1);
+        assertAll(
+                () -> assertEquals(expectedSimpleClass, tuple.simpleClassName()),
+                () -> assertEquals(expectedOuterClass, tuple.outerClassString())
+        );
     }
 }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/NewAttributeBandsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/NewAttributeBandsTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -30,6 +34,9 @@ import org.apache.commons.compress.harmony.unpack200.NewAttributeBands.Replicati
 import org.apache.commons.compress.harmony.unpack200.NewAttributeBands.Union;
 import org.apache.commons.compress.harmony.unpack200.NewAttributeBands.UnionCase;
 import org.apache.commons.compress.harmony.unpack200.Segment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for unpack200 support for non-predefined attributes
@@ -48,6 +55,7 @@ public class NewAttributeBandsTest extends AbstractBandsTestCase {
         }
     }
 
+    @Test
     public void testEmptyLayout() throws IOException, Pack200Exception {
         MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
                 new MockSegment(), new AttributeLayout("test",
@@ -56,30 +64,22 @@ public class NewAttributeBandsTest extends AbstractBandsTestCase {
         assertEquals(0, layoutElements.size());
     }
 
-    public void testIntegralLayout() throws IOException, Pack200Exception {
-        tryIntegral("B");
-        tryIntegral("FB");
-        tryIntegral("SB");
-        tryIntegral("H");
-        tryIntegral("FH");
-        tryIntegral("SH");
-        tryIntegral("I");
-        tryIntegral("FI");
-        tryIntegral("SI");
-        tryIntegral("PB");
-        tryIntegral("OB");
-        tryIntegral("OSB");
-        tryIntegral("POB");
-        tryIntegral("PH");
-        tryIntegral("OH");
-        tryIntegral("OSH");
-        tryIntegral("POH");
-        tryIntegral("PI");
-        tryIntegral("OI");
-        tryIntegral("OSI");
-        tryIntegral("POI");
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "B", "FB", "SB", "H", "FH", "SH", "I", "FI", "SI", "PB", "OB",
+            "OSB", "POB", "PH", "OH", "OSH", "POH", "PI", "OI", "OSI", "POI"
+    })
+    public void testIntegralLayout(final String layoutStr) throws IOException, Pack200Exception {
+        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
+                new MockSegment(), new AttributeLayout("test",
+                        AttributeLayout.CONTEXT_CLASS, layoutStr, 25));
+        List layoutElements = newAttributeBands.getLayoutElements();
+        assertEquals(1, layoutElements.size());
+        Integral element = (Integral) layoutElements.get(0);
+        assertEquals(layoutStr, element.getTag());
     }
 
+    @Test
     public void testLayoutWithBackwardsCall() throws IOException,
             Pack200Exception {
         MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
@@ -133,6 +133,7 @@ public class NewAttributeBandsTest extends AbstractBandsTestCase {
         assertFalse(firstCallable.isBackwardsCallable());
     }
 
+    @Test
     public void testLayoutWithCalls() throws IOException, Pack200Exception {
         MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
                 new MockSegment(),
@@ -159,27 +160,22 @@ public class NewAttributeBandsTest extends AbstractBandsTestCase {
         assertFalse(thirdCallable.isBackwardsCallable());
     }
 
-    public void testReferenceLayouts() throws IOException, Pack200Exception {
-        tryReference("KIB");
-        tryReference("KIH");
-        tryReference("KII");
-        tryReference("KINH");
-        tryReference("KJH");
-        tryReference("KDH");
-        tryReference("KSH");
-        tryReference("KQH");
-        tryReference("RCH");
-        tryReference("RSH");
-        tryReference("RDH");
-        tryReference("RFH");
-        tryReference("RMH");
-        tryReference("RIH");
-        tryReference("RUH");
-        tryReference("RQH");
-        tryReference("RQNH");
-        tryReference("RQNI");
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "KIB", "KIH", "KII", "KINH", "KJH", "KDH", "KSH", "KQH", "RCH",
+            "RSH", "RDH", "RFH", "RMH", "RIH", "RUH", "RQH", "RQNH", "RQNI"
+    })
+    public void testReferenceLayouts(final String layout) throws IOException, Pack200Exception {
+        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
+                new MockSegment(), new AttributeLayout("test",
+                        AttributeLayout.CONTEXT_CODE, layout, 26));
+        List layoutElements = newAttributeBands.getLayoutElements();
+        assertEquals(1, layoutElements.size());
+        Reference element = (Reference) layoutElements.get(0);
+        assertEquals(layout, element.getTag());
     }
 
+    @Test
     public void testReplicationLayout() throws IOException, Pack200Exception {
         MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
                 new MockSegment(), new AttributeLayout("test",
@@ -203,6 +199,7 @@ public class NewAttributeBandsTest extends AbstractBandsTestCase {
         assertEquals("H", fifthElement.getTag());
     }
 
+    @Test
     public void testUnionLayout() throws IOException, Pack200Exception {
         MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
                 new MockSegment(), new AttributeLayout("test",
@@ -233,24 +230,4 @@ public class NewAttributeBandsTest extends AbstractBandsTestCase {
         assertEquals("RSH", ref.getTag());
     }
 
-    public void tryIntegral(final String layout) throws IOException, Pack200Exception {
-        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
-                new MockSegment(), new AttributeLayout("test",
-                        AttributeLayout.CONTEXT_CLASS, layout, 25));
-        List layoutElements = newAttributeBands.getLayoutElements();
-        assertEquals(1, layoutElements.size());
-        Integral element = (Integral) layoutElements.get(0);
-        assertEquals(layout, element.getTag());
-    }
-
-    private void tryReference(final String layout) throws IOException,
-            Pack200Exception {
-        MockNewAttributeBands newAttributeBands = new MockNewAttributeBands(
-                new MockSegment(), new AttributeLayout("test",
-                        AttributeLayout.CONTEXT_CODE, layout, 26));
-        List layoutElements = newAttributeBands.getLayoutElements();
-        assertEquals(1, layoutElements.size());
-        Reference element = (Reference) layoutElements.get(0);
-        assertEquals(layout, element.getTag());
-    }
 }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentConstantPoolArrayCacheTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentConstantPoolArrayCacheTest.java
@@ -21,10 +21,13 @@ import java.util.List;
 
 import org.apache.commons.compress.harmony.unpack200.SegmentConstantPoolArrayCache;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class SegmentConstantPoolArrayCacheTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+public class SegmentConstantPoolArrayCacheTest {
+
+    @Test
     public void testMultipleArrayMultipleHit() {
         SegmentConstantPoolArrayCache arrayCache = new SegmentConstantPoolArrayCache();
         String arrayOne[] = {"Zero", "Shared", "Two", "Shared", "Shared"};
@@ -57,6 +60,7 @@ public class SegmentConstantPoolArrayCacheTest extends TestCase {
         assertEquals(0, listThree.size());
     }
 
+    @Test
     public void testSingleMultipleHitArray() {
         SegmentConstantPoolArrayCache arrayCache = new SegmentConstantPoolArrayCache();
         String array[] = {"Zero", "OneThreeFour", "Two", "OneThreeFour", "OneThreeFour"};
@@ -67,6 +71,7 @@ public class SegmentConstantPoolArrayCacheTest extends TestCase {
         assertEquals(4, ((Integer)list.get(2)).intValue());
     }
 
+    @Test
     public void testSingleSimpleArray() {
         SegmentConstantPoolArrayCache arrayCache = new SegmentConstantPoolArrayCache();
         String array[] = {"Zero", "One", "Two", "Three", "Four"};

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentConstantPoolTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentConstantPoolTest.java
@@ -16,16 +16,19 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.compress.harmony.unpack200.CpBands;
 import org.apache.commons.compress.harmony.unpack200.Segment;
 import org.apache.commons.compress.harmony.unpack200.SegmentConstantPool;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for org.apache.commons.compress.harmony.unpack200.SegmentConstantPool.
  */
-public class SegmentConstantPoolTest extends TestCase {
+public class SegmentConstantPoolTest {
 
     public class MockSegmentConstantPool extends SegmentConstantPool {
 
@@ -60,6 +63,7 @@ public class SegmentConstantPoolTest extends TestCase {
     String[] testMethodArray = { "<init>()", "clone()", "equals()", "<init>",
             "isNull()", "Other" };
 
+    @Test
     public void testMatchSpecificPoolEntryIndex_DoubleArray() {
         MockSegmentConstantPool mockInstance = new MockSegmentConstantPool();
         // Elements should be found at the proper position.
@@ -84,6 +88,7 @@ public class SegmentConstantPoolTest extends TestCase {
                 "^<init>.*", 1));
     }
 
+    @Test
     public void testMatchSpecificPoolEntryIndex_SingleArray() {
         MockSegmentConstantPool mockInstance = new MockSegmentConstantPool();
         // Elements should be found at the proper position.
@@ -110,6 +115,7 @@ public class SegmentConstantPoolTest extends TestCase {
                 testClassArray, "java/lang/String", 2));
     }
 
+    @Test
     public void testRegexReplacement() {
         MockSegmentConstantPool mockPool = new MockSegmentConstantPool();
         assertTrue(mockPool.regexMatchesVisible(".*", "anything"));

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentOptionsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentOptionsTest.java
@@ -16,28 +16,22 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.unpack200.SegmentOptions;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  *
  */
-public class SegmentOptionsTest extends TestCase {
+public class SegmentOptionsTest {
 
-    public void testUnused() {
-        int[] unused = { 3, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                23, 24, 25, 26, 27, 28, 29, 30, 31 };
-        for (int element : unused) {
-            try {
-                new SegmentOptions(1 << element);
-                fail("Bit "
-                        + element
-                        + " should be unused, but it's not caught during construction");
-            } catch (Pack200Exception e) {
-                assertTrue(true);
-            }
-        }
+    @ParameterizedTest
+    @ValueSource(ints = { 3, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 })
+    public void testUnused(final int element) {
+        assertThrows(Pack200Exception.class, () -> new SegmentOptions(1 << element));
     }
 }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -28,20 +31,20 @@ import java.util.jar.JarOutputStream;
 
 import org.apache.commons.compress.harmony.unpack200.Segment;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for org.apache.commons.compress.harmony.unpack200.Segment.
  */
-public class SegmentTest extends TestCase {
+public class SegmentTest {
 
     InputStream in;
     JarOutputStream out;
     File file;
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @AfterEach
+    public void tearDown() throws Exception {
         if (in != null) {
             try {
                 in.close();
@@ -59,6 +62,7 @@ public class SegmentTest extends TestCase {
         file.delete();
     }
 
+    @Test
     public void testHelloWorld() throws Exception {
         in = Segment.class
                 .getResourceAsStream("/pack200/HelloWorld.pack");
@@ -90,7 +94,7 @@ public class SegmentTest extends TestCase {
         String line2 = reader2.readLine();
         int i = 1;
         while (line1 != null || line2 != null) {
-            assertEquals("Unpacked class files differ", line2, line1);
+            assertEquals(line2, line1, "Unpacked class files differ");
             line1 = reader1.readLine();
             line2 = reader2.readLine();
             i++;
@@ -99,6 +103,7 @@ public class SegmentTest extends TestCase {
         reader2.close();
     }
 
+    @Test
     public void testInterfaceOnly() throws Exception {
         in = Segment.class
                 .getResourceAsStream("/pack200/InterfaceOnly.pack");
@@ -108,6 +113,7 @@ public class SegmentTest extends TestCase {
         segment.unpack(in, out);
     }
 
+    @Test
     public void testJustResources() throws Exception {
         in = Segment.class
                 .getResourceAsStream("/pack200/JustResources.pack");

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentUtilsTest.java
@@ -22,6 +22,11 @@ import org.apache.commons.compress.harmony.unpack200.IMatcher;
 import org.apache.commons.compress.harmony.unpack200.SegmentUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 public class SegmentUtilsTest {
 
@@ -43,32 +48,43 @@ public class SegmentUtilsTest {
     public static final IMatcher even = new MultipleMatches(2);
     public static final IMatcher five = new MultipleMatches(5);
 
-    @Test
-    public void testCountArgs() {
-        assertEquals(0, SegmentUtils.countArgs("()V"));
-        assertEquals(1, SegmentUtils.countArgs("(D)V"));
-        assertEquals(1, SegmentUtils.countArgs("([D)V"));
-        assertEquals(1, SegmentUtils.countArgs("([[D)V"));
-        assertEquals(2, SegmentUtils.countArgs("(DD)V"));
-        assertEquals(3, SegmentUtils.countArgs("(DDD)V"));
-        assertEquals(2, SegmentUtils.countArgs("(Lblah/blah;D)V"));
-        assertEquals(3, SegmentUtils.countArgs("(Lblah/blah;DLbLah;)V"));
+    static Stream<Arguments> countArgs() {
+        return Stream.of(
+                Arguments.of("()V", 0),
+                Arguments.of("(D)V", 1),
+                Arguments.of("([D)V", 1),
+                Arguments.of("([[D)V", 1),
+                Arguments.of("(DD)V", 2),
+                Arguments.of("(DDD)V", 3),
+                Arguments.of("(Lblah/blah;D)V", 2),
+                Arguments.of("(Lblah/blah;DLbLah;)V", 3)
+        );
     }
 
-    @Test
-    public void testCountInvokeInterfaceArgs() {
-        assertEquals(1, SegmentUtils.countInvokeInterfaceArgs("(Z)V"));
-        assertEquals(2, SegmentUtils.countInvokeInterfaceArgs("(D)V"));
-        assertEquals(2, SegmentUtils.countInvokeInterfaceArgs("(J)V"));
-        assertEquals(1, SegmentUtils.countInvokeInterfaceArgs("([D)V"));
-        assertEquals(1, SegmentUtils.countInvokeInterfaceArgs("([[D)V"));
-        assertEquals(4, SegmentUtils.countInvokeInterfaceArgs("(DD)V"));
-        assertEquals(3, SegmentUtils
-                .countInvokeInterfaceArgs("(Lblah/blah;D)V"));
-        assertEquals(4, SegmentUtils
-                .countInvokeInterfaceArgs("(Lblah/blah;DLbLah;)V"));
-        assertEquals(4, SegmentUtils
-                .countInvokeInterfaceArgs("([Lblah/blah;DLbLah;)V"));
+    @ParameterizedTest
+    @MethodSource("countArgs")
+    public void testCountArgs(final String descriptor, final int expectedArgsCount) {
+        assertEquals(expectedArgsCount, SegmentUtils.countArgs(descriptor));
+    }
+
+    static Stream<Arguments> countInvokeInterfaceArgs() {
+        return Stream.of(
+                Arguments.of("(Z)V", 1),
+                Arguments.of("(D)V", 2),
+                Arguments.of("(J)V", 2),
+                Arguments.of("([D)V", 1),
+                Arguments.of("([[D)V", 1),
+                Arguments.of("(DD)V", 4),
+                Arguments.of("(Lblah/blah;D)V", 3),
+                Arguments.of("(Lblah/blah;DLbLah;)V", 4),
+                Arguments.of("([Lblah/blah;DLbLah;)V", 4)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("countInvokeInterfaceArgs")
+    public void testCountInvokeInterfaceArgs(final String descriptor, final int expectedCountInvokeInterfaceArgs) {
+        assertEquals(expectedCountInvokeInterfaceArgs, SegmentUtils.countInvokeInterfaceArgs(descriptor));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentUtilsTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.commons.compress.harmony.unpack200.IMatcher;
 import org.apache.commons.compress.harmony.unpack200.SegmentUtils;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class SegmentUtilsTest extends TestCase {
+public class SegmentUtilsTest {
 
     private static class MultipleMatches implements IMatcher {
 
@@ -41,6 +43,7 @@ public class SegmentUtilsTest extends TestCase {
     public static final IMatcher even = new MultipleMatches(2);
     public static final IMatcher five = new MultipleMatches(5);
 
+    @Test
     public void testCountArgs() {
         assertEquals(0, SegmentUtils.countArgs("()V"));
         assertEquals(1, SegmentUtils.countArgs("(D)V"));
@@ -52,6 +55,7 @@ public class SegmentUtilsTest extends TestCase {
         assertEquals(3, SegmentUtils.countArgs("(Lblah/blah;DLbLah;)V"));
     }
 
+    @Test
     public void testCountInvokeInterfaceArgs() {
         assertEquals(1, SegmentUtils.countInvokeInterfaceArgs("(Z)V"));
         assertEquals(2, SegmentUtils.countInvokeInterfaceArgs("(D)V"));
@@ -67,6 +71,7 @@ public class SegmentUtilsTest extends TestCase {
                 .countInvokeInterfaceArgs("([Lblah/blah;DLbLah;)V"));
     }
 
+    @Test
     public void testMatches() {
         long[] oneToTen = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         assertEquals(6, SegmentUtils.countMatches(new long[][] { oneToTen,

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ByteCodeTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ByteCodeTest.java
@@ -18,10 +18,13 @@ package org.apache.commons.compress.harmony.unpack200.tests.bytecode;
 
 import org.apache.commons.compress.harmony.unpack200.bytecode.ByteCode;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ByteCodeTest extends TestCase {
+import org.junit.jupiter.api.Test;
 
+public class ByteCodeTest {
+
+    @Test
     public void testByteCode() {
         assertEquals("nop", ByteCode.getByteCode(0).getName());
         assertEquals("return", ByteCode.getByteCode(-79).getName());

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ByteCodeTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ByteCodeTest.java
@@ -20,14 +20,25 @@ import org.apache.commons.compress.harmony.unpack200.bytecode.ByteCode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 public class ByteCodeTest {
 
-    @Test
-    public void testByteCode() {
-        assertEquals("nop", ByteCode.getByteCode(0).getName());
-        assertEquals("return", ByteCode.getByteCode(-79).getName());
-        assertEquals("return", ByteCode.getByteCode(177).getName());
+    static Stream<Arguments> byteCode() {
+        return Stream.of(
+                Arguments.of(0, "nop"),
+                Arguments.of(-79, "return"),
+                Arguments.of(177, "return")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("byteCode")
+    public void testByteCode(final int opCode, final String expectedName) {
+        assertEquals(expectedName, ByteCode.getByteCode(opCode).getName());
     }
 }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ClassFileEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ClassFileEntryTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests.bytecode;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPDouble;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPFloat;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPInteger;
@@ -24,22 +28,22 @@ import org.apache.commons.compress.harmony.unpack200.bytecode.CPMember;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPString;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPUTF8;
 import org.apache.commons.compress.harmony.unpack200.bytecode.SourceFileAttribute;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
-
-public class ClassFileEntryTest extends TestCase {
+public class ClassFileEntryTest {
 
     private void checkEquality(Object equal1, Object equal2, String toString,
             Object unequal) {
         assertEquals(equal1, equal2);
         assertEquals(equal1.hashCode(), equal2.hashCode());
         assertTrue(equal1.toString().indexOf(toString) >= 0);
-        assertFalse(equal1.equals(unequal));
-        assertFalse(equal2.equals(unequal));
-        assertFalse(unequal.equals(equal1));
-        assertFalse(unequal.equals(equal2));
+        assertNotEquals(equal1, unequal);
+        assertNotEquals(equal2, unequal);
+        assertNotEquals(unequal, equal1);
+        assertNotEquals(unequal, equal2);
     }
 
+    @Test
     public void testCPDouble() {
         CPDouble cp1 = new CPDouble(new Double(3), 3);
         CPDouble cp2 = new CPDouble(new Double(3), 3);
@@ -47,6 +51,7 @@ public class ClassFileEntryTest extends TestCase {
         checkEquality(cp1, cp2, "3", cp3); //$NON-NLS-1$
     }
 
+    @Test
     public void testCPField() {
         CPMember cp1 = new CPMember(new CPUTF8("Name", 3), new CPUTF8("I", 4),
                 0, null);
@@ -60,6 +65,7 @@ public class ClassFileEntryTest extends TestCase {
         checkEquality(cp1, cp2, "I", cp4); //$NON-NLS-1$
     }
 
+    @Test
     public void testCPFloat() {
         CPFloat cp1 = new CPFloat(new Float(3), 3);
         CPFloat cp2 = new CPFloat(new Float(3), 3);
@@ -67,6 +73,7 @@ public class ClassFileEntryTest extends TestCase {
         checkEquality(cp1, cp2, "3", cp3); //$NON-NLS-1$
     }
 
+    @Test
     public void testCPInteger() {
         CPInteger cp1 = new CPInteger(new Integer(3), 3);
         CPInteger cp2 = new CPInteger(new Integer(3), 3);
@@ -74,6 +81,7 @@ public class ClassFileEntryTest extends TestCase {
         checkEquality(cp1, cp2, "3", cp3); //$NON-NLS-1$
     }
 
+    @Test
     public void testCPLong() {
         CPLong cp1 = new CPLong(new Long(3), 3);
         CPLong cp2 = new CPLong(new Long(3), 3);
@@ -81,6 +89,7 @@ public class ClassFileEntryTest extends TestCase {
         checkEquality(cp1, cp2, "3", cp3); //$NON-NLS-1$
     }
 
+    @Test
     public void testCPString() {
         CPString cp1 = new CPString(new CPUTF8(new String("3"), 3), 3);
         CPString cp2 = new CPString(new CPUTF8(new String("3"), 3), 3);
@@ -88,6 +97,7 @@ public class ClassFileEntryTest extends TestCase {
         checkEquality(cp1, cp2, "3", cp3); //$NON-NLS-1$
     }
 
+    @Test
     public void testSourceAttribute() {
         SourceFileAttribute sfa1 = new SourceFileAttribute(new CPUTF8(
                 new String("Thing.java"), 1)); //$NON-NLS-1$
@@ -98,6 +108,7 @@ public class ClassFileEntryTest extends TestCase {
         checkEquality(sfa1, sfa2, "Thing.java", sfa3); //$NON-NLS-1$
     }
 
+    @Test
     public void testUTF8() {
         CPUTF8 u1 = new CPUTF8(new String("thing"), 1); //$NON-NLS-1$
         CPUTF8 u2 = new CPUTF8(new String("thing"), 1); //$NON-NLS-1$

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ConstantPoolTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/bytecode/ConstantPoolTest.java
@@ -16,23 +16,28 @@
  */
 package org.apache.commons.compress.harmony.unpack200.tests.bytecode;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.compress.harmony.unpack200.Segment;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPClass;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPMember;
 import org.apache.commons.compress.harmony.unpack200.bytecode.CPUTF8;
 import org.apache.commons.compress.harmony.unpack200.bytecode.ClassConstantPool;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ConstantPoolTest extends TestCase {
+public class ConstantPoolTest {
 
     private ClassConstantPool pool;
 
-    @Override
+    @BeforeEach
     public void setUp() {
         pool = new ClassConstantPool();
     }
 
+    @Test
     public void testDuplicateField() {
         CPMember cp1 = new CPMember(new CPUTF8("name", 1), new CPUTF8("I", 2),
                 0, null);
@@ -46,6 +51,7 @@ public class ConstantPoolTest extends TestCase {
         assertEquals(2, pool.size());
     }
 
+    @Test
     public void testDuplicateUTF8() {
         CPUTF8 u1 = new CPUTF8("thing", 1);
         CPUTF8 u2 = new CPUTF8("thing", 1);
@@ -54,12 +60,14 @@ public class ConstantPoolTest extends TestCase {
         assertEquals(1, pool.size());
     }
 
+    @Test
     public void testEntries() {
         pool.add(new CPClass(new CPUTF8("RandomClass", 1), 10));
         pool.add(new CPClass(new CPUTF8("RandomClass2", 2), 20));
         assertEquals(2, pool.entries().size());
     }
 
+    @Test
     public void testIndex() {
         pool.add(new CPUTF8("OtherThing", 1));
         CPUTF8 u1 = new CPUTF8("thing", 2);

--- a/src/test/java/org/apache/commons/compress/java/util/jar/Pack200Test.java
+++ b/src/test/java/org/apache/commons/compress/java/util/jar/Pack200Test.java
@@ -16,15 +16,19 @@
  */
 package org.apache.commons.compress.java.util.jar;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class Pack200Test extends TestCase {
+import org.junit.jupiter.api.Test;
 
+public class Pack200Test {
+
+    @Test
     public void testPacker() {
         Pack200.Packer packer = Pack200.newPacker();
         assertEquals("org.apache.commons.compress.harmony.pack200.Pack200PackerAdapter", packer.getClass().getName());
     }
 
+    @Test
     public void testUnpacker() {
         Pack200.Unpacker unpacker = Pack200.newUnpacker();
         assertEquals("org.apache.commons.compress.harmony.unpack200.Pack200UnpackerAdapter", unpacker.getClass().getName());


### PR DESCRIPTION
Most tests are replaced with simple JUnit 5 tests. A small number of tests were migrated to parameterized tests.