### PR TITLE
COMPRESS-613: Support for extra time data in Zip archives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,13 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>
-    </dependency>    
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveEntry.java
@@ -27,10 +27,10 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Date;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.utils.ExactMath;
+import org.apache.commons.compress.utils.TimeUtils;
 
 /**
  * A cpio archive consists of a sequence of files. There are several types of
@@ -977,7 +977,7 @@ public class CpioArchiveEntry implements CpioConstants, ArchiveEntry {
      *            The time to set.
      */
     public void setTime(final FileTime time) {
-        this.mtime = time.to(TimeUnit.SECONDS);
+        this.mtime = TimeUtils.fileTimeToUnixTime(time);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveEntry.java
@@ -977,7 +977,7 @@ public class CpioArchiveEntry implements CpioConstants, ArchiveEntry {
      *            The time to set.
      */
     public void setTime(final FileTime time) {
-        this.mtime = TimeUtils.fileTimeToUnixTime(time);
+        this.mtime = TimeUtils.toUnixTime(time);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -41,7 +41,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -2069,7 +2068,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
         offset = writeEntryHeaderField(groupId, outbuf, offset, GIDLEN,
                                        starMode);
         offset = writeEntryHeaderField(size, outbuf, offset, SIZELEN, starMode);
-        offset = writeEntryHeaderField(TimeUtils.fileTimeToUnixTime(mTime), outbuf, offset,
+        offset = writeEntryHeaderField(TimeUtils.toUnixTime(mTime), outbuf, offset,
                                        MODTIMELEN, starMode);
 
         final int csOffset = offset;
@@ -2124,7 +2123,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
 
     private int writeEntryHeaderOptionalTimeField(final FileTime time, int offset, final byte[] outbuf, final int fieldLength) {
         if (time != null) {
-            offset = writeEntryHeaderField(TimeUtils.fileTimeToUnixTime(time), outbuf, offset, fieldLength, true);
+            offset = writeEntryHeaderField(TimeUtils.toUnixTime(time), outbuf, offset, fieldLength, true);
         } else {
             offset = fill(0, offset, outbuf, fieldLength);
         }

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -222,7 +222,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
         if (seconds <= 0) {
             return null;
         }
-        return FileTime.from(seconds, TimeUnit.SECONDS);
+        return TimeUtils.unixTimeToFileTime(seconds);
     }
 
     /**
@@ -1528,7 +1528,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
             throw new IOException("broken archive, entry with negative size");
         }
         offset += SIZELEN;
-        mTime = FileTime.from(parseOctalOrBinary(header, offset, MODTIMELEN, lenient), TimeUnit.SECONDS);
+        mTime = TimeUtils.unixTimeToFileTime(parseOctalOrBinary(header, offset, MODTIMELEN, lenient));
         offset += MODTIMELEN;
         checkSumOK = TarUtils.verifyCheckSum(header);
         offset += CHKSUMLEN;
@@ -2069,7 +2069,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
         offset = writeEntryHeaderField(groupId, outbuf, offset, GIDLEN,
                                        starMode);
         offset = writeEntryHeaderField(size, outbuf, offset, SIZELEN, starMode);
-        offset = writeEntryHeaderField(mTime.to(TimeUnit.SECONDS), outbuf, offset,
+        offset = writeEntryHeaderField(TimeUtils.fileTimeToUnixTime(mTime), outbuf, offset,
                                        MODTIMELEN, starMode);
 
         final int csOffset = offset;
@@ -2124,7 +2124,7 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
 
     private int writeEntryHeaderOptionalTimeField(final FileTime time, int offset, final byte[] outbuf, final int fieldLength) {
         if (time != null) {
-            offset = writeEntryHeaderField(time.to(TimeUnit.SECONDS), outbuf, offset, fieldLength, true);
+            offset = writeEntryHeaderField(TimeUtils.fileTimeToUnixTime(time), outbuf, offset, fieldLength, true);
         } else {
             offset = fill(0, offset, outbuf, fieldLength);
         }

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -43,6 +43,7 @@ import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
 import org.apache.commons.compress.utils.CountingOutputStream;
 import org.apache.commons.compress.utils.ExactMath;
 import org.apache.commons.compress.utils.FixedLengthBlockOutputStream;
+import org.apache.commons.compress.utils.TimeUtils;
 
 /**
  * The TarOutputStream writes a UNIX tar archive as an OutputStream. Methods are provided to put
@@ -413,7 +414,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         failForBigNumber("entry size", entry.getSize(), TarConstants.MAXSIZE);
         failForBigNumberWithPosixMessage("group id", entry.getLongGroupId(), TarConstants.MAXID);
         failForBigNumber("last modification time",
-            entry.getLastModifiedTime().to(TimeUnit.SECONDS),
+            TimeUtils.fileTimeToUnixTime(entry.getLastModifiedTime()),
             TarConstants.MAXSIZE);
         failForBigNumber("user id", entry.getLongUserId(), TarConstants.MAXID);
         failForBigNumber("mode", entry.getMode(), TarConstants.MAXID);
@@ -682,11 +683,11 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     }
 
     private void transferModTime(final TarArchiveEntry from, final TarArchiveEntry to) {
-        long fromModTimeSeconds = from.getLastModifiedTime().to(TimeUnit.SECONDS);
+        long fromModTimeSeconds = TimeUtils.fileTimeToUnixTime(from.getLastModifiedTime());
         if (fromModTimeSeconds < 0 || fromModTimeSeconds > TarConstants.MAXSIZE) {
             fromModTimeSeconds = 0;
         }
-        to.setLastModifiedTime(FileTime.from(fromModTimeSeconds, TimeUnit.SECONDS));
+        to.setLastModifiedTime(TimeUtils.unixTimeToFileTime(fromModTimeSeconds));
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -34,7 +34,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -413,7 +413,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
         failForBigNumber("entry size", entry.getSize(), TarConstants.MAXSIZE);
         failForBigNumberWithPosixMessage("group id", entry.getLongGroupId(), TarConstants.MAXID);
         failForBigNumber("last modification time",
-            TimeUtils.fileTimeToUnixTime(entry.getLastModifiedTime()),
+            TimeUtils.toUnixTime(entry.getLastModifiedTime()),
             TarConstants.MAXSIZE);
         failForBigNumber("user id", entry.getLongUserId(), TarConstants.MAXID);
         failForBigNumber("mode", entry.getMode(), TarConstants.MAXID);
@@ -682,7 +682,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     }
 
     private void transferModTime(final TarArchiveEntry from, final TarArchiveEntry to) {
-        long fromModTimeSeconds = TimeUtils.fileTimeToUnixTime(from.getLastModifiedTime());
+        long fromModTimeSeconds = TimeUtils.toUnixTime(from.getLastModifiedTime());
         if (fromModTimeSeconds < 0 || fromModTimeSeconds > TarConstants.MAXSIZE) {
             fromModTimeSeconds = 0;
         }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X000A_NTFS.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X000A_NTFS.java
@@ -91,7 +91,6 @@ public class X000A_NTFS implements ZipExtraField {
         }
         return new ZipEightByteInteger(TimeUtils.toNtfsTime(time));
     }
-
     private static Date zipToDate(final ZipEightByteInteger z) {
         if (z == null || ZipEightByteInteger.ZERO.equals(z)) {
             return null;
@@ -105,12 +104,12 @@ public class X000A_NTFS implements ZipExtraField {
         }
         return TimeUtils.ntfsTimeToFileTime(z.getLongValue());
     }
+
     private ZipEightByteInteger modifyTime = ZipEightByteInteger.ZERO;
 
     private ZipEightByteInteger accessTime = ZipEightByteInteger.ZERO;
 
     private ZipEightByteInteger createTime = ZipEightByteInteger.ZERO;
-
 
     @Override
     public boolean equals(final Object o) {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X000A_NTFS.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X000A_NTFS.java
@@ -68,6 +68,14 @@ import org.apache.commons.compress.utils.TimeUtils;
  * @NotThreadSafe
  */
 public class X000A_NTFS implements ZipExtraField {
+
+    /**
+     * The header ID for this extra field.
+     *
+     * @since 1.23
+     */
+    public static final ZipShort HEADER_ID = new ZipShort(0x000a);
+
     private static final ZipShort TIME_ATTR_TAG = new ZipShort(0x0001);
     private static final ZipShort TIME_ATTR_SIZE = new ZipShort(3 * 8);
 
@@ -83,6 +91,7 @@ public class X000A_NTFS implements ZipExtraField {
         }
         return new ZipEightByteInteger(TimeUtils.toNtfsTime(time));
     }
+
     private static Date zipToDate(final ZipEightByteInteger z) {
         if (z == null || ZipEightByteInteger.ZERO.equals(z)) {
             return null;
@@ -96,12 +105,12 @@ public class X000A_NTFS implements ZipExtraField {
         }
         return TimeUtils.ntfsTimeToFileTime(z.getLongValue());
     }
-
     private ZipEightByteInteger modifyTime = ZipEightByteInteger.ZERO;
 
     private ZipEightByteInteger accessTime = ZipEightByteInteger.ZERO;
 
     private ZipEightByteInteger createTime = ZipEightByteInteger.ZERO;
+
 
     @Override
     public boolean equals(final Object o) {
@@ -114,13 +123,6 @@ public class X000A_NTFS implements ZipExtraField {
         }
         return false;
     }
-
-    /**
-     * The header ID for this extra field.
-     *
-     * @since 1.23
-     */
-    public static final ZipShort HEADER_ID = new ZipShort(0x000a);
 
     /**
      * Gets the access time as a {@link FileTime}

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X000A_NTFS.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X000A_NTFS.java
@@ -68,7 +68,6 @@ import org.apache.commons.compress.utils.TimeUtils;
  * @NotThreadSafe
  */
 public class X000A_NTFS implements ZipExtraField {
-    private static final ZipShort HEADER_ID = new ZipShort(0x000a);
     private static final ZipShort TIME_ATTR_TAG = new ZipShort(0x0001);
     private static final ZipShort TIME_ATTR_SIZE = new ZipShort(3 * 8);
 
@@ -115,6 +114,13 @@ public class X000A_NTFS implements ZipExtraField {
         }
         return false;
     }
+
+    /**
+     * The header ID for this extra field.
+     *
+     * @since 1.23
+     */
+    public static final ZipShort HEADER_ID = new ZipShort(0x000a);
 
     /**
      * Gets the access time as a {@link FileTime}

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestamp.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestamp.java
@@ -83,8 +83,14 @@ import java.util.zip.ZipException;
  * @since 1.5
  */
 public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serializable {
-    private static final ZipShort HEADER_ID = new ZipShort(0x5455);
     private static final long serialVersionUID = 1L;
+
+    /**
+     * The header ID for this extra field.
+     *
+     * @since 1.23
+     */
+    public static final ZipShort HEADER_ID = new ZipShort(0x5455);
 
     /**
      * The bit set inside the flags by when the last modification time

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestamp.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestamp.java
@@ -141,11 +141,11 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
         if (time == null) {
             return null;
         }
-        return unixTimeToZipLong(TimeUtils.fileTimeToUnixTime(time));
+        return unixTimeToZipLong(TimeUtils.toUnixTime(time));
     }
 
     private static ZipLong unixTimeToZipLong(final long l) {
-        if (TimeUtils.exceedsUnixTime(l)) {
+        if (!TimeUtils.isUnixTime(l)) {
             throw new IllegalArgumentException("X5455 timestamps must fit in a signed 32 bit integer: " + l);
         }
         return new ZipLong(l);
@@ -155,7 +155,7 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
         return unixTime != null ? new Date(unixTime.getIntValue() * 1000L) : null;
     }
 
-    private static FileTime zipLongToFileTime(final ZipLong unixTime) {
+    private static FileTime unixTimeToFileTime(final ZipLong unixTime) {
         return unixTime != null ? TimeUtils.unixTimeToFileTime(unixTime.getIntValue()) : null;
     }
     // The 3 boolean fields (below) come from this flags byte.  The remaining 5 bits
@@ -221,11 +221,10 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      * offers only per-second precision.
      *
      * @return modify time as {@link FileTime} or null.
-     *
      * @since 1.23
      */
     public FileTime getAccessFileTime() {
-        return zipLongToFileTime(accessTime);
+        return unixTimeToFileTime(accessTime);
     }
 
     /**
@@ -292,11 +291,10 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      * offers only per-second precision.
      *
      * @return modify time as {@link FileTime} or null.
-     *
      * @since 1.23
      */
     public FileTime getCreateFileTime() {
-        return zipLongToFileTime(createTime);
+        return unixTimeToFileTime(createTime);
     }
 
     /**
@@ -405,11 +403,10 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      * offers only per-second precision.
      *
      * @return modify time as {@link FileTime} or null.
-     *
      * @since 1.23
      */
     public FileTime getModifyFileTime() {
-        return zipLongToFileTime(modifyTime);
+        return unixTimeToFileTime(modifyTime);
     }
 
     /**
@@ -557,7 +554,6 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      * </p>
      *
      * @param time access time as {@link FileTime}
-     *
      * @since 1.23
      */
     public void setAccessFileTime(final FileTime time) {
@@ -609,7 +605,6 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      * </p>
      *
      * @param time create time as {@link FileTime}
-     *
      * @since 1.23
      */
     public void setCreateFileTime(final FileTime time) {
@@ -684,7 +679,6 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      * </p>
      *
      * @param time modify time as {@link FileTime}
-     *
      * @since 1.23
      */
     public void setModifyFileTime(final FileTime time) {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestamp.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestamp.java
@@ -18,7 +18,10 @@
  */
 package org.apache.commons.compress.archivers.zip;
 
+import org.apache.commons.compress.utils.TimeUtils;
+
 import java.io.Serializable;
+import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Objects;
@@ -125,8 +128,24 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
         return unixTimeToZipLong(d.getTime() / 1000);
     }
 
+    /**
+     * Utility method converts {@link FileTime} into a ZipLong (seconds since epoch).
+     * <p/>
+     * Also makes sure the converted ZipLong is not too big to fit
+     * in 32 unsigned bits.
+     *
+     * @param time {@link FileTime} to convert to ZipLong
+     * @return ZipLong
+     */
+    private static ZipLong fileTimeToZipLong(final FileTime time) {
+        if (time == null) {
+            return null;
+        }
+        return unixTimeToZipLong(TimeUtils.fileTimeToUnixTime(time));
+    }
+
     private static ZipLong unixTimeToZipLong(final long l) {
-        if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
+        if (TimeUtils.exceedsUnixTime(l)) {
             throw new IllegalArgumentException("X5455 timestamps must fit in a signed 32 bit integer: " + l);
         }
         return new ZipLong(l);
@@ -136,16 +155,20 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
         return unixTime != null ? new Date(unixTime.getIntValue() * 1000L) : null;
     }
 
+    private static FileTime zipLongToFileTime(final ZipLong unixTime) {
+        return unixTime != null ? TimeUtils.unixTimeToFileTime(unixTime.getIntValue()) : null;
+    }
     // The 3 boolean fields (below) come from this flags byte.  The remaining 5 bits
     // are ignored according to the current version of the spec (December 2012).
-    private byte flags;
 
+    private byte flags;
     // Note: even if bit1 and bit2 are set, the Central data will still not contain
     // access/create fields:  only local data ever holds those!  This causes
     // some of our implementation to look a little odd, with seemingly spurious
     // != null and length checks.
     private boolean bit0_modifyTimePresent;
     private boolean bit1_accessTimePresent;
+
     private boolean bit2_createTimePresent;
 
     private ZipLong modifyTime;
@@ -189,6 +212,20 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      */
     public Date getAccessJavaTime() {
         return zipLongToDate(accessTime);
+    }
+
+    /**
+     * Returns the access time as a {@link FileTime}
+     * of this zip entry, or null if no such timestamp exists in the zip entry.
+     * The milliseconds are always zeroed out, since the underlying data
+     * offers only per-second precision.
+     *
+     * @return modify time as {@link FileTime} or null.
+     *
+     * @since 1.23
+     */
+    public FileTime getAccessFileTime() {
+        return zipLongToFileTime(accessTime);
     }
 
     /**
@@ -246,6 +283,20 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      */
     public Date getCreateJavaTime() {
         return zipLongToDate(createTime);
+    }
+
+    /**
+     * Returns the create time as a {@link FileTime}
+     * of this zip entry, or null if no such timestamp exists in the zip entry.
+     * The milliseconds are always zeroed out, since the underlying data
+     * offers only per-second precision.
+     *
+     * @return modify time as {@link FileTime} or null.
+     *
+     * @since 1.23
+     */
+    public FileTime getCreateFileTime() {
+        return zipLongToFileTime(createTime);
     }
 
     /**
@@ -345,6 +396,20 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      */
     public Date getModifyJavaTime() {
         return zipLongToDate(modifyTime);
+    }
+
+    /**
+     * Returns the modify time as a {@link FileTime}
+     * of this zip entry, or null if no such timestamp exists in the zip entry.
+     * The milliseconds are always zeroed out, since the underlying data
+     * offers only per-second precision.
+     *
+     * @return modify time as {@link FileTime} or null.
+     *
+     * @since 1.23
+     */
+    public FileTime getModifyFileTime() {
+        return zipLongToFileTime(modifyTime);
     }
 
     /**
@@ -482,6 +547,25 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
 
     /**
      * <p>
+     * Sets the acccess time as a {@link FileTime}
+     * of this zip entry. Supplied value is truncated to per-second
+     * precision (milliseconds zeroed-out).
+     * </p><p>
+     * Note: the setters for flags and timestamps are decoupled.
+     * Even if the timestamp is not-null, it will only be written
+     * out if the corresponding bit in the flags is also set.
+     * </p>
+     *
+     * @param time access time as {@link FileTime}
+     *
+     * @since 1.23
+     */
+    public void setAccessFileTime(final FileTime time) {
+        setAccessTime(fileTimeToZipLong(time));
+    }
+
+    /**
+     * <p>
      * Sets the access time (seconds since epoch) of this zip entry
      * using a ZipLong object
      * </p><p>
@@ -512,6 +596,25 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      * @param d create time as java.util.Date
      */
     public void setCreateJavaTime(final Date d) { setCreateTime(dateToZipLong(d)); }
+
+    /**
+     * <p>
+     * Sets the create time as a {@link FileTime}
+     * of this zip entry. Supplied value is truncated to per-second
+     * precision (milliseconds zeroed-out).
+     * </p><p>
+     * Note: the setters for flags and timestamps are decoupled.
+     * Even if the timestamp is not-null, it will only be written
+     * out if the corresponding bit in the flags is also set.
+     * </p>
+     *
+     * @param time create time as {@link FileTime}
+     *
+     * @since 1.23
+     */
+    public void setCreateFileTime(final FileTime time) {
+        setCreateTime(fileTimeToZipLong(time));
+    }
 
     /**
      * <p>
@@ -567,6 +670,25 @@ public class X5455_ExtendedTimestamp implements ZipExtraField, Cloneable, Serial
      */
     public void setModifyJavaTime(final Date d) {
         setModifyTime(dateToZipLong(d));
+    }
+
+    /**
+     * <p>
+     * Sets the modify time as a {@link FileTime}
+     * of this zip entry. Supplied value is truncated to per-second
+     * precision (milliseconds zeroed-out).
+     * </p><p>
+     * Note: the setters for flags and timestamps are decoupled.
+     * Even if the timestamp is not-null, it will only be written
+     * out if the corresponding bit in the flags is also set.
+     * </p>
+     *
+     * @param time modify time as {@link FileTime}
+     *
+     * @since 1.23
+     */
+    public void setModifyFileTime(final FileTime time) {
+        setModifyTime(fileTimeToZipLong(time));
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -22,17 +22,21 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.EntryStreamOffsets;
 import org.apache.commons.compress.utils.ByteUtils;
+import org.apache.commons.compress.utils.TimeUtils;
 
 /**
  * Extension that adds better handling of extra fields and provides
@@ -294,11 +298,14 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
     public ZipArchiveEntry(final File inputFile, final String entryName) {
         this(inputFile.isDirectory() && !entryName.endsWith("/") ?
              entryName + "/" : entryName);
-        if (inputFile.isFile()){
-            setSize(inputFile.length());
+        try {
+            setAttributes(inputFile.toPath());
+        } catch (IOException e) { // NOSONAR
+            if (inputFile.isFile()){
+                setSize(inputFile.length());
+            }
+            setTime(inputFile.lastModified());
         }
-        setTime(inputFile.lastModified());
-        // TODO are there any other fields we can set here?
     }
 
     /**
@@ -315,7 +322,8 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
         setName(entry.getName());
         final byte[] extra = entry.getExtra();
         if (extra != null) {
-            setExtraFields(ExtraFieldUtils.parse(extra, true, ExtraFieldParsingMode.BEST_EFFORT));        } else {
+            setExtraFields(ExtraFieldUtils.parse(extra, true, ExtraFieldParsingMode.BEST_EFFORT));
+        } else {
             // initializes extra data to an empty byte array
             setExtra();
         }
@@ -340,11 +348,18 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
     public ZipArchiveEntry(final Path inputPath, final String entryName, final LinkOption... options) throws IOException {
         this(Files.isDirectory(inputPath, options) && !entryName.endsWith("/") ?
              entryName + "/" : entryName);
-        if (Files.isRegularFile(inputPath, options)){
-            setSize(Files.size(inputPath));
+        setAttributes(inputPath, options);
+    }
+
+    private void setAttributes(final Path inputPath, final LinkOption... options) throws IOException {
+        final BasicFileAttributes attributes = Files.readAttributes(inputPath, BasicFileAttributes.class, options);
+        if (attributes.isRegularFile()) {
+            setSize(attributes.size());
         }
-        setTime(Files.getLastModifiedTime(inputPath, options));
-        // TODO are there any other fields we can set here?
+        super.setLastModifiedTime(attributes.lastModifiedTime());
+        super.setCreationTime(attributes.creationTime());
+        super.setLastAccessTime(attributes.lastAccessTime());
+        setExtraTimeFields();
     }
 
     /**
@@ -373,7 +388,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
         this((java.util.zip.ZipEntry) entry);
         setInternalAttributes(entry.getInternalAttributes());
         setExternalAttributes(entry.getExternalAttributes());
-        setExtraFields(getAllExtraFieldsNoCopy());
+        setExtraFields(entry.getAllExtraFieldsNoCopy());
         setPlatform(entry.getPlatform());
         final GeneralPurposeBit other = entry.getGeneralPurposeBit();
         setGeneralPurposeBit(other == null ? null :
@@ -392,7 +407,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
             unparseableExtra = (UnparseableExtraFieldData) ze;
         } else {
             if (getExtraField(ze.getHeaderId()) != null) {
-                removeExtraField(ze.getHeaderId());
+                internalRemoveExtraField(ze.getHeaderId());
             }
             final ZipExtraField[] copy = extraFields;
             final int newLen = extraFields != null ? extraFields.length + 1 : 1;
@@ -414,19 +429,23 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      * @param ze an extra field
      */
     public void addExtraField(final ZipExtraField ze) {
+        internalAddExtraField(ze);
+        setExtra();
+    }
+
+    private void internalAddExtraField(ZipExtraField ze) {
         if (ze instanceof UnparseableExtraFieldData) {
             unparseableExtra = (UnparseableExtraFieldData) ze;
         } else if (extraFields == null) {
-            extraFields = new ZipExtraField[]{ ze };
+            extraFields = new ZipExtraField[]{ze};
         } else {
             if (getExtraField(ze.getHeaderId()) != null) {
-                removeExtraField(ze.getHeaderId());
+                internalRemoveExtraField(ze.getHeaderId());
             }
             final ZipExtraField[] zipExtraFields = copyOf(extraFields, extraFields.length + 1);
             zipExtraFields[zipExtraFields.length - 1] = ze;
             extraFields = zipExtraFields;
         }
-        setExtra();
     }
 
     /**
@@ -447,6 +466,33 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
         final ZipExtraField[] cpy = new ZipExtraField[length];
         System.arraycopy(src, 0, cpy, 0, Math.min(src.length, length));
         return cpy;
+    }
+
+    @Override
+    public void setTime(long time) {
+        super.setTime(time);
+        setExtraTimeFields();
+    }
+
+    @Override
+    public ZipEntry setLastModifiedTime(FileTime time) {
+        ZipEntry zipEntry = super.setLastModifiedTime(time);
+        setExtraTimeFields();
+        return zipEntry;
+    }
+
+    @Override
+    public ZipEntry setLastAccessTime(FileTime time) {
+        ZipEntry zipEntry = super.setLastAccessTime(time);
+        setExtraTimeFields();
+        return zipEntry;
+    }
+
+    @Override
+    public ZipEntry setCreationTime(FileTime time) {
+        ZipEntry zipEntry = super.setCreationTime(time);
+        setExtraTimeFields();
+        return zipEntry;
     }
 
     /* (non-Javadoc)
@@ -474,7 +520,9 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
         if (otherComment == null) {
             otherComment = "";
         }
-        return getTime() == other.getTime()
+        return Objects.equals(getLastModifiedTime(), other.getLastModifiedTime())
+            && Objects.equals(getLastAccessTime(), other.getLastAccessTime())
+            && Objects.equals(getCreationTime(), other.getCreationTime())
             && myComment.equals(otherComment)
             && getInternalAttributes() == other.getInternalAttributes()
             && getPlatform() == other.getPlatform()
@@ -918,7 +966,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
                     existing = getExtraField(element.getHeaderId());
                 }
                 if (existing == null) {
-                    addExtraField(element);
+                    internalAddExtraField(element);
                 } else {
                     final byte[] b = local ? element.getLocalFileDataData()
                         : element.getCentralDirectoryData();
@@ -939,8 +987,8 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
                             u.setLocalFileDataData(existing.getLocalFileDataData());
                             u.setCentralDirectoryData(b);
                         }
-                        removeExtraField(existing.getHeaderId());
-                        addExtraField(u);
+                        internalRemoveExtraField(existing.getHeaderId());
+                        internalAddExtraField(u);
                     }
                 }
             }
@@ -953,10 +1001,18 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      * @param type the type of extra field to remove
      */
     public void removeExtraField(final ZipShort type) {
-        if (extraFields == null) {
-            throw new java.util.NoSuchElementException();
+        if (getExtraField(type) != null) {
+            internalRemoveExtraField(type);
+        } else {
+            throw new NoSuchElementException();
         }
+        setExtra();
+    }
 
+    private void internalRemoveExtraField(final ZipShort type) {
+        if (extraFields == null) {
+            return;
+        }
         final List<ZipExtraField> newResult = new ArrayList<>();
         for (final ZipExtraField extraField : extraFields) {
             if (!type.equals(extraField.getHeaderId())) {
@@ -964,10 +1020,9 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
             }
         }
         if (extraFields.length == newResult.size()) {
-            throw new java.util.NoSuchElementException();
+            return;
         }
         extraFields = newResult.toArray(ExtraFieldUtils.EMPTY_ZIP_EXTRA_FIELD_ARRAY);
-        setExtra();
     }
 
     /**
@@ -977,7 +1032,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      */
     public void removeUnparseableExtraFieldData() {
         if (unparseableExtra == null) {
-            throw new java.util.NoSuchElementException();
+            throw new NoSuchElementException();
         }
         unparseableExtra = null;
         setExtra();
@@ -996,6 +1051,54 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
                 + 0xffff + " but is " + alignment);
         }
         this.alignment = alignment;
+    }
+
+    private void setExtraTimeFields() {
+        boolean modified = false;
+        if (getExtraField(X5455_ExtendedTimestamp.HEADER_ID) != null) {
+            internalRemoveExtraField(X5455_ExtendedTimestamp.HEADER_ID);
+            modified = true;
+        }
+        if (getExtraField(X000A_NTFS.HEADER_ID) != null) {
+            internalRemoveExtraField(X000A_NTFS.HEADER_ID);
+            modified = true;
+        }
+        if (requiresExtraTimeFields()) {
+            final X000A_NTFS ntfsTimestamp = new X000A_NTFS();
+            final FileTime lastModifiedTime = getLastModifiedTime();
+            if (lastModifiedTime != null) {
+                ntfsTimestamp.setModifyFileTime(lastModifiedTime);
+            }
+            final FileTime lastAccessTime = getLastAccessTime();
+            if (lastAccessTime != null) {
+                ntfsTimestamp.setAccessFileTime(lastAccessTime);
+            }
+            final FileTime creationTime = getCreationTime();
+            if (creationTime != null) {
+                ntfsTimestamp.setCreateFileTime(creationTime);
+            }
+            internalAddExtraField(ntfsTimestamp);
+            modified = true;
+        }
+        if (modified) {
+            setExtra();
+        }
+    }
+
+    private boolean requiresExtraTimeFields() {
+        if (getLastAccessTime() != null || getCreationTime() != null) {
+            return true;
+        }
+        final FileTime modifyTime = getLastModifiedTime();
+        return modifyTime != null && (exceedsMaximumTimeLimits(modifyTime) || isHighPrecision(modifyTime));
+    }
+
+    private static boolean exceedsMaximumTimeLimits(FileTime time) {
+        return ZipUtil.exceedsDosTime(time) || TimeUtils.exceedsUnixTime(time);
+    }
+
+    private static boolean isHighPrecision(FileTime time) {
+        return time.toInstant().getNano() != 0;
     }
 
     /**
@@ -1049,13 +1152,70 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
     }
 
     /**
-     * Unfortunately {@link java.util.zip.ZipOutputStream
-     * java.util.zip.ZipOutputStream} seems to access the extra data
-     * directly, so overriding getExtra doesn't help - we need to
-     * modify super's data directly.
+     * Unfortunately {@link java.util.zip.ZipOutputStream} seems to
+     * access the extra data directly, so overriding getExtra doesn't
+     * help - we need to modify super's data directly and on every update.
      */
     protected void setExtra() {
+        // ZipEntry will update the time fields here
         super.setExtra(ExtraFieldUtils.mergeLocalFileDataData(getAllExtraFieldsNoCopy()));
+        // Let ZipEntry process the times, but overwrite the modifications afterwards
+        updateTimeFieldsFromExtraFields();
+    }
+
+    private void updateTimeFieldsFromExtraFields() {
+        // Update times from X5455_ExtendedTimestamp field
+        updateTimeFromExtendedTimestampField();
+        // Update times from X000A_NTFS field, overriding X5455_ExtendedTimestamp if both are present
+        updateTimeFromNtfsField();
+    }
+
+    /**
+     * Workaround for the fact that, as of Java 17, {@link java.util.zip.ZipEntry} does not properly modify
+     * the entry's {@code xdostime} field, only setting {@code mtime}. While this is not strictly necessary,
+     * it's better to maintain the same behavior between this and the NTFS field.
+     */
+    private void updateTimeFromExtendedTimestampField() {
+        final ZipExtraField extraField = getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
+        if (extraField instanceof X5455_ExtendedTimestamp) {
+            final X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) extraField;
+            if (extendedTimestamp.isBit0_modifyTimePresent() && extendedTimestamp.getModifyTime() != null) {
+                final int unixTime = extendedTimestamp.getModifyTime().getIntValue();
+                super.setLastModifiedTime(TimeUtils.unixTimeToFileTime(unixTime));
+            }
+            if (extendedTimestamp.isBit1_accessTimePresent() && extendedTimestamp.getAccessTime() != null) {
+                final int unixTime = extendedTimestamp.getAccessTime().getIntValue();
+                super.setLastAccessTime(TimeUtils.unixTimeToFileTime(unixTime));
+            }
+            if (extendedTimestamp.isBit2_createTimePresent() && extendedTimestamp.getCreateTime() != null) {
+                final int unixTime = extendedTimestamp.getCreateTime().getIntValue();
+                super.setCreationTime(TimeUtils.unixTimeToFileTime(unixTime));
+            }
+        }
+    }
+
+    /**
+     * Workaround for the fact that, as of Java 17, {@link java.util.zip.ZipEntry} parses NTFS
+     * timestamps with a maximum precision of microseconds, which is lower than the 100ns precision
+     * provided by this extra field.
+     */
+    private void updateTimeFromNtfsField() {
+        final ZipExtraField extraField = getExtraField(X000A_NTFS.HEADER_ID);
+        if (extraField instanceof X000A_NTFS) {
+            final X000A_NTFS ntfsTimestamp = (X000A_NTFS) extraField;
+            final FileTime modifyTime = ntfsTimestamp.getModifyFileTime();
+            if (modifyTime != null) {
+                super.setLastModifiedTime(modifyTime);
+            }
+            final FileTime accessTime = ntfsTimestamp.getAccessFileTime();
+            if (accessTime != null) {
+                super.setLastAccessTime(accessTime);
+            }
+            final FileTime creationTime = ntfsTimestamp.getCreateFileTime();
+            if (creationTime != null) {
+                super.setCreationTime(creationTime);
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -508,13 +508,13 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      */
     @Override
     public void setTime(final long time) {
-        if (ZipUtil.exceedsDosTime(time)) {
-            setLastModifiedTime(FileTime.fromMillis(time));
-        } else {
+        if (ZipUtil.isDosTime(time)) {
             super.setTime(time);
             this.time = time;
             lastModifiedDateSet = false;
             setExtraTimeFields();
+        } else {
+            setLastModifiedTime(FileTime.fromMillis(time));
         }
     }
 
@@ -1114,7 +1114,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
             final FileTime lastModifiedTime = getLastModifiedTime();
             final FileTime lastAccessTime = getLastAccessTime();
             final FileTime creationTime = getCreationTime();
-            if (fitsInInfoZipExtendedTimestamp(lastModifiedTime, lastAccessTime, creationTime)) {
+            if (canConvertToInfoZipExtendedTimestamp(lastModifiedTime, lastAccessTime, creationTime)) {
                 addInfoZipExtendedTimestamp(lastModifiedTime, lastAccessTime, creationTime);
             }
             addNTFSTimestamp(lastModifiedTime, lastAccessTime, creationTime);
@@ -1163,13 +1163,13 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
         internalAddExtraField(ntfsTimestamp);
     }
 
-    private static boolean fitsInInfoZipExtendedTimestamp(
+    private static boolean canConvertToInfoZipExtendedTimestamp(
             final FileTime lastModifiedTime,
             final FileTime lastAccessTime,
             final FileTime creationTime) {
-        return !TimeUtils.exceedsUnixTime(lastModifiedTime)
-                && !TimeUtils.exceedsUnixTime(lastAccessTime)
-                && !TimeUtils.exceedsUnixTime(creationTime);
+        return TimeUtils.isUnixTime(lastModifiedTime)
+                && TimeUtils.isUnixTime(lastAccessTime)
+                && TimeUtils.isUnixTime(creationTime);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
@@ -377,8 +377,6 @@ public class ZipArchiveOutputStream extends ArchiveOutputStream {
 
     private final byte[] copyBuffer = new byte[32768];
 
-    private final Calendar calendarInstance = Calendar.getInstance();
-
     /**
      * Whether we are creating a split zip
      */
@@ -820,7 +818,7 @@ public class ZipArchiveOutputStream extends ArchiveOutputStream {
 
 
         // last mod. time and date
-        ZipUtil.toDosTime(calendarInstance, ze.getTime(), buf, CFH_TIME_OFFSET);
+        ZipUtil.toDosTime(ze.getTime(), buf, CFH_TIME_OFFSET);
 
         // CRC
         // compressed length
@@ -926,7 +924,7 @@ public class ZipArchiveOutputStream extends ArchiveOutputStream {
         // compression method
         ZipShort.putShort(zipMethod, buf, LFH_METHOD_OFFSET);
 
-        ZipUtil.toDosTime(calendarInstance, ze.getTime(), buf, LFH_TIME_OFFSET);
+        ZipUtil.toDosTime(ze.getTime(), buf, LFH_TIME_OFFSET);
 
         // CRC
         if (phased || !(zipMethod == DEFLATED || channel != null)){

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
@@ -196,10 +196,7 @@ public abstract class ZipUtil {
 
     /**
      * Converts DOS time to Java time (number of milliseconds since
-     * epoch). Accepts the extended DOS format used by {@link ZipEntry},
-     * where up to 1999 milliseconds can be stored in the upper
-     * 32 bits of the DOS time.
-     *
+     * epoch).
      * @param dosTime time to convert
      * @return converted time
      */
@@ -214,7 +211,7 @@ public abstract class ZipUtil {
         cal.set(Calendar.SECOND, (int) (dosTime << 1) & 0x3e);
         cal.set(Calendar.MILLISECOND, 0);
         // CheckStyle:MagicNumberCheck ON
-        return cal.getTime().getTime() + (dosTime >> 32);
+        return cal.getTime().getTime();
     }
 
     /**
@@ -372,15 +369,6 @@ public abstract class ZipUtil {
             || entry.getMethod() == ZipMethod.BZIP2.getCode();
     }
 
-    /**
-     * Converts Java time to DOS time, encoding any milliseconds lost in the conversion
-     * into the upper 32 bits of the returned long.
-     *
-     * @param c the calendar object used for data conversion
-     * @param t milliseconds since epoch
-     * @param buf the byte buffer where to put the resulting long
-     * @param offset the offset in the buffer from which to start writing
-     */
     static void toDosTime(final Calendar c, final long t, final byte[] buf, final int offset) {
         c.setTimeInMillis(t);
 
@@ -389,15 +377,13 @@ public abstract class ZipUtil {
             copy(DOSTIME_BEFORE_1980_BYTES, buf, offset); // stop callers from changing the array
             return;
         }
-        long value =  ((year - 1980) << 25)
-                |     ((c.get(Calendar.MONTH) + 1) << 21)
-                |     (c.get(Calendar.DAY_OF_MONTH) << 16)
-                |     (c.get(Calendar.HOUR_OF_DAY) << 11)
-                |     (c.get(Calendar.MINUTE) << 5)
-                |     (c.get(Calendar.SECOND) >> 1);
-        if (value != DOSTIME_BEFORE_1980) {
-            value += ((t % 2000) << 32);
-        }
+        final int month = c.get(Calendar.MONTH) + 1;
+        final long value =  ((year - 1980) << 25)
+                |         (month << 21)
+                |         (c.get(Calendar.DAY_OF_MONTH) << 16)
+                |         (c.get(Calendar.HOUR_OF_DAY) << 11)
+                |         (c.get(Calendar.MINUTE) << 5)
+                |         (c.get(Calendar.SECOND) >> 1);
         ZipLong.putLong(value, buf, offset);
     }
 

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
@@ -103,14 +103,14 @@ public abstract class ZipUtil {
     private static final long UPPER_DOSTIME_BOUND = 128L * 365 * 24 * 60 * 60 * 1000;
 
     /**
-     * Checks if a given time exceeds the boundaries of a DOS time
+     * Tests whether a given time (in milliseconds since Epoch) can be safely represented as DOS time
      *
-     * @param millis time in milliseconds since epoch
-     * @return true if the time exceeds the boundaries of a DOS time, false otherwise
+     * @param time time in milliseconds since epoch
+     * @return true if the time can be safely represented as DOS time, false otherwise
      * @since 1.23
      */
-    public static boolean exceedsDosTime(final long millis) {
-        return millis > UPPER_DOSTIME_BOUND || javaToDosTime(millis) == DOSTIME_BEFORE_1980;
+    public static boolean isDosTime(final long time) {
+        return time <= UPPER_DOSTIME_BOUND && javaToDosTime(time) != DOSTIME_BEFORE_1980;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
@@ -46,6 +46,40 @@ public final class TimeUtils {
      */
     static final long WINDOWS_EPOCH_OFFSET = -116444736000000000L;
 
+    /** The upper bound of the 32-bit unix time, the "year 2038 problem" */
+    public static final long UPPER_UNIXTIME_BOUND = 0x7fffffff;
+
+    /**
+     * Converts "standard UNIX time" (in seconds, UTC/GMT) to {@link FileTime}.
+     *
+     * @param time UNIX timestamp
+     * @return the corresponding FileTime
+     */
+    public static FileTime unixTimeToFileTime(final long time) {
+        return FileTime.from(time, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Converts {@link FileTime} to "standard UNIX time".
+     *
+     * @param time the original FileTime
+     * @return the UNIX timestamp
+     */
+    public static long fileTimeToUnixTime(final FileTime time) {
+        return time.to(TimeUnit.SECONDS);
+    }
+
+    /**
+     * Checks whether a FileTime exceeds the maximum for the "standard UNIX time".
+     * If the FileTime is null, this method always returns false.
+     *
+     * @param time the FileTime to evaluate, can be null
+     * @return true if the time exceeds the maximum UNIX time, false otherwise
+     */
+    public static boolean exceedsUnixTime(final FileTime time) {
+        return time != null && fileTimeToUnixTime(time) > UPPER_UNIXTIME_BOUND;
+    }
+
     /**
      * Converts NTFS time (100 nanosecond units since 1 January 1601) to Java time.
      *

--- a/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
@@ -46,9 +46,6 @@ public final class TimeUtils {
      */
     static final long WINDOWS_EPOCH_OFFSET = -116444736000000000L;
 
-    /** The upper bound of the 32-bit unix time, the "year 2038 problem" */
-    public static final long UPPER_UNIXTIME_BOUND = 0x7fffffff;
-
     /**
      * Converts "standard UNIX time" (in seconds, UTC/GMT) to {@link FileTime}.
      *
@@ -70,14 +67,39 @@ public final class TimeUtils {
     }
 
     /**
-     * Checks whether a FileTime exceeds the maximum for the "standard UNIX time".
+     * Converts Java time (milliseconds since Epoch) to "standard UNIX time".
+     *
+     * @param time the original Java time
+     * @return the UNIX timestamp
+     */
+    public static long javaTimeToUnixTime(final long time) {
+        return time / 1000L;
+    }
+
+    /**
+     * Checks whether a FileTime exceeds the minimum or maximum for the "standard UNIX time".
      * If the FileTime is null, this method always returns false.
      *
      * @param time the FileTime to evaluate, can be null
-     * @return true if the time exceeds the maximum UNIX time, false otherwise
+     * @return true if the time exceeds the minimum or maximum UNIX time, false otherwise
      */
     public static boolean exceedsUnixTime(final FileTime time) {
-        return time != null && fileTimeToUnixTime(time) > UPPER_UNIXTIME_BOUND;
+        if (time == null) {
+            return false;
+        }
+        final long fileTimeToUnixTime = fileTimeToUnixTime(time);
+        return exceedsUnixTime(fileTimeToUnixTime);
+    }
+
+    /**
+     * Checks whether a given number of seconds (since Epoch) exceeds the minimum or
+     * maximum for the "standard UNIX time".
+     *
+     * @param seconds the UNIX seconds to evaluate
+     * @return true if the time exceeds the minimum or maximum UNIX time, false otherwise
+     */
+    public static boolean exceedsUnixTime(final long seconds) {
+        return seconds < Integer.MIN_VALUE || seconds > Integer.MAX_VALUE;
     }
 
     /**
@@ -139,7 +161,17 @@ public final class TimeUtils {
      * @return the NTFS time
      */
     public static long toNtfsTime(final Date date) {
-        final long javaHundredNanos = date.getTime() * HUNDRED_NANOS_PER_MILLISECOND;
+        return toNtfsTime(date.getTime());
+    }
+
+    /**
+     * Converts Java time (milliseconds since Epoch) to NTFS time.
+     *
+     * @param time the Java time
+     * @return the NTFS time
+     */
+    public static long toNtfsTime(final long time) {
+        final long javaHundredNanos = time * HUNDRED_NANOS_PER_MILLISECOND;
         return Math.subtractExact(javaHundredNanos, WINDOWS_EPOCH_OFFSET);
     }
 

--- a/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
@@ -62,7 +62,7 @@ public final class TimeUtils {
      * @param time the original FileTime
      * @return the UNIX timestamp
      */
-    public static long fileTimeToUnixTime(final FileTime time) {
+    public static long toUnixTime(final FileTime time) {
         return time.to(TimeUnit.SECONDS);
     }
 
@@ -77,29 +77,29 @@ public final class TimeUtils {
     }
 
     /**
-     * Checks whether a FileTime exceeds the minimum or maximum for the standard UNIX time.
-     * If the FileTime is null, this method always returns false.
+     * Tests whether a FileTime can be safely represented in the standard UNIX time.
+     *
+     * <p>If the FileTime is null, this method always returns true.</p>
      *
      * @param time the FileTime to evaluate, can be null
      * @return true if the time exceeds the minimum or maximum UNIX time, false otherwise
      */
-    public static boolean exceedsUnixTime(final FileTime time) {
+    public static boolean isUnixTime(final FileTime time) {
         if (time == null) {
-            return false;
+            return true;
         }
-        final long fileTimeToUnixTime = fileTimeToUnixTime(time);
-        return exceedsUnixTime(fileTimeToUnixTime);
+        final long fileTimeToUnixTime = toUnixTime(time);
+        return isUnixTime(fileTimeToUnixTime);
     }
 
     /**
-     * Checks whether a given number of seconds (since Epoch) exceeds the minimum or
-     * maximum for the standard UNIX time.
+     * Tests whether a given number of seconds (since Epoch) can be safely represented in the standard UNIX time.
      *
-     * @param seconds the UNIX seconds to evaluate
-     * @return true if the time exceeds the minimum or maximum UNIX time, false otherwise
+     * @param seconds the number of seconds (since Epoch) to evaluate
+     * @return true if the time can be represented in the standard UNIX time, false otherwise
      */
-    public static boolean exceedsUnixTime(final long seconds) {
-        return seconds < Integer.MIN_VALUE || seconds > Integer.MAX_VALUE;
+    public static boolean isUnixTime(final long seconds) {
+        return Integer.MIN_VALUE <= seconds && seconds <= Integer.MAX_VALUE;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/TimeUtils.java
@@ -47,7 +47,7 @@ public final class TimeUtils {
     static final long WINDOWS_EPOCH_OFFSET = -116444736000000000L;
 
     /**
-     * Converts "standard UNIX time" (in seconds, UTC/GMT) to {@link FileTime}.
+     * Converts standard UNIX time (in seconds, UTC/GMT) to {@link FileTime}.
      *
      * @param time UNIX timestamp
      * @return the corresponding FileTime
@@ -57,7 +57,7 @@ public final class TimeUtils {
     }
 
     /**
-     * Converts {@link FileTime} to "standard UNIX time".
+     * Converts {@link FileTime} to standard UNIX time.
      *
      * @param time the original FileTime
      * @return the UNIX timestamp
@@ -67,7 +67,7 @@ public final class TimeUtils {
     }
 
     /**
-     * Converts Java time (milliseconds since Epoch) to "standard UNIX time".
+     * Converts Java time (milliseconds since Epoch) to standard UNIX time.
      *
      * @param time the original Java time
      * @return the UNIX timestamp
@@ -77,7 +77,7 @@ public final class TimeUtils {
     }
 
     /**
-     * Checks whether a FileTime exceeds the minimum or maximum for the "standard UNIX time".
+     * Checks whether a FileTime exceeds the minimum or maximum for the standard UNIX time.
      * If the FileTime is null, this method always returns false.
      *
      * @param time the FileTime to evaluate, can be null
@@ -93,7 +93,7 @@ public final class TimeUtils {
 
     /**
      * Checks whether a given number of seconds (since Epoch) exceeds the minimum or
-     * maximum for the "standard UNIX time".
+     * maximum for the standard UNIX time.
      *
      * @param seconds the UNIX seconds to evaluate
      * @return true if the time exceeds the minimum or maximum UNIX time, false otherwise

--- a/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveOutputStreamTest.java
@@ -25,9 +25,13 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Instant;
 
 import org.apache.commons.compress.AbstractTestCase;
-import org.apache.commons.compress.archivers.zip.*;
+import org.apache.commons.compress.archivers.zip.JarMarker;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.junit.jupiter.api.Test;
 
 public class JarArchiveOutputStreamTest {
@@ -41,9 +45,15 @@ public class JarArchiveOutputStreamTest {
         try {
 
             out = new JarArchiveOutputStream(Files.newOutputStream(testArchive.toPath()));
-            out.putArchiveEntry(new ZipArchiveEntry("foo/"));
+            ZipArchiveEntry ze1 = new ZipArchiveEntry("foo/");
+            // Ensure we won't accidentally add an Extra field.
+            ze1.setTime(Instant.parse("2022-12-27T12:10:23Z").toEpochMilli());
+            out.putArchiveEntry(ze1);
             out.closeArchiveEntry();
-            out.putArchiveEntry(new ZipArchiveEntry("bar/"));
+            ZipArchiveEntry ze2 = new ZipArchiveEntry("bar/");
+            // Ensure we won't accidentally add an Extra field.
+            ze2.setTime(Instant.parse("2022-12-28T02:56:01Z").toEpochMilli());
+            out.putArchiveEntry(ze2);
             out.closeArchiveEntry();
             out.finish();
             out.close();

--- a/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveOutputStreamTest.java
@@ -27,10 +27,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.apache.commons.compress.AbstractTestCase;
-import org.apache.commons.compress.archivers.zip.JarMarker;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipExtraField;
-import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.*;
 import org.junit.jupiter.api.Test;
 
 public class JarArchiveOutputStreamTest {
@@ -56,13 +53,15 @@ public class JarArchiveOutputStreamTest {
             ZipArchiveEntry ze = zf.getEntry("foo/");
             assertNotNull(ze);
             ZipExtraField[] fes = ze.getExtraFields();
-            assertEquals(1, fes.length);
+            assertEquals(2, fes.length);
             assertTrue(fes[0] instanceof JarMarker);
+            assertTrue(fes[1] instanceof X000A_NTFS);
 
             ze = zf.getEntry("bar/");
             assertNotNull(ze);
             fes = ze.getExtraFields();
-            assertEquals(0, fes.length);
+            assertEquals(1, fes.length);
+            assertTrue(fes[0] instanceof X000A_NTFS);
         } finally {
             if (out != null) {
                 try {

--- a/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveOutputStreamTest.java
@@ -53,15 +53,13 @@ public class JarArchiveOutputStreamTest {
             ZipArchiveEntry ze = zf.getEntry("foo/");
             assertNotNull(ze);
             ZipExtraField[] fes = ze.getExtraFields();
-            assertEquals(2, fes.length);
+            assertEquals(1, fes.length);
             assertTrue(fes[0] instanceof JarMarker);
-            assertTrue(fes[1] instanceof X000A_NTFS);
 
             ze = zf.getEntry("bar/");
             assertNotNull(ze);
             fes = ze.getExtraFields();
-            assertEquals(1, fes.length);
-            assertTrue(fes[0] instanceof X000A_NTFS);
+            assertEquals(0, fes.length);
         } finally {
             if (out != null) {
                 try {

--- a/src/test/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestampTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestampTest.java
@@ -36,11 +36,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -226,54 +228,113 @@ public class X5455_ExtendedTimestampTest {
         // get/set modify time
         xf.setModifyTime(time);
         assertEquals(time, xf.getModifyTime());
-        final Date xfModifyJavaTime = xf.getModifyJavaTime();
-        assertEquals(timeMillis, xfModifyJavaTime.getTime());
+        assertEquals(timeMillis, xf.getModifyJavaTime().getTime());
+        assertEquals(timeMillis, xf.getModifyFileTime().toMillis());
+        assertTrue(xf.isBit0_modifyTimePresent());
         xf.setModifyJavaTime(new Date(timeMillis));
         assertEquals(time, xf.getModifyTime());
         assertEquals(timeMillis, xf.getModifyJavaTime().getTime());
+        assertEquals(timeMillis, xf.getModifyFileTime().toMillis());
+        assertTrue(xf.isBit0_modifyTimePresent());
         // Make sure milliseconds get zeroed out:
         xf.setModifyJavaTime(new Date(timeMillis + 123));
         assertEquals(time, xf.getModifyTime());
         assertEquals(timeMillis, xf.getModifyJavaTime().getTime());
+        assertEquals(timeMillis, xf.getModifyFileTime().toMillis());
+        assertTrue(xf.isBit0_modifyTimePresent());
+        // Make sure it works correctly for FileTime
+        xf.setModifyFileTime(FileTime.fromMillis(timeMillis + 123));
+        assertEquals(time, xf.getModifyTime());
+        assertEquals(timeMillis, xf.getModifyJavaTime().getTime());
+        assertEquals(timeMillis, xf.getModifyFileTime().toMillis());
+        assertTrue(xf.isBit0_modifyTimePresent());
         // Null
         xf.setModifyTime(null);
         assertNull(xf.getModifyJavaTime());
+        assertNull(xf.getModifyFileTime());
+        assertFalse(xf.isBit0_modifyTimePresent());
         xf.setModifyJavaTime(null);
         assertNull(xf.getModifyTime());
+        assertNull(xf.getModifyFileTime());
+        assertFalse(xf.isBit0_modifyTimePresent());
+        xf.setModifyFileTime(null);
+        assertNull(xf.getModifyJavaTime());
+        assertNull(xf.getModifyTime());
+        assertFalse(xf.isBit0_modifyTimePresent());
 
         // get/set access time
         xf.setAccessTime(time);
         assertEquals(time, xf.getAccessTime());
         assertEquals(timeMillis, xf.getAccessJavaTime().getTime());
+        assertEquals(timeMillis, xf.getAccessFileTime().toMillis());
+        assertTrue(xf.isBit1_accessTimePresent());
         xf.setAccessJavaTime(new Date(timeMillis));
         assertEquals(time, xf.getAccessTime());
         assertEquals(timeMillis, xf.getAccessJavaTime().getTime());
+        assertEquals(timeMillis, xf.getAccessFileTime().toMillis());
+        assertTrue(xf.isBit1_accessTimePresent());
         // Make sure milliseconds get zeroed out:
         xf.setAccessJavaTime(new Date(timeMillis + 123));
         assertEquals(time, xf.getAccessTime());
         assertEquals(timeMillis, xf.getAccessJavaTime().getTime());
+        assertEquals(timeMillis, xf.getAccessFileTime().toMillis());
+        assertTrue(xf.isBit1_accessTimePresent());
+        // Make sure it works correctly for FileTime
+        xf.setAccessFileTime(FileTime.fromMillis(timeMillis + 123));
+        assertEquals(time, xf.getAccessTime());
+        assertEquals(timeMillis, xf.getAccessJavaTime().getTime());
+        assertEquals(timeMillis, xf.getAccessFileTime().toMillis());
+        assertTrue(xf.isBit1_accessTimePresent());
         // Null
         xf.setAccessTime(null);
         assertNull(xf.getAccessJavaTime());
+        assertNull(xf.getAccessFileTime());
+        assertFalse(xf.isBit1_accessTimePresent());
         xf.setAccessJavaTime(null);
         assertNull(xf.getAccessTime());
+        assertNull(xf.getAccessFileTime());
+        assertFalse(xf.isBit1_accessTimePresent());
+        xf.setAccessFileTime(null);
+        assertNull(xf.getAccessJavaTime());
+        assertNull(xf.getAccessTime());
+        assertFalse(xf.isBit1_accessTimePresent());
 
         // get/set create time
         xf.setCreateTime(time);
         assertEquals(time, xf.getCreateTime());
         assertEquals(timeMillis, xf.getCreateJavaTime().getTime());
+        assertEquals(timeMillis, xf.getCreateFileTime().toMillis());
+        assertTrue(xf.isBit2_createTimePresent());
         xf.setCreateJavaTime(new Date(timeMillis));
         assertEquals(time, xf.getCreateTime());
         assertEquals(timeMillis, xf.getCreateJavaTime().getTime());
+        assertEquals(timeMillis, xf.getCreateFileTime().toMillis());
+        assertTrue(xf.isBit2_createTimePresent());
         // Make sure milliseconds get zeroed out:
         xf.setCreateJavaTime(new Date(timeMillis + 123));
         assertEquals(time, xf.getCreateTime());
         assertEquals(timeMillis, xf.getCreateJavaTime().getTime());
+        assertEquals(timeMillis, xf.getCreateFileTime().toMillis());
+        assertTrue(xf.isBit2_createTimePresent());
+        // Make sure it works correctly for FileTime
+        xf.setCreateFileTime(FileTime.fromMillis(timeMillis + 123));
+        assertEquals(time, xf.getCreateTime());
+        assertEquals(timeMillis, xf.getCreateJavaTime().getTime());
+        assertEquals(timeMillis, xf.getCreateFileTime().toMillis());
+        assertTrue(xf.isBit2_createTimePresent());
         // Null
         xf.setCreateTime(null);
         assertNull(xf.getCreateJavaTime());
+        assertNull(xf.getCreateFileTime());
+        assertFalse(xf.isBit2_createTimePresent());
         xf.setCreateJavaTime(null);
         assertNull(xf.getCreateTime());
+        assertNull(xf.getCreateFileTime());
+        assertFalse(xf.isBit2_createTimePresent());
+        xf.setCreateFileTime(null);
+        assertNull(xf.getCreateJavaTime());
+        assertNull(xf.getCreateTime());
+        assertFalse(xf.isBit2_createTimePresent());
 
 
         // initialize for flags

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntryTest.java
@@ -19,19 +19,26 @@
 package org.apache.commons.compress.archivers.zip;
 
 import static org.apache.commons.compress.AbstractTestCase.getFile;
+import static org.apache.commons.compress.archivers.zip.ZipUtilTest.assertDosDate;
+import static org.apache.commons.compress.archivers.zip.ZipUtilTest.toLocalInstant;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 
 import org.apache.commons.compress.utils.ByteUtils;
+import org.apache.commons.compress.utils.TimeUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -373,5 +380,164 @@ public class ZipArchiveEntryTest {
             final ZipArchiveEntry clonedZe = (ZipArchiveEntry) ze.clone();
             assertEquals(ze, clonedZe);
         }
+    }
+
+    @Test
+    public void testShouldNotSetExtraDateFieldsIfDateFitsInDosDates() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime time = FileTime.from(toLocalInstant("2022-12-28T20:39:33.1234567"));
+        ze.setTime(time);
+
+        assertEquals(time.toMillis(), ze.getTime());
+        assertEquals(time.toMillis(), ze.getLastModifiedTime().toMillis());
+        assertNull(ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID));
+        assertNull(ze.getExtraField(X000A_NTFS.HEADER_ID));
+
+        final long dosTime = ZipLong.getValue(ZipUtil.toDosTime(ze.getTime()));
+        assertDosDate(dosTime, 2022, 12, 28, 20, 39, 32); // DOS dates only store even seconds
+    }
+
+    @Test
+    public void testShouldSetExtraDateFieldsIfDateExceedsDosDate() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime time = FileTime.from(toLocalInstant("1975-11-27T00:00:00"));
+        ze.setTime(time.toMillis());
+
+        assertEquals(time.toMillis(), ze.getTime());
+        assertEquals(time, ze.getLastModifiedTime());
+        X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
+        assertNotNull(extendedTimestamp);
+        assertEquals(TimeUtils.fileTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
+        assertNull(extendedTimestamp.getAccessTime());
+        assertNull(extendedTimestamp.getCreateTime());
+        X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
+        assertNotNull(ntfs);
+        assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
+        assertEquals(0L, ntfs.getAccessTime().getLongValue());
+        assertEquals(0L, ntfs.getCreateTime().getLongValue());
+    }
+
+    @Test
+    public void testShouldNotSetInfoZipFieldIfDateExceedsUnixTime() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime time = FileTime.from(toLocalInstant("2138-11-27T00:00:00"));
+        ze.setTime(time.toMillis());
+
+        assertEquals(time.toMillis(), ze.getTime());
+        assertEquals(time, ze.getLastModifiedTime());
+        assertNull(ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID));
+        X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
+        assertNotNull(ntfs);
+        assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
+        assertEquals(0L, ntfs.getAccessTime().getLongValue());
+        assertEquals(0L, ntfs.getCreateTime().getLongValue());
+    }
+
+    @Test
+    public void testShouldSetExtraDateFieldsIfModifyDateIsExplicitlySet() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime time = FileTime.from(Instant.parse("2022-12-28T20:39:33.1234567Z"));
+        ze.setLastModifiedTime(time);
+
+        assertEquals(time.toMillis(), ze.getTime());
+        assertEquals(time, ze.getLastModifiedTime());
+        X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
+        assertNotNull(extendedTimestamp);
+        assertEquals(TimeUtils.fileTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
+        assertNull(extendedTimestamp.getAccessTime());
+        assertNull(extendedTimestamp.getCreateTime());
+        X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
+        assertNotNull(ntfs);
+        assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
+        assertEquals(0L, ntfs.getAccessTime().getLongValue());
+        assertEquals(0L, ntfs.getCreateTime().getLongValue());
+    }
+
+    @Test
+    public void testShouldSetExtraDateFieldsIfAccessDateIsSet() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime lastAccessTime = FileTime.from(Instant.parse("2022-12-28T20:39:33.1234567Z"));
+        final long time = Instant.parse("2020-03-04T12:34:56.1234567Z").toEpochMilli();
+        ze.setTime(time);
+        ze.setLastAccessTime(lastAccessTime);
+
+        assertEquals(time, ze.getTime());
+        assertEquals(time, ze.getLastModifiedTime().toMillis());
+        X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
+        assertNotNull(extendedTimestamp);
+        assertEquals(TimeUtils.javaTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
+        assertEquals(TimeUtils.fileTimeToUnixTime(lastAccessTime), extendedTimestamp.getAccessTime().getValue());
+        assertNull(extendedTimestamp.getCreateTime());
+        X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
+        assertNotNull(ntfs);
+        assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
+        assertEquals(TimeUtils.toNtfsTime(lastAccessTime), ntfs.getAccessTime().getLongValue());
+        assertEquals(0L, ntfs.getCreateTime().getLongValue());
+    }
+
+    @Test
+    public void testShouldSetExtraDateFieldsIfCreationDateIsSet() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime creationTime = FileTime.from(Instant.parse("2022-12-28T20:39:33.1234567Z"));
+        final long time = Instant.parse("2020-03-04T12:34:56.1234567Z").toEpochMilli();
+        ze.setTime(time);
+        ze.setCreationTime(creationTime);
+
+        assertEquals(time, ze.getTime());
+        assertEquals(time, ze.getLastModifiedTime().toMillis());
+        X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
+        assertNotNull(extendedTimestamp);
+        assertEquals(TimeUtils.javaTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
+        assertNull(extendedTimestamp.getAccessTime());
+        assertEquals(TimeUtils.fileTimeToUnixTime(creationTime), extendedTimestamp.getCreateTime().getValue());
+        X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
+        assertNotNull(ntfs);
+        assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
+        assertEquals(0L, ntfs.getAccessTime().getLongValue());
+        assertEquals(TimeUtils.toNtfsTime(creationTime), ntfs.getCreateTime().getLongValue());
+    }
+
+    @Test
+    public void testShouldSetExtraDateFieldsIfAllDatesAreSet() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime accessTime = FileTime.from(Instant.parse("2022-12-29T21:40:34.1234567Z"));
+        final FileTime creationTime = FileTime.from(Instant.parse("2022-12-28T20:39:33.1234567Z"));
+        final long time = Instant.parse("2020-03-04T12:34:56.1234567Z").toEpochMilli();
+        ze.setTime(time);
+        ze.setLastAccessTime(accessTime);
+        ze.setCreationTime(creationTime);
+
+        assertEquals(time, ze.getTime());
+        assertEquals(time, ze.getLastModifiedTime().toMillis());
+        X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
+        assertNotNull(extendedTimestamp);
+        assertEquals(TimeUtils.javaTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
+        assertEquals(TimeUtils.fileTimeToUnixTime(accessTime), extendedTimestamp.getAccessTime().getValue());
+        assertEquals(TimeUtils.fileTimeToUnixTime(creationTime), extendedTimestamp.getCreateTime().getValue());
+        X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
+        assertNotNull(ntfs);
+        assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
+        assertEquals(TimeUtils.toNtfsTime(accessTime), ntfs.getAccessTime().getLongValue());
+        assertEquals(TimeUtils.toNtfsTime(creationTime), ntfs.getCreateTime().getLongValue());
+    }
+
+    @Test
+    public void testShouldNotSetInfoZipFieldIfAnyDatesExceedUnixTime() {
+        final ZipArchiveEntry ze = new ZipArchiveEntry();
+        final FileTime accessTime = FileTime.from(Instant.parse("2022-12-29T21:40:34.1234567Z"));
+        final FileTime creationTime = FileTime.from(Instant.parse("2038-12-28T20:39:33.1234567Z"));
+        final long time = Instant.parse("2020-03-04T12:34:56.1234567Z").toEpochMilli();
+        ze.setTime(time);
+        ze.setLastAccessTime(accessTime);
+        ze.setCreationTime(creationTime);
+
+        assertEquals(time, ze.getTime());
+        assertEquals(time, ze.getLastModifiedTime().toMillis());
+        assertNull(ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID));
+        X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
+        assertNotNull(ntfs);
+        assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
+        assertEquals(TimeUtils.toNtfsTime(accessTime), ntfs.getAccessTime().getLongValue());
+        assertEquals(TimeUtils.toNtfsTime(creationTime), ntfs.getCreateTime().getLongValue());
     }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntryTest.java
@@ -407,7 +407,7 @@ public class ZipArchiveEntryTest {
         assertEquals(time, ze.getLastModifiedTime());
         X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
         assertNotNull(extendedTimestamp);
-        assertEquals(TimeUtils.fileTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
+        assertEquals(TimeUtils.toUnixTime(time), extendedTimestamp.getModifyTime().getValue());
         assertNull(extendedTimestamp.getAccessTime());
         assertNull(extendedTimestamp.getCreateTime());
         X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
@@ -443,7 +443,7 @@ public class ZipArchiveEntryTest {
         assertEquals(time, ze.getLastModifiedTime());
         X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
         assertNotNull(extendedTimestamp);
-        assertEquals(TimeUtils.fileTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
+        assertEquals(TimeUtils.toUnixTime(time), extendedTimestamp.getModifyTime().getValue());
         assertNull(extendedTimestamp.getAccessTime());
         assertNull(extendedTimestamp.getCreateTime());
         X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
@@ -466,7 +466,7 @@ public class ZipArchiveEntryTest {
         X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
         assertNotNull(extendedTimestamp);
         assertEquals(TimeUtils.javaTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
-        assertEquals(TimeUtils.fileTimeToUnixTime(lastAccessTime), extendedTimestamp.getAccessTime().getValue());
+        assertEquals(TimeUtils.toUnixTime(lastAccessTime), extendedTimestamp.getAccessTime().getValue());
         assertNull(extendedTimestamp.getCreateTime());
         X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
         assertNotNull(ntfs);
@@ -489,7 +489,7 @@ public class ZipArchiveEntryTest {
         assertNotNull(extendedTimestamp);
         assertEquals(TimeUtils.javaTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
         assertNull(extendedTimestamp.getAccessTime());
-        assertEquals(TimeUtils.fileTimeToUnixTime(creationTime), extendedTimestamp.getCreateTime().getValue());
+        assertEquals(TimeUtils.toUnixTime(creationTime), extendedTimestamp.getCreateTime().getValue());
         X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
         assertNotNull(ntfs);
         assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());
@@ -512,8 +512,8 @@ public class ZipArchiveEntryTest {
         X5455_ExtendedTimestamp extendedTimestamp = (X5455_ExtendedTimestamp) ze.getExtraField(X5455_ExtendedTimestamp.HEADER_ID);
         assertNotNull(extendedTimestamp);
         assertEquals(TimeUtils.javaTimeToUnixTime(time), extendedTimestamp.getModifyTime().getValue());
-        assertEquals(TimeUtils.fileTimeToUnixTime(accessTime), extendedTimestamp.getAccessTime().getValue());
-        assertEquals(TimeUtils.fileTimeToUnixTime(creationTime), extendedTimestamp.getCreateTime().getValue());
+        assertEquals(TimeUtils.toUnixTime(accessTime), extendedTimestamp.getAccessTime().getValue());
+        assertEquals(TimeUtils.toUnixTime(creationTime), extendedTimestamp.getCreateTime().getValue());
         X000A_NTFS ntfs = (X000A_NTFS) ze.getExtraField(X000A_NTFS.HEADER_ID);
         assertNotNull(ntfs);
         assertEquals(TimeUtils.toNtfsTime(time), ntfs.getModifyTime().getLongValue());

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -103,14 +104,14 @@ public class ZipArchiveInputStreamTest {
             entryA.setMethod(ZipEntry.STORED);
             entryA.setSize(4);
             entryA.setCrc(0xb63cfbcdL);
+            // Ensure we won't write extra fields. They are not compatible with the manual edits below.
+            entryA.setTime(Instant.parse("2022-12-26T17:01:00Z").toEpochMilli());
             zo.putArchiveEntry(entryA);
             zo.write(new byte[] { 1, 2, 3, 4 });
             zo.closeArchiveEntry();
             zo.close();
 
             final byte[] zipContent = byteArrayOutputStream.toByteArray();
-            final byte[] old = Arrays.copyOf(zipContent, zipContent.length);
-
             final byte[] zipContentWithDataDescriptor = new byte[zipContent.length + 12];
             System.arraycopy(zipContent, 0, zipContentWithDataDescriptor, 0, 37);
             // modify the general purpose bit flag

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
@@ -18,19 +18,23 @@
 
 package org.apache.commons.compress.archivers.zip;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
-
-import java.math.BigInteger;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.TimeZone;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ZipUtilTest {
 
@@ -120,13 +124,32 @@ public class ZipUtilTest {
 
     @Test
     public void testInsideCalendar(){
-        final TimeZone tz = TimeZone.getDefault();
-        final long date = 476096400000L; // 1.1.1985, 10:00 am GMT
-        final byte[] b1 = ZipUtil.toDosTime(date - tz.getOffset(date));
+        final long date = toLocalInstant("1985-02-01T09:00:00").toEpochMilli();
+        final byte[] b1 = ZipUtil.toDosTime(date);
         assertEquals(0, b1[0]);
         assertEquals(72, b1[1]);
         assertEquals(65, b1[2]);
         assertEquals(10, b1[3]);
+    }
+
+    @Test
+    public void testInsideCalendar_long(){
+        final long date = toLocalInstant("1985-02-01T09:00:00").toEpochMilli();
+        final long value = ZipLong.getValue(ZipUtil.toDosTime(date));
+        assertDosDate(value, 1985, 2, 1, 9, 0, 0);
+    }
+
+    @Test
+    public void testInsideCalendar_modernDate(){
+        final long date = toLocalInstant("2022-12-27T16:18:23").toEpochMilli();
+        final long value = ZipLong.getValue(ZipUtil.toDosTime(date));
+        assertDosDate(value, 2022, 12, 27, 16, 18, 22); // DOS dates only store even seconds
+    }
+    @Test
+    public void testInsideCalendar_bigValue(){
+        final long date = toLocalInstant("2097-11-27T23:59:59").toEpochMilli();
+        final long value = ZipLong.getValue(ZipUtil.toDosTime(date));
+        assertDosDate(value, 2097, 11, 27, 23, 59, 58); // DOS dates only store even seconds
     }
 
     @Test
@@ -169,11 +192,48 @@ public class ZipUtilTest {
 
     @Test
     public void testOutsideCalendar(){
-        final byte[] b1 = ZipUtil.toDosTime(160441200000L); // 1.1..1975
+        final long date = toLocalInstant("1975-01-31T23:00:00").toEpochMilli();
+        final byte[] b1 = ZipUtil.toDosTime(date);
         assertEquals(0, b1[0]);
         assertEquals(0, b1[1]);
         assertEquals(33, b1[2]);
         assertEquals(0, b1[3]);
+    }
+
+    @Test
+    public void testOutsideCalendar_long(){
+        final long date = toLocalInstant("1975-01-31T23:00:00").toEpochMilli();
+        final long value = ZipLong.getValue(ZipUtil.toDosTime(date));
+        assertDosDate(value, 1980, 1, 1, 0, 0, 0);
+    }
+
+    @Test
+    public void testExceedsDosTime(){
+        assertTrue(ZipUtil.exceedsDosTime(toLocalInstant("1975-01-31T23:00:00").toEpochMilli()));
+        assertFalse(ZipUtil.exceedsDosTime(toLocalInstant("1980-01-03T00:00:00").toEpochMilli()));
+        assertFalse(ZipUtil.exceedsDosTime(toLocalInstant("2097-11-27T00:00:00").toEpochMilli()));
+        assertTrue(ZipUtil.exceedsDosTime(toLocalInstant("2099-01-01T00:00:00").toEpochMilli()));
+    }
+
+    static void assertDosDate(
+            final long value,
+            final int year,
+            final int month,
+            final int day,
+            final int hour,
+            final int minute,
+            final int second) {
+        int pos = 0;
+        assertEquals((year - 1980), ((int) (value << pos)) >>> (32 - 7));
+        assertEquals(month, ((int) (value << (pos += 7))) >>> (32 - 4));
+        assertEquals(day, ((int) (value << (pos += 4))) >>> (32 - 5));
+        assertEquals(hour, ((int) (value << (pos += 5))) >>> (32 - 5));
+        assertEquals(minute, ((int) (value << (pos += 5))) >>> (32 - 6));
+        assertEquals(second, ((int) (value << (pos + 6))) >>> (32 - 5) << 1); // DOS dates only store even seconds
+    }
+
+    static Instant toLocalInstant(final String date) {
+        return LocalDateTime.parse(date).atZone(ZoneId.systemDefault()).toInstant();
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
@@ -171,8 +171,8 @@ public class ZipUtilTest {
     public void testOutsideCalendar(){
         final byte[] b1 = ZipUtil.toDosTime(160441200000L); // 1.1..1975
         assertEquals(0, b1[0]);
-        assertEquals(33, b1[1]);
-        assertEquals(0, b1[2]);
+        assertEquals(0, b1[1]);
+        assertEquals(33, b1[2]);
         assertEquals(0, b1[3]);
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
@@ -208,11 +208,11 @@ public class ZipUtilTest {
     }
 
     @Test
-    public void testExceedsDosTime(){
-        assertTrue(ZipUtil.exceedsDosTime(toLocalInstant("1975-01-31T23:00:00").toEpochMilli()));
-        assertFalse(ZipUtil.exceedsDosTime(toLocalInstant("1980-01-03T00:00:00").toEpochMilli()));
-        assertFalse(ZipUtil.exceedsDosTime(toLocalInstant("2097-11-27T00:00:00").toEpochMilli()));
-        assertTrue(ZipUtil.exceedsDosTime(toLocalInstant("2099-01-01T00:00:00").toEpochMilli()));
+    public void testIsDosTime(){
+        assertFalse(ZipUtil.isDosTime(toLocalInstant("1975-01-31T23:00:00").toEpochMilli()));
+        assertTrue(ZipUtil.isDosTime(toLocalInstant("1980-01-03T00:00:00").toEpochMilli()));
+        assertTrue(ZipUtil.isDosTime(toLocalInstant("2097-11-27T00:00:00").toEpochMilli()));
+        assertFalse(ZipUtil.isDosTime(toLocalInstant("2099-01-01T00:00:00").toEpochMilli()));
     }
 
     static void assertDosDate(

--- a/src/test/java/org/apache/commons/compress/utils/TimeUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/TimeUtilsTest.java
@@ -188,12 +188,12 @@ public class TimeUtilsTest {
     }
 
     @Test
-    public void shouldCheckWhetherTimeExceedsUnixTime() {
-        assertFalse(TimeUtils.exceedsUnixTime(null));
-        assertFalse(TimeUtils.exceedsUnixTime(FileTime.from(Instant.parse("2022-12-27T12:45:22Z"))));
-        assertFalse(TimeUtils.exceedsUnixTime(FileTime.from(Instant.parse("2038-01-19T03:14:07Z"))));
-        assertTrue(TimeUtils.exceedsUnixTime(FileTime.from(Instant.parse("2038-01-19T03:14:08Z"))));
-        assertTrue(TimeUtils.exceedsUnixTime(FileTime.from(Instant.parse("2099-06-30T12:31:42Z"))));
+    public void shouldCheckWhetherTimeCanBeRepresentedAsUnixTime() {
+        assertTrue(TimeUtils.isUnixTime(null));
+        assertTrue(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2022-12-27T12:45:22Z"))));
+        assertTrue(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2038-01-19T03:14:07Z"))));
+        assertFalse(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2038-01-19T03:14:08Z"))));
+        assertFalse(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2099-06-30T12:31:42Z"))));
     }
 
     public static Stream<Arguments> fileTimeToUnixTimeArguments() {
@@ -207,7 +207,7 @@ public class TimeUtilsTest {
     @ParameterizedTest
     @MethodSource("fileTimeToUnixTimeArguments")
     public void shouldConvertFileTimeToUnixTime(final long expectedUnixTime, final String instant) {
-        assertEquals(expectedUnixTime, TimeUtils.fileTimeToUnixTime(FileTime.from(Instant.parse(instant))));
+        assertEquals(expectedUnixTime, TimeUtils.toUnixTime(FileTime.from(Instant.parse(instant))));
     }
 
     @ParameterizedTest

--- a/src/test/java/org/apache/commons/compress/utils/TimeUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/TimeUtilsTest.java
@@ -192,6 +192,8 @@ public class TimeUtilsTest {
         assertTrue(TimeUtils.isUnixTime(null));
         assertTrue(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2022-12-27T12:45:22Z"))));
         assertTrue(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2038-01-19T03:14:07Z"))));
+        assertTrue(TimeUtils.isUnixTime(FileTime.from(Instant.parse("1901-12-13T23:14:08Z"))));
+        assertFalse(TimeUtils.isUnixTime(FileTime.from(Instant.parse("1901-12-13T03:14:08Z"))));
         assertFalse(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2038-01-19T03:14:08Z"))));
         assertFalse(TimeUtils.isUnixTime(FileTime.from(Instant.parse("2099-06-30T12:31:42Z"))));
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/COMPRESS-613

This adds support for extra time data (InfoZip and NTFS Extra fields) to Zip archives.
This supports both reading and writing to these fields automatically, including when creating a ZipArchiveEntry from an existing file on the disk, with proper fall backs.

Additionally:

1. Works around a bug involving Integer Overflow in Java 8 and Zip archives: https://bugs.openjdk.org/browse/JDK-8130914
2. Consolidates a few more time conversions into TimeUtils
3. Works around an oversight in Java 8 where the NTFS fields on Zip archives are only read to the precision of microseconds instead of their maximum of 100ns.

Currently, it's missing a few test cases for reading/writing, though I have tested them myself. Submitting for this review because the code itself is likely final (and there are enough tests to cover most of them, and I'll submit the rest of the test cases in the coming days).