### PR TITLE
COMPRESS-641: add getLinkFlag for TarArchiveEntry

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -2129,5 +2129,15 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
         }
         return offset;
     }
+
+    /**
+     * Get this entry's link flag.
+     *
+     * @since 1.23
+     */
+    public byte getLinkFlag() {
+        return this.linkFlag;
+    }
+
 }
 

--- a/src/test/java/org/apache/commons/compress/ChainingTestCase.java
+++ b/src/test/java/org/apache/commons/compress/ChainingTestCase.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ public class ChainingTestCase extends AbstractTestCase {
             final TarArchiveEntry entry = (TarArchiveEntry) is.getNextEntry();
             assertNotNull(entry);
             assertEquals("test1.xml", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
         }
     }
 
@@ -44,6 +46,7 @@ public class ChainingTestCase extends AbstractTestCase {
             final TarArchiveEntry entry = (TarArchiveEntry) is.getNextEntry();
             assertNotNull(entry);
             assertEquals("test1.xml", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
         }
     }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/TarTestCase.java
+++ b/src/test/java/org/apache/commons/compress/archivers/TarTestCase.java
@@ -41,6 +41,7 @@ import org.apache.commons.compress.AbstractTestCase;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
 import org.apache.commons.compress.archivers.tar.TarFile;
 import org.apache.commons.compress.utils.ByteUtils;
 import org.apache.commons.compress.utils.CharsetNames;
@@ -75,8 +76,10 @@ public final class TarTestCase extends AbstractTestCase {
              final ArchiveInputStream in = new TarArchiveInputStream(is, CharsetNames.ISO_8859_1)) {
             TarArchiveEntry entry = (TarArchiveEntry) in.getNextEntry();
             assertEquals("3\u00b1\u00b1\u00b1F06\u00b1W2345\u00b1ZB\u00b1la\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1BLA", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
             entry = (TarArchiveEntry) in.getNextEntry();
             assertEquals("0302-0601-3\u00b1\u00b1\u00b1F06\u00b1W2345\u00b1ZB\u00b1la\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1BLA", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
         }
     }
 
@@ -121,6 +124,7 @@ public final class TarTestCase extends AbstractTestCase {
             tis = null;
             assertNotNull(out);
             assertEquals("foo/", out.getName());
+            assertEquals(TarConstants.LF_DIR, out.getLinkFlag());
             assertEquals(0, out.getSize());
             // TAR stores time with a granularity of 1 second
             assertEquals(beforeArchiveWrite / 1000,
@@ -146,6 +150,7 @@ public final class TarTestCase extends AbstractTestCase {
              final TarArchiveInputStream in = new TarArchiveInputStream(is)) {
             final TarArchiveEntry directoryEntry = in.getNextTarEntry();
             assertEquals("directory/", directoryEntry.getName());
+            assertEquals(TarConstants.LF_DIR, directoryEntry.getLinkFlag());
             assertTrue(directoryEntry.isDirectory());
             final byte[] directoryRead = IOUtils.toByteArray(in);
             assertArrayEquals(ByteUtils.EMPTY_BYTE_ARRAY, directoryRead);
@@ -175,6 +180,7 @@ public final class TarTestCase extends AbstractTestCase {
             tis = null;
             assertNotNull(out);
             assertEquals("foo/", out.getName());
+            assertEquals(TarConstants.LF_DIR, in.getLinkFlag());
             assertEquals(0, out.getSize());
             assertEquals(beforeArchiveWrite / 1000,
                          out.getLastModifiedDate().getTime() / 1000);
@@ -223,6 +229,7 @@ public final class TarTestCase extends AbstractTestCase {
             tis = null;
             assertNotNull(out);
             assertEquals("foo", out.getName());
+            assertEquals(TarConstants.LF_NORMAL, out.getLinkFlag());
             assertEquals(tmp[1].length(), out.getSize());
             assertEquals(tmp[1].lastModified() / 1000,
                          out.getLastModifiedDate().getTime() / 1000);
@@ -272,6 +279,7 @@ public final class TarTestCase extends AbstractTestCase {
             tis = null;
             assertNotNull(out);
             assertEquals("foo", out.getName());
+            assertEquals(TarConstants.LF_NORMAL, out.getLinkFlag());
             assertEquals(tmp[1].length(), out.getSize());
             assertEquals(tmp[1].lastModified() / 1000,
                          out.getLastModifiedDate().getTime() / 1000);
@@ -384,8 +392,10 @@ public final class TarTestCase extends AbstractTestCase {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             TarArchiveEntry entry = entries.get(0);
             assertEquals("3\u00b1\u00b1\u00b1F06\u00b1W2345\u00b1ZB\u00b1la\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1BLA", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
             entry = entries.get(1);
             assertEquals("0302-0601-3\u00b1\u00b1\u00b1F06\u00b1W2345\u00b1ZB\u00b1la\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1BLA", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
         }
     }
 
@@ -425,6 +435,7 @@ public final class TarTestCase extends AbstractTestCase {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo/", entry.getName());
+                assertEquals(TarConstants.LF_DIR, entry.getLinkFlag());
                 assertEquals(0, entry.getSize());
                 // TAR stores time with a granularity of 1 second
                 assertEquals(beforeArchiveWrite / 1000, entry.getLastModifiedDate().getTime() / 1000);
@@ -443,6 +454,7 @@ public final class TarTestCase extends AbstractTestCase {
         try (TarFile tarFile = new TarFile(input)) {
             final TarArchiveEntry directoryEntry = tarFile.getEntries().get(0);
             assertEquals("directory/", directoryEntry.getName());
+            assertEquals(TarConstants.LF_DIR, directoryEntry.getLinkFlag());
             assertTrue(directoryEntry.isDirectory());
             try (InputStream directoryStream = tarFile.getInputStream(directoryEntry)) {
                 final byte[] directoryRead = IOUtils.toByteArray(directoryStream);
@@ -471,6 +483,7 @@ public final class TarTestCase extends AbstractTestCase {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo", entry.getName());
+                assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
                 assertEquals(tmp[1].length(), entry.getSize());
                 assertEquals(tmp[1].lastModified() / 1000, entry.getLastModifiedDate().getTime() / 1000);
                 assertFalse(entry.isDirectory());
@@ -498,6 +511,7 @@ public final class TarTestCase extends AbstractTestCase {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo/", entry.getName());
+                assertEquals(TarConstants.LF_DIR, entry.getLinkFlag());
                 assertEquals(0, entry.getSize());
                 assertEquals(beforeArchiveWrite / 1000, entry.getLastModifiedDate().getTime() / 1000);
                 assertTrue(entry.isDirectory());
@@ -531,6 +545,7 @@ public final class TarTestCase extends AbstractTestCase {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo", entry.getName());
+                assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
                 assertEquals(tmp[1].length(), entry.getSize());
                 assertEquals(tmp[1].lastModified() / 1000, entry.getLastModifiedDate().getTime() / 1000);
                 assertFalse(entry.isDirectory());
@@ -553,6 +568,7 @@ public final class TarTestCase extends AbstractTestCase {
             try (final TarFile tarFile = new TarFile(data)) {
                 final List<TarArchiveEntry> entries = tarFile.getEntries();
                 assertEquals(fileName, entries.get(0).getName());
+                assertEquals(TarConstants.LF_NORMAL, entries.get(0).getLinkFlag());
             }
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/FileTimesIT.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/FileTimesIT.java
@@ -54,6 +54,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/", e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T01:02:11.910960100Z"), e.getLastAccessTime(), "atime");
@@ -63,6 +64,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T00:38:20.536752000Z"), e.getLastAccessTime(), "atime");
@@ -81,6 +83,7 @@ public class FileTimesIT extends AbstractTestCase {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertEquals("name", "test/", e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T00:47:00.367783300Z"), e.getLastAccessTime(), "atime");
@@ -89,6 +92,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertGlobalHeaders(e);
             e = tin.getNextTarEntry();
             assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T00:38:20.536752000Z"), e.getLastAccessTime(), "atime");
@@ -235,6 +239,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/", e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T01:01:53.369146300Z"), e.getLastAccessTime(), "atime");
@@ -244,6 +249,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T00:38:20.536752000Z"), e.getLastAccessTime(), "atime");
@@ -282,6 +288,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/", e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-16T10:19:43.382883700Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-16T10:21:01.251181000Z"), e.getLastAccessTime(), "atime");
@@ -291,6 +298,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-16T10:21:00.249238500Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-16T10:21:01.251181000Z"), e.getLastAccessTime(), "atime");
@@ -328,6 +336,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/", e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44Z"), e.getLastModifiedTime(), "mtime");
             assertNull(e.getLastAccessTime(), "atime");
@@ -336,6 +345,7 @@ public class FileTimesIT extends AbstractTestCase {
             e = tin.getNextTarEntry();
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20Z"), e.getLastModifiedTime(), "mtime");
             assertNull(e.getLastAccessTime(), "atime");
@@ -406,6 +416,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/", e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T01:01:34Z"), e.getLastAccessTime(), "atime");
@@ -413,6 +424,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNull(e.getCreationTime(), "birthtime");
             e = tin.getNextTarEntry();
             assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals(toFileTime("2022-03-17T00:38:20Z"), e.getLastModifiedTime(), "mtime");
@@ -476,6 +488,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/", e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T01:01:19.581236400Z"), e.getLastAccessTime(), "atime");
@@ -484,6 +497,7 @@ public class FileTimesIT extends AbstractTestCase {
             e = tin.getNextTarEntry();
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T00:38:20.536752000Z"), e.getLastAccessTime(), "atime");
@@ -503,6 +517,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("test-times.txt", e.getName(), "name");
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T00:38:20.536752000Z"), e.getLastAccessTime(), "atime");
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getStatusChangeTime(), "ctime");
@@ -511,6 +526,7 @@ public class FileTimesIT extends AbstractTestCase {
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
             assertEquals("test-times.txt", e.getName(), "name");
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertEquals(toFileTime("2022-03-17T01:52:25.592262900Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-17T01:52:25.724278500Z"), e.getLastAccessTime(), "atime");
             assertEquals(toFileTime("2022-03-17T01:52:25.592262900Z"), e.getStatusChangeTime(), "ctime");

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -47,6 +47,7 @@ public class SparseFilesTest extends AbstractTestCase {
 
     private void assertPaxGNUEntry(final TarArchiveEntry entry, final String suffix) {
         assertEquals("sparsefile-" + suffix, entry.getName());
+        assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
         assertTrue(entry.isGNUSparse());
         assertTrue(entry.isPaxGNUSparse());
         assertFalse(entry.isOldGNUSparse());
@@ -67,6 +68,7 @@ public class SparseFilesTest extends AbstractTestCase {
     private void assertPaxGNUEntry(final TarArchiveInputStream tin, final String suffix) throws Throwable {
         final TarArchiveEntry ae = tin.getNextTarEntry();
         assertEquals("sparsefile-" + suffix, ae.getName());
+        assertEquals(TarConstants.LF_NORMAL, ae.getLinkFlag());
         assertTrue(ae.isGNUSparse());
         assertTrue(ae.isPaxGNUSparse());
         assertFalse(ae.isOldGNUSparse());
@@ -255,6 +257,7 @@ public class SparseFilesTest extends AbstractTestCase {
         try (TarArchiveInputStream tin = new TarArchiveInputStream(Files.newInputStream(file.toPath()))) {
             final TarArchiveEntry ae = tin.getNextTarEntry();
             assertEquals("sparsefile", ae.getName());
+            assertEquals(TarConstants.LF_GNUTYPE_SPARSE, ae.getLinkFlag());
             assertTrue(ae.isOldGNUSparse());
             assertTrue(ae.isGNUSparse());
             assertFalse(ae.isPaxGNUSparse());
@@ -429,6 +432,7 @@ public class SparseFilesTest extends AbstractTestCase {
         try (final TarFile tarFile = new TarFile(file)) {
             final TarArchiveEntry ae = tarFile.getEntries().get(0);
             assertEquals("sparsefile", ae.getName());
+            assertEquals(TarConstants.LF_GNUTYPE_SPARSE, ae.getLinkFlag());
             assertTrue(ae.isOldGNUSparse());
             assertTrue(ae.isGNUSparse());
             assertFalse(ae.isPaxGNUSparse());

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
@@ -154,8 +154,10 @@ public class TarArchiveEntryTest implements TarConstants {
         assumeTrue("C:\\".equals(ROOT));
         TarArchiveEntry t = new TarArchiveEntry(ROOT + "foo.txt", true);
         assertEquals("C:/foo.txt", t.getName());
+        assertEquals(TarConstants.LF_NORMAL, t.getLinkFlag());
         t = new TarArchiveEntry(ROOT + "foo.txt", LF_GNUTYPE_LONGNAME, true);
         assertEquals("C:/foo.txt", t.getName());
+        assertEquals(TarConstants.LF_GNUTYPE_LONGNAME, t.getLinkFlag());
     }
 
     private String readMagic(final TarArchiveEntry t) {
@@ -349,6 +351,7 @@ public class TarArchiveEntryTest implements TarConstants {
     public void testFileSystemRoot() {
         final TarArchiveEntry t = new TarArchiveEntry(new File(ROOT));
         assertEquals("/", t.getName());
+        assertEquals(TarConstants.LF_DIR, t.getLinkFlag());
     }
 
     @Test
@@ -356,6 +359,7 @@ public class TarArchiveEntryTest implements TarConstants {
         final TarArchiveEntry t = new TarArchiveEntry("/foo", LF_GNUTYPE_LONGNAME);
         assertGnuMagic(t);
         assertEquals("foo", t.getName());
+        assertEquals(TarConstants.LF_GNUTYPE_LONGNAME, t.getLinkFlag());
     }
 
     @Test
@@ -363,6 +367,7 @@ public class TarArchiveEntryTest implements TarConstants {
         final TarArchiveEntry t = new TarArchiveEntry("/foo", LF_NORMAL);
         assertPosixMagic(t);
         assertEquals("foo", t.getName());
+        assertEquals(TarConstants.LF_NORMAL, t.getLinkFlag());
     }
 
     @Test
@@ -371,6 +376,7 @@ public class TarArchiveEntryTest implements TarConstants {
                                                 true);
         assertGnuMagic(t);
         assertEquals("/foo", t.getName());
+        assertEquals(TarConstants.LF_GNUTYPE_LONGNAME, t.getLinkFlag());
     }
 
     @Test
@@ -437,18 +443,22 @@ public class TarArchiveEntryTest implements TarConstants {
             t = tin.getNextTarEntry();
             assertNotNull(t);
             assertEquals("/", t.getName());
+            assertEquals(TarConstants.LF_DIR, t.getLinkFlag());
             assertTrue(t.isCheckSumOK());
             t = tin.getNextTarEntry();
             assertNotNull(t);
             assertEquals("foo.txt", t.getName());
+            assertEquals(TarConstants.LF_NORMAL, t.getLinkFlag());
             assertTrue(t.isCheckSumOK());
             t = tin.getNextTarEntry();
             assertNotNull(t);
             assertEquals("bar.txt", t.getName());
+            assertEquals(TarConstants.LF_NORMAL, t.getLinkFlag());
             assertTrue(t.isCheckSumOK());
             t = tin.getNextTarEntry();
             assertNotNull(t);
             assertEquals("baz.txt", t.getName());
+            assertEquals(TarConstants.LF_NORMAL, t.getLinkFlag());
             assertTrue(t.isCheckSumOK());
         } finally {
             if (tin != null) {

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
@@ -54,6 +54,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream in = new TarArchiveInputStream(Files.newInputStream(getFile(archive).toPath()))) {
             final TarArchiveEntry tae = in.getNextTarEntry();
             assertEquals("foo", tae.getName());
+            assertEquals(TarConstants.LF_NORMAL, tae.getLinkFlag());
             final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
             cal.set(1969, 11, 31, 23, 59, 59);
             cal.set(Calendar.MILLISECOND, 0);
@@ -234,7 +235,9 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
     public void skipsDevNumbersWhenEntryIsNoDevice() throws Exception {
         try (TarArchiveInputStream is = getTestStream("/COMPRESS-417.tar")) {
             assertEquals("test1.xml", is.getNextTarEntry().getName());
+            assertEquals(TarConstants.LF_NORMAL, is.getCurrentEntry().getLinkFlag());
             assertEquals("test2.xml", is.getNextTarEntry().getName());
+            assertEquals(TarConstants.LF_NORMAL, is.getCurrentEntry().getLinkFlag());
             assertNull(is.getNextTarEntry());
         }
     }
@@ -247,6 +250,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream is = getTestStream("/COMPRESS-355.tar")) {
             final TarArchiveEntry entry = is.getNextTarEntry();
             assertEquals("package/package.json", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
             assertNull(is.getNextTarEntry());
         }
     }
@@ -259,6 +263,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream is = getTestStream("/COMPRESS-356.tar")) {
             final TarArchiveEntry entry = is.getNextTarEntry();
             assertEquals("package/package.json", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
             assertNull(is.getNextTarEntry());
         }
     }
@@ -296,8 +301,11 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         try (final ByteArrayInputStream bis = new ByteArrayInputStream(data);
              final TarArchiveInputStream tis = new TarArchiveInputStream(bis)) {
             assertEquals(folderName, tis.getNextTarEntry().getName());
+            assertEquals(TarConstants.LF_DIR, tis.getCurrentEntry().getLinkFlag());
             assertEquals(consumerJavaName, tis.getNextTarEntry().getName());
+            assertEquals(TarConstants.LF_NORMAL, tis.getCurrentEntry().getLinkFlag());
             assertEquals(producerJavaName, tis.getNextTarEntry().getName());
+            assertEquals(TarConstants.LF_NORMAL, tis.getCurrentEntry().getLinkFlag());
         }
     }
 
@@ -355,6 +363,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream is = getTestStream("/COMPRESS-356.tar")) {
             final TarArchiveEntry entry = is.getNextTarEntry();
             assertEquals("package/package.json", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
             assertEquals(is.getCurrentEntry(),entry);
             final TarArchiveEntry weaselEntry = new TarArchiveEntry(entry.getName());
             weaselEntry.setSize(entry.getSize());
@@ -425,6 +434,7 @@ public class TarArchiveInputStreamTest extends AbstractTestCase {
             TarArchiveEntry tae = in.getNextTarEntry();
             tae = in.getNextTarEntry();
             assertEquals("sample/link-to-txt-file.lnk", tae.getName());
+            assertEquals(TarConstants.LF_SYMLINK, tae.getLinkFlag());
             assertEquals(new Date(0), tae.getLastModifiedDate());
             assertTrue(tae.isSymbolicLink());
             assertTrue(tae.isCheckSumOK());

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
@@ -395,8 +395,9 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
 		TarArchiveEntry entryIn = in.getNextTarEntry();
 		assertNotNull(entryIn);
 		assertEquals("message", entryIn.getName());
+        assertEquals(TarConstants.LF_NORMAL, entryIn.getLinkFlag());
 		assertEquals("global-weasels", entryIn.getExtraPaxHeader("SCHILLY.xattr.user.org.apache.weasels"));
-		final Reader reader = new InputStreamReader(in);
+        final Reader reader = new InputStreamReader(in);
 		for (int i = 0; i < x.length(); i++) {
 			assertEquals(x.charAt(i), reader.read());
 		}
@@ -524,6 +525,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n.substring(0, TarConstants.NAMELEN) + "/", e.getName(), "Entry name");
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory(), "The entry is not a directory");
         }
     }
@@ -547,6 +549,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
             assertEquals("160 path=" + n + "\n", new String(data, 512, 160, UTF_8));
             try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
                 assertEquals(n, tin.getNextTarEntry().getName());
+                assertEquals(TarConstants.LF_NORMAL, tin.getCurrentEntry().getLinkFlag());
             }
         }
     }
@@ -584,6 +587,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
             assertEquals("test", e.getName(), "Entry name");
             assertEquals(linkname, e.getLinkName(), "Link name");
             assertTrue(e.isSymbolicLink(), "The entry is not a symbolic link");
+            assertEquals(TarConstants.LF_SYMLINK, e.getLinkFlag(), "Link flag");
         }
     }
 
@@ -643,6 +647,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(linkname.substring(0, TarConstants.NAMELEN), e.getLinkName(), "Link name");
+            assertEquals(TarConstants.LF_SYMLINK, e.getLinkFlag(), "Link flag");
         }
     }
 
@@ -663,6 +668,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getName());
+            assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
         }
     }
@@ -685,6 +691,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getLinkName());
+            assertEquals(TarConstants.LF_LINK, e.getLinkFlag(), "Link flag");
         }
     }
 
@@ -705,6 +712,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertFalse(e.isDirectory());
         }
     }
@@ -726,6 +734,7 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getName());
+            assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarFileTest.java
@@ -63,6 +63,7 @@ public class TarFileTest extends AbstractTestCase {
         try (final TarFile tarFile = new TarFile(getPath(archive))) {
             final TarArchiveEntry entry = tarFile.getEntries().get(0);
             assertEquals("foo", entry.getName());
+            assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
             final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
             cal.set(1969, 11, 31, 23, 59, 59);
             cal.set(Calendar.MILLISECOND, 0);
@@ -197,7 +198,9 @@ public class TarFileTest extends AbstractTestCase {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(2, entries.size());
             assertEquals("test1.xml", entries.get(0).getName());
+            assertEquals(TarConstants.LF_NORMAL, entries.get(0).getLinkFlag());
             assertEquals("test2.xml", entries.get(1).getName());
+            assertEquals(TarConstants.LF_NORMAL, entries.get(1).getLinkFlag());
         }
     }
 
@@ -210,6 +213,7 @@ public class TarFileTest extends AbstractTestCase {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(1, entries.size());
             assertEquals("package/package.json", entries.get(0).getName());
+            assertEquals(TarConstants.LF_NORMAL, entries.get(0).getLinkFlag());
         }
     }
 
@@ -222,6 +226,7 @@ public class TarFileTest extends AbstractTestCase {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(1, entries.size());
             assertEquals("package/package.json", entries.get(0).getName());
+            assertEquals(TarConstants.LF_NORMAL, entries.get(0).getLinkFlag());
         }
     }
 
@@ -253,8 +258,11 @@ public class TarFileTest extends AbstractTestCase {
         try (final TarFile tarFile = new TarFile(data)) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(folderName, entries.get(0).getName());
+            assertEquals(TarConstants.LF_DIR, entries.get(0).getLinkFlag());
             assertEquals(consumerJavaName, entries.get(1).getName());
+            assertEquals(TarConstants.LF_NORMAL, entries.get(1).getLinkFlag());
             assertEquals(producerJavaName, entries.get(2).getName());
+            assertEquals(TarConstants.LF_NORMAL, entries.get(2).getLinkFlag());
         }
     }
 
@@ -342,6 +350,7 @@ public class TarFileTest extends AbstractTestCase {
             assertEquals(3, entries.size());
             final TarArchiveEntry entry = entries.get(1);
             assertEquals("sample/link-to-txt-file.lnk", entry.getName());
+            assertEquals(TarConstants.LF_SYMLINK, entry.getLinkFlag());
             assertEquals(new Date(0), entry.getLastModifiedDate());
             assertTrue(entry.isSymbolicLink());
             assertTrue(entry.isCheckSumOK());


### PR DESCRIPTION
Hi.
I'm making a tar compressing tool.
And I need to know what the original flag of a tar entry I read, otherwise I would make it changed in the decompressed result...
