### PR TITLE
Removed dependency on the java.desktop module

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/pack200/Pack200Adapter.java
+++ b/src/main/java/org/apache/commons/compress/harmony/pack200/Pack200Adapter.java
@@ -16,44 +16,16 @@
  */
 package org.apache.commons.compress.harmony.pack200;
 
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-/**
- * Provides generic JavaBeans support for the Pack/UnpackAdapters
- */
 public abstract class Pack200Adapter {
 
     protected static final int DEFAULT_BUFFER_SIZE = 8192;
 
-    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
-
     private final SortedMap<String, String> properties = new TreeMap<>();
-
-    public void addPropertyChangeListener(final PropertyChangeListener listener) {
-        support.addPropertyChangeListener(listener);
-    }
-
-    /**
-     * Completion between 0..1.
-     *
-     * @param value Completion between 0..1.
-     */
-    protected void completed(final double value) {
-        firePropertyChange("pack.progress", null, String.valueOf((int) (100 * value))); //$NON-NLS-1$
-    }
-
-    protected void firePropertyChange(final String propertyName, final Object oldValue, final Object newValue) {
-        support.firePropertyChange(propertyName, oldValue, newValue);
-    }
 
     public SortedMap<String, String> properties() {
         return properties;
-    }
-
-    public void removePropertyChangeListener(final PropertyChangeListener listener) {
-        support.removePropertyChangeListener(listener);
     }
 }

--- a/src/main/java/org/apache/commons/compress/harmony/pack200/Pack200PackerAdapter.java
+++ b/src/main/java/org/apache/commons/compress/harmony/pack200/Pack200PackerAdapter.java
@@ -33,54 +33,15 @@ public class Pack200PackerAdapter extends Pack200Adapter implements Packer {
     private final PackingOptions options = new PackingOptions();
 
     @Override
-    protected void firePropertyChange(final String propertyName, final Object oldValue, final Object newValue) {
-        super.firePropertyChange(propertyName, oldValue, newValue);
-        if (newValue != null && !newValue.equals(oldValue)) {
-            if (propertyName.startsWith(CLASS_ATTRIBUTE_PFX)) {
-                final String attributeName = propertyName.substring(CLASS_ATTRIBUTE_PFX.length());
-                options.addClassAttributeAction(attributeName, (String) newValue);
-            } else if (propertyName.startsWith(CODE_ATTRIBUTE_PFX)) {
-                final String attributeName = propertyName.substring(CODE_ATTRIBUTE_PFX.length());
-                options.addCodeAttributeAction(attributeName, (String) newValue);
-            } else if (propertyName.equals(DEFLATE_HINT)) {
-                options.setDeflateHint((String) newValue);
-            } else if (propertyName.equals(EFFORT)) {
-                options.setEffort(Integer.parseInt((String) newValue));
-            } else if (propertyName.startsWith(FIELD_ATTRIBUTE_PFX)) {
-                final String attributeName = propertyName.substring(FIELD_ATTRIBUTE_PFX.length());
-                options.addFieldAttributeAction(attributeName, (String) newValue);
-            } else if (propertyName.equals(KEEP_FILE_ORDER)) {
-                options.setKeepFileOrder(Boolean.parseBoolean((String) newValue));
-            } else if (propertyName.startsWith(METHOD_ATTRIBUTE_PFX)) {
-                final String attributeName = propertyName.substring(METHOD_ATTRIBUTE_PFX.length());
-                options.addMethodAttributeAction(attributeName, (String) newValue);
-            } else if (propertyName.equals(MODIFICATION_TIME)) {
-                options.setModificationTime((String) newValue);
-            } else if (propertyName.startsWith(PASS_FILE_PFX)) {
-                if (oldValue != null && !oldValue.equals("")) {
-                    options.removePassFile((String) oldValue);
-                }
-                options.addPassFile((String) newValue);
-            } else if (propertyName.equals(SEGMENT_LIMIT)) {
-                options.setSegmentLimit(Long.parseLong((String) newValue));
-            } else if (propertyName.equals(UNKNOWN_ATTRIBUTE)) {
-                options.setUnknownAttributeAction((String) newValue);
-            }
-        }
-    }
-
-    @Override
     public void pack(final JarFile file, final OutputStream out) throws IOException {
         if (file == null || out == null) {
             throw new IllegalArgumentException("Must specify both input and output streams");
         }
-        completed(0);
         try {
             new org.apache.commons.compress.harmony.pack200.Archive(file, out, options).pack();
         } catch (final Pack200Exception e) {
             throw new IOException("Failed to pack Jar:" + e);
         }
-        completed(1);
     }
 
     @Override
@@ -88,7 +49,6 @@ public class Pack200PackerAdapter extends Pack200Adapter implements Packer {
         if (in == null || out == null) {
             throw new IllegalArgumentException("Must specify both input and output streams");
         }
-        completed(0);
         final PackingOptions options = new PackingOptions();
 
         try {
@@ -96,7 +56,6 @@ public class Pack200PackerAdapter extends Pack200Adapter implements Packer {
         } catch (final Pack200Exception e) {
             throw new IOException("Failed to pack Jar:" + e);
         }
-        completed(1);
         in.close();
     }
 

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/Pack200UnpackerAdapter.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/Pack200UnpackerAdapter.java
@@ -62,12 +62,10 @@ public class Pack200UnpackerAdapter extends Pack200Adapter implements Unpacker {
         if (in == null || out == null) {
             throw new IllegalArgumentException("Must specify both input and output streams");
         }
-        completed(0);
         try {
             new Archive(in, out).unpack();
         } catch (final Pack200Exception e) {
             throw new IOException("Failed to unpack Jar:" + e);
         }
-        completed(1);
     }
 }

--- a/src/main/java/org/apache/commons/compress/java/util/jar/Pack200.java
+++ b/src/main/java/org/apache/commons/compress/java/util/jar/Pack200.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.compress.java.util.jar;
 
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -138,14 +137,6 @@ public abstract class Pack200 {
         String UNKNOWN_ATTRIBUTE = "pack.unknown.attribute";//$NON-NLS-1$
 
         /**
-         * add a listener for PropertyChange events
-         *
-         * @param listener
-         *            the listener to listen if PropertyChange events occurs
-         */
-        void addPropertyChangeListener(PropertyChangeListener listener);
-
-        /**
          * Pack the specified JAR file to the specified output stream.
          *
          * @param in
@@ -176,14 +167,6 @@ public abstract class Pack200 {
          * @return the properties of the packer.
          */
         SortedMap<String, String> properties();
-
-        /**
-         * remove a listener
-         *
-         * @param listener
-         *            listener to remove
-         */
-        void removePropertyChangeListener(PropertyChangeListener listener);
     }
 
     /**
@@ -219,28 +202,11 @@ public abstract class Pack200 {
         String TRUE = "true";//$NON-NLS-1$
 
         /**
-         * add a listener for {@code PropertyChange} events.
-         *
-         * @param listener
-         *            the listener to listen if {@code PropertyChange} events
-         *            occurs.
-         */
-        void addPropertyChangeListener(PropertyChangeListener listener);
-
-        /**
          * Returns a sorted map of the properties of this unpacker.
          *
          * @return the properties of unpacker.
          */
         SortedMap<String, String> properties();
-
-        /**
-         * remove a listener.
-         *
-         * @param listener
-         *            listener to remove.
-         */
-        void removePropertyChangeListener(PropertyChangeListener listener);
 
         /**
          * Unpack the contents of the specified {@code File} to the specified


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/COMPRESS-610

It removes commons-compress' dependency on the java.desktop module, allowing for much smaller JVM runtime images for jlink users.