### PR TITLE
COMPRESS-642 Integer overflow ArithmeticException in TarArchiveOutputStream

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -107,7 +107,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     private int longFileMode = LONGFILE_ERROR;
     private int bigNumberMode = BIGNUMBER_ERROR;
 
-    private int recordsWritten;
+    private long recordsWritten;
 
     private final int recordsPerBlock;
 
@@ -348,7 +348,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
                 + "' before the '" + currSize
                 + "' bytes specified in the header were written");
         }
-        recordsWritten = ExactMath.add(recordsWritten, (currSize / RECORD_SIZE));
+        recordsWritten += (currSize / RECORD_SIZE);
 
         if (0 != currSize % RECORD_SIZE) {
             recordsWritten++;
@@ -535,7 +535,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
     }
 
     private void padAsNeeded() throws IOException {
-        final int start = recordsWritten % recordsPerBlock;
+        final int start = Math.toIntExact(recordsWritten % recordsPerBlock);
         if (start != 0) {
             for (int i = start; i < recordsPerBlock; i++) {
                 writeEOFRecord();

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -348,7 +348,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
                 + "' before the '" + currSize
                 + "' bytes specified in the header were written");
         }
-        recordsWritten += (currSize / RECORD_SIZE);
+        recordsWritten += currSize / RECORD_SIZE;
 
         if (0 != currSize % RECORD_SIZE) {
             recordsWritten++;

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
@@ -48,6 +48,8 @@ import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class TarArchiveOutputStreamTest extends AbstractTestCase {
@@ -766,6 +768,27 @@ public class TarArchiveOutputStreamTest extends AbstractTestCase {
         }
 
         return bos.toByteArray();
+    }
+
+    /**
+     * @see "https://issues.apache.org/jira/browse/COMPRESS-642"
+     */
+    @Disabled("The test needs to write 1.1 TB in chunks of 512 bytes which takes a long time. So it's disabled by default")
+    @Test
+    public void testWritingBigFile() throws Exception {
+        final TarArchiveEntry t = new TarArchiveEntry("foo");
+        t.setSize((Integer.MAX_VALUE + 1L) * TarConstants.DEFAULT_RCDSIZE);
+        final TarArchiveOutputStream tos = new TarArchiveOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+        tos.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+        tos.putArchiveEntry(t);
+
+        byte[] bytes = new byte[TarConstants.DEFAULT_RCDSIZE];
+        for (int i = 0; i < Integer.MAX_VALUE; i++) {
+            tos.write(bytes);
+        }
+        tos.write(bytes);
+        tos.closeArchiveEntry();
+        tos.close();
     }
 
 }


### PR DESCRIPTION
I wrote a test to reproduce the issue, writing to a `NullOutputStream`, but that turned out to be really slow due to the forced 512 bytes chunking. So I opted to not include that.

```java
    @Test
    public void testWritingBigFile() throws Exception {
        final TarArchiveEntry t = new TarArchiveEntry("foo");
        t.setSize((Integer.MAX_VALUE + 1L) * TarConstants.DEFAULT_RCDSIZE);
        final TarArchiveOutputStream tos = new TarArchiveOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
        tos.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
        tos.putArchiveEntry(t);

        byte[] bytes = new byte[TarConstants.DEFAULT_RCDSIZE];
        for (int i = 0; i < Integer.MAX_VALUE; i++) {
            tos.write(bytes);
        }
        tos.closeArchiveEntry();
        tos.close();
    }
```