### PR TITLE
pack200: Fix FileBands misusing InputStream#read(byte[])

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/FileBands.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/FileBands.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 
 import org.apache.commons.compress.harmony.pack200.Codec;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
+import org.apache.commons.compress.utils.IOUtils;
 
 /**
  * Parses the file band headers (not including the actual bits themselves). At the end of this parse call, the input
@@ -82,7 +83,7 @@ public class FileBands extends BandSet {
             // TODO This breaks if file_size > 2^32. Probably an array is
             // not the right choice, and we should just serialize it here?
             fileBits[i] = new byte[size];
-            final int read = in.read(fileBits[i]);
+            final int read = IOUtils.readFully(in, fileBits[i]);
             if (size != 0 && read < size) {
                 throw new Pack200Exception("Expected to read " + size + " bytes but read " + read);
             }


### PR DESCRIPTION
The Pack200 decompressor expects `read` to always return the amount of bytes it requested. This is *usually* true for raw input streams, such as File or ByteArray, but breaks down when combined with other block-based decompressors. For example, combining an LZMAInputStream with a Pack200 decompressor results in an error similar to the following if a file falls between block boundaries:

```
Exception in thread "main" org.apache.commons.compress.harmony.pack200.Pack200Exception: Expected to read 48873 bytes but read 3274
	at org.apache.commons.compress.harmony.unpack200.FileBands.processFileBits(FileBands.java:87)
	at org.apache.commons.compress.harmony.unpack200.Segment.readSegment(Segment.java:460)
	at org.apache.commons.compress.harmony.unpack200.Segment.unpackRead(Segment.java:514)
	at org.apache.commons.compress.harmony.unpack200.Segment.unpack(Segment.java:484)
	at org.apache.commons.compress.harmony.unpack200.Archive.unpack(Archive.java:198)
	at com.unascribed.unpacktest.UnpackTest.main(UnpackTest.java:20)
```

Pack200 is *intended* to be combined with other forms of compression, so this is a major issue in some cases.

This reimplements the portion of the method to use `read` correctly, keeping track of how much has been read. I did not address the TODO as I don't believe there's a good way to implement it with the current architecture of the decompressor.

The file I'm having issues with is a Pack200+LZMA file that does not contain any class files. Kind of a weird case, but it's what I'm stuck with, and Commons Compress is the only real extant Pack200 decompressor for modern Java.