### PR TITLE
Change source encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
     <commons.releaseManagerName>Gary Gregory</commons.releaseManagerName>    
     <commons.releaseManagerKey>86fdc7e2a11262cb</commons.releaseManagerKey>
 
+    <commons.encoding>UTF-8</commons.encoding>
     <commons.manifestlocation>${project.build.outputDirectory}/META-INF</commons.manifestlocation>
     <commons.manifestfile>${commons.manifestlocation}/MANIFEST.MF</commons.manifestfile>
     <commons.osgi.import>

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -297,7 +297,7 @@ public class TarArchiveOutputStream extends ArchiveOutputStream {
             TarConstants.MAXID);
         // libarchive extensions
         addFileTimePaxHeader(paxHeaders, "LIBARCHIVE.creationtime", entry.getCreationTime());
-        // star extensions by Jörg Schilling
+        // star extensions by JÃ¶rg Schilling
         addPaxHeaderForBigNumber(paxHeaders, "SCHILY.devmajor",
             entry.getDevMajor(), TarConstants.MAXID);
         addPaxHeaderForBigNumber(paxHeaders, "SCHILY.devminor",


### PR DESCRIPTION
We have a project which bootstraps Maven. It manually calls `javac` and we encountered a problem with source encoding.
I would like to unify source encodings to UTF-8.