### PR TITLE
Remove redundant (null) initializations

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -201,7 +201,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream {
         boolean found = false;
         byte[] basicHeaderBytes = null;
         do {
-            int first = 0;
+            int first;
             int second = read8(in);
             do {
                 first = second;

--- a/src/main/java/org/apache/commons/compress/archivers/examples/Expander.java
+++ b/src/main/java/org/apache/commons/compress/archivers/examples/Expander.java
@@ -198,11 +198,10 @@ public class Expander {
      * @since 1.22
      */
     public void expand(final Path archive, final Path targetDirectory) throws IOException, ArchiveException {
-        String format = null;
         try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(archive))) {
-            format = ArchiveStreamFactory.detect(inputStream);
+            String format = ArchiveStreamFactory.detect(inputStream);
+            expand(format, archive, targetDirectory);
         }
-        expand(format, archive, targetDirectory);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -40,7 +40,6 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipEncoding;
 import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
 import org.apache.commons.compress.utils.CountingOutputStream;
-import org.apache.commons.compress.utils.ExactMath;
 import org.apache.commons.compress.utils.FixedLengthBlockOutputStream;
 import org.apache.commons.compress.utils.TimeUtils;
 

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -680,7 +680,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
             parsingBehavior)));
         final List<ZipExtraField> merged = new ArrayList<>();
         for (final ZipExtraField l : localFields) {
-            ZipExtraField c = null;
+            ZipExtraField c;
             if (l instanceof UnparseableExtraFieldData) {
                 c = findUnparseable(centralFields);
             } else {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
@@ -480,7 +480,7 @@ public class ZipArchiveOutputStream extends ArchiveOutputStream {
         def = new Deflater(level, true);
         OutputStream outputStream = null;
         SeekableByteChannel channel = null;
-        StreamCompressor streamCompressor = null;
+        StreamCompressor streamCompressor;
         try {
             channel = Files.newByteChannel(file,
                 EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE,

--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
@@ -98,7 +98,7 @@ public class GzipCompressorInputStream extends CompressorInputStream
 
     private static byte[] readToNull(final DataInput inData) throws IOException {
         try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            int b = 0;
+            int b;
             while ((b = inData.readUnsignedByte()) != 0x00) { // NOPMD NOSONAR
                 bos.write(b);
             }

--- a/src/main/java/org/apache/commons/compress/compressors/lz4/BlockLZ4CompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/lz4/BlockLZ4CompressorInputStream.java
@@ -63,7 +63,7 @@ public class BlockLZ4CompressorInputStream extends AbstractLZ77CompressorInputSt
      * last block of the stream.
      */
     private boolean initializeBackReference() throws IOException {
-        int backReferenceOffset = 0;
+        int backReferenceOffset;
         try {
             backReferenceOffset = (int) ByteUtils.fromLittleEndian(supplier, 2);
         } catch (final IOException ex) {

--- a/src/main/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorOutputStream.java
@@ -271,7 +271,7 @@ public class SnappyCompressorOutputStream extends CompressorOutputStream {
     }
 
     private void writeUncompressedSize(long uncompressedSize) throws IOException {
-        boolean more = false;
+        boolean more;
         do {
             int currentByte = (int) (uncompressedSize & 0x7F);
             more = uncompressedSize > currentByte;

--- a/src/main/java/org/apache/commons/compress/harmony/pack200/MetadataBandGroup.java
+++ b/src/main/java/org/apache/commons/compress/harmony/pack200/MetadataBandGroup.java
@@ -266,7 +266,7 @@ public class MetadataBandGroup extends BandSet {
             } else {
                 contextStr = "Method";
             }
-            byte[] encodedBand = null;
+            byte[] encodedBand;
             if (!type.equals("AD")) {
                 if (type.indexOf('P') != -1) {
                     // Parameter annotation so we need to transmit param_NB

--- a/src/main/java/org/apache/commons/compress/harmony/pack200/PopulationCodec.java
+++ b/src/main/java/org/apache/commons/compress/harmony/pack200/PopulationCodec.java
@@ -92,7 +92,7 @@ public class PopulationCodec extends Codec {
             } else {
                 // if k >= 256, b >= 2
                 int b = 1;
-                BHSDCodec codec = null;
+                BHSDCodec codec;
                 while (++b < 5) {
                     codec = new BHSDCodec(b, 256 - l, 0);
                     if (codec.encodes(k)) {

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/Segment.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/Segment.java
@@ -148,7 +148,7 @@ public class Segment {
                         firstDollar = index;
                     }
                 }
-                String fileName = null;
+                String fileName;
 
                 if (firstDollar > -1 && (i <= firstDollar)) {
                     fileName = fullName.substring(i, firstDollar) + ".java";
@@ -235,11 +235,10 @@ public class Segment {
             final String outerClassString = icStored.outerClassString();
             final String simpleClassName = icStored.simpleClassName();
 
-            CPClass innerClass = null;
             CPUTF8 innerName = null;
             CPClass outerClass = null;
 
-            innerClass = innerClassIndex != -1 ? cpBands.cpClassValue(innerClassIndex)
+            CPClass innerClass = innerClassIndex != -1 ? cpBands.cpClassValue(innerClassIndex)
                 : cpBands.cpClassValue(innerClassString);
             if (!icStored.isAnonymous()) {
                 innerName = simpleClassNameIndex != -1 ? cpBands.cpUTF8Value(simpleClassNameIndex)

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/SegmentConstantPool.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/SegmentConstantPool.java
@@ -113,7 +113,7 @@ public class SegmentConstantPool {
         final String desiredClassName) throws Pack200Exception {
         final int index = (int) desiredIndex;
         int realIndex = -1;
-        String[] array = null;
+        String[] array;
         switch (cp) {
         case CP_FIELD:
             array = bands.getCpFieldClass();

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ClassRefForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ClassRefForm.java
@@ -62,9 +62,8 @@ public class ClassRefForm extends ReferenceForm {
         // the spec except for multianewarray, which has
         // its own form.)
         final SegmentConstantPool globalPool = operandManager.globalConstantPool();
-        ClassFileEntry[] nested = null;
         // How do I get this class?
-        nested = new ClassFileEntry[] {globalPool.getClassPoolEntry(operandManager.getCurrentClass())};
+        ClassFileEntry[] nested = new ClassFileEntry[] {globalPool.getClassPoolEntry(operandManager.getCurrentClass())};
         byteCode.setNested(nested);
         byteCode.setNestedPositions(new int[][] {{0, 2}});
     }

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ClassSpecificReferenceForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ClassSpecificReferenceForm.java
@@ -45,8 +45,7 @@ public abstract class ClassSpecificReferenceForm extends ReferenceForm {
     protected void setNestedEntries(final ByteCode byteCode, final OperandManager operandManager, final int offset)
         throws Pack200Exception {
         final SegmentConstantPool globalPool = operandManager.globalConstantPool();
-        ClassFileEntry[] nested = null;
-        nested = new ClassFileEntry[] {
+        ClassFileEntry[] nested = new ClassFileEntry[] {
             globalPool.getClassSpecificPoolEntry(getPoolID(), offset, context(operandManager))};
         byteCode.setNested(nested);
         byteCode.setNestedPositions(new int[][] {{0, 2}});

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/InitMethodReferenceForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/InitMethodReferenceForm.java
@@ -49,8 +49,7 @@ public abstract class InitMethodReferenceForm extends ClassSpecificReferenceForm
     protected void setNestedEntries(final ByteCode byteCode, final OperandManager operandManager, final int offset)
         throws Pack200Exception {
         final SegmentConstantPool globalPool = operandManager.globalConstantPool();
-        ClassFileEntry[] nested = null;
-        nested = new ClassFileEntry[] {
+        ClassFileEntry[] nested = new ClassFileEntry[] {
             globalPool.getInitMethodPoolEntry(SegmentConstantPool.CP_METHOD, offset, context(operandManager))};
         byteCode.setNested(nested);
         byteCode.setNestedPositions(new int[][] {{0, 2}});

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/NewClassRefForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/NewClassRefForm.java
@@ -45,12 +45,11 @@ public class NewClassRefForm extends ClassRefForm {
     @Override
     public void setByteCodeOperands(final ByteCode byteCode, final OperandManager operandManager,
         final int codeLength) {
-        ClassFileEntry[] nested = null;
         final int offset = getOffset(operandManager);
         if (offset == 0) {
             // Use current class
             final SegmentConstantPool globalPool = operandManager.globalConstantPool();
-            nested = new ClassFileEntry[] {globalPool.getClassPoolEntry(operandManager.getCurrentClass())};
+            ClassFileEntry[] nested = new ClassFileEntry[] {globalPool.getClassPoolEntry(operandManager.getCurrentClass())};
             byteCode.setNested(nested);
             byteCode.setNestedPositions(new int[][] {{0, 2}});
         } else {

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/NewInitMethodRefForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/NewInitMethodRefForm.java
@@ -41,8 +41,7 @@ public class NewInitMethodRefForm extends InitMethodReferenceForm {
     protected void setNestedEntries(final ByteCode byteCode, final OperandManager operandManager, final int offset)
         throws Pack200Exception {
         final SegmentConstantPool globalPool = operandManager.globalConstantPool();
-        ClassFileEntry[] nested = null;
-        nested = new ClassFileEntry[] {
+        ClassFileEntry[] nested = new ClassFileEntry[] {
             globalPool.getInitMethodPoolEntry(SegmentConstantPool.CP_METHOD, offset, context(operandManager))};
         byteCode.setNested(nested);
         byteCode.setNestedPositions(new int[][] {{0, 2}});

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ReferenceForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ReferenceForm.java
@@ -60,8 +60,7 @@ public abstract class ReferenceForm extends ByteCodeForm {
     protected void setNestedEntries(final ByteCode byteCode, final OperandManager operandManager, final int offset)
         throws Pack200Exception {
         final SegmentConstantPool globalPool = operandManager.globalConstantPool();
-        ClassFileEntry[] nested = null;
-        nested = new ClassFileEntry[] {globalPool.getConstantPoolEntry(getPoolID(), offset)};
+        ClassFileEntry[] nested = new ClassFileEntry[] {globalPool.getConstantPoolEntry(getPoolID(), offset)};
         Objects.requireNonNull(nested[0], "Null nested entries are not allowed");
         byteCode.setNested(nested);
         byteCode.setNestedPositions(new int[][] {{0, 2}});

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/StringRefForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/StringRefForm.java
@@ -19,7 +19,6 @@ package org.apache.commons.compress.harmony.unpack200.bytecode.forms;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
 import org.apache.commons.compress.harmony.unpack200.SegmentConstantPool;
 import org.apache.commons.compress.harmony.unpack200.bytecode.ByteCode;
-import org.apache.commons.compress.harmony.unpack200.bytecode.CPString;
 import org.apache.commons.compress.harmony.unpack200.bytecode.ClassFileEntry;
 import org.apache.commons.compress.harmony.unpack200.bytecode.OperandManager;
 
@@ -52,8 +51,7 @@ public class StringRefForm extends SingleByteReferenceForm {
     protected void setNestedEntries(final ByteCode byteCode, final OperandManager operandManager, final int offset)
         throws Pack200Exception {
         final SegmentConstantPool globalPool = operandManager.globalConstantPool();
-        ClassFileEntry[] nested = null;
-        nested = new ClassFileEntry[] {((CPString) globalPool.getValue(getPoolID(), offset))};
+        ClassFileEntry[] nested = new ClassFileEntry[] {globalPool.getValue(getPoolID(), offset)};
         byteCode.setNested(nested);
         if (widened) {
             byteCode.setNestedPositions(new int[][] {{0, 2}});

--- a/src/test/java/org/apache/commons/compress/AbstractTestCase.java
+++ b/src/test/java/org/apache/commons/compress/AbstractTestCase.java
@@ -35,7 +35,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -56,13 +55,12 @@ public abstract class AbstractTestCase {
         if (url == null) {
             throw new FileNotFoundException("couldn't find " + path);
         }
-        URI uri = null;
         try {
-            uri = url.toURI();
+            URI uri = url.toURI();
+            return new File(uri);
         } catch (final java.net.URISyntaxException ex) {
             throw new IOException(ex);
         }
-        return new File(uri);
     }
 
     public static Path getPath(final String path) throws IOException {
@@ -189,7 +187,7 @@ public abstract class AbstractTestCase {
         result.deleteOnExit();
 
         try {
-            ArchiveEntry entry = null;
+            ArchiveEntry entry;
             while ((entry = in.getNextEntry()) != null) {
                 final File outfile = new File(result.getCanonicalPath() + "/result/" + entry.getName());
                 long copied = 0;

--- a/src/test/java/org/apache/commons/compress/archivers/CpioTestCase.java
+++ b/src/test/java/org/apache/commons/compress/archivers/CpioTestCase.java
@@ -93,7 +93,7 @@ public final class CpioTestCase extends AbstractTestCase {
 
 
         final Map<String, File> result = new HashMap<>();
-        ArchiveEntry entry = null;
+        ArchiveEntry entry;
         while ((entry = in.getNextEntry()) != null) {
             final File cpioget = new File(dir, entry.getName());
             Files.copy(in, cpioget.toPath());

--- a/src/test/java/org/apache/commons/compress/archivers/LongPathTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/LongPathTest.java
@@ -81,7 +81,6 @@ public class LongPathTest extends AbstractTestCase {
                     FILELIST.add(line);
                 }
             }
-            br.close();
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/ZipTestCase.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ZipTestCase.java
@@ -618,13 +618,13 @@ public final class ZipTestCase extends AbstractTestCase {
         try (final InputStream fis = Files.newInputStream(input.toPath());
             ArchiveInputStream in = ArchiveStreamFactory.DEFAULT.createArchiveInputStream("zip", fis)) {
 
-            ZipArchiveEntry entry = null;
+            ZipArchiveEntry entry;
             while ((entry = (ZipArchiveEntry) in.getNextEntry()) != null) {
                 results.add(entry.getName());
 
                 final ArchiveInputStream nestedIn = ArchiveStreamFactory.DEFAULT.createArchiveInputStream("zip", in);
                 try {
-                    ZipArchiveEntry nestedEntry = null;
+                    ZipArchiveEntry nestedEntry;
                     while ((nestedEntry = (ZipArchiveEntry) nestedIn.getNextEntry()) != null) {
                         results.add(nestedEntry.getName());
                     }
@@ -746,7 +746,7 @@ public final class ZipTestCase extends AbstractTestCase {
         try (final InputStream fileInputStream = Files.newInputStream(output.toPath())) {
             try (ArchiveInputStream archiveInputStream = ArchiveStreamFactory.DEFAULT.createArchiveInputStream("zip",
                 fileInputStream)) {
-                ZipArchiveEntry entry = null;
+                ZipArchiveEntry entry;
                 while ((entry = (ZipArchiveEntry) archiveInputStream.getNextEntry()) != null) {
                     final File outfile = new File(resultDir.getCanonicalPath() + "/result/" + entry.getName());
                     outfile.getParentFile().mkdirs();
@@ -809,7 +809,7 @@ public final class ZipTestCase extends AbstractTestCase {
     public void testZipArchiveEntryNewFromPath() throws Exception {
         final File[] tmp = createTempDirAndFile();
         File archiveFile = null;
-        Path archivePath = null;
+        Path archivePath;
         ZipArchiveOutputStream zos = null;
         ZipFile zf = null;
         InputStream fis = null;

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
@@ -77,7 +77,7 @@ public class CpioArchiveInputStreamTest extends AbstractTestCase {
     public void testCpioUnarchiveCreatedByRedlineRpm() throws Exception {
         int count = 0;
         try (final CpioArchiveInputStream in = new CpioArchiveInputStream(newInputStream("redline.cpio"))) {
-            CpioArchiveEntry entry = null;
+            CpioArchiveEntry entry;
 
             while ((entry = (CpioArchiveEntry) in.getNextEntry()) != null) {
                 count++;
@@ -92,7 +92,7 @@ public class CpioArchiveInputStreamTest extends AbstractTestCase {
     public void testCpioUnarchiveMultibyteCharName() throws Exception {
         int count = 0;
         try (final CpioArchiveInputStream in = new CpioArchiveInputStream(newInputStream("COMPRESS-459.cpio"), "UTF-8")) {
-            CpioArchiveEntry entry = null;
+            CpioArchiveEntry entry;
 
             while ((entry = (CpioArchiveEntry) in.getNextEntry()) != null) {
                 count++;

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStreamTest.java
@@ -45,7 +45,6 @@ public class CpioArchiveOutputStreamTest extends AbstractTestCase {
             final CpioArchiveEntry e = in.getNextCPIOEntry();
             assertEquals("test1.xml", e.getName());
             assertNull(in.getNextEntry());
-        } finally {
         }
     }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -31,11 +31,9 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Locale;
 
 import org.apache.commons.compress.AbstractTestCase;
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;

--- a/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
@@ -81,28 +81,26 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
 
         final ZipEncoding zipEncoding = ZipEncodingHelper.getZipEncoding(encoding);
 
-        ZipArchiveOutputStream zos = null;
-        try {
-            zos = new ZipArchiveOutputStream(file);
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(file)) {
             zos.setEncoding(encoding);
             zos.setUseLanguageEncodingFlag(withEFS);
             zos.setCreateUnicodeExtraFields(withExplicitUnicodeExtra ?
-                                            ZipArchiveOutputStream
-                                            .UnicodeExtraFieldPolicy.NEVER
-                                            : ZipArchiveOutputStream
-                                            .UnicodeExtraFieldPolicy.ALWAYS);
+                    ZipArchiveOutputStream
+                            .UnicodeExtraFieldPolicy.NEVER
+                    : ZipArchiveOutputStream
+                    .UnicodeExtraFieldPolicy.ALWAYS);
 
             ZipArchiveEntry ze = new ZipArchiveEntry(OIL_BARREL_TXT);
             if (withExplicitUnicodeExtra
-                && !zipEncoding.canEncode(ze.getName())) {
+                    && !zipEncoding.canEncode(ze.getName())) {
 
                 final ByteBuffer en = zipEncoding.encode(ze.getName());
 
                 ze.addExtraField(new UnicodePathExtraField(ze.getName(),
-                                                           en.array(),
-                                                           en.arrayOffset(),
-                                                           en.limit()
-                                                           - en.position()));
+                        en.array(),
+                        en.arrayOffset(),
+                        en.limit()
+                                - en.position()));
             }
 
             zos.putArchiveEntry(ze);
@@ -111,15 +109,15 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
 
             ze = new ZipArchiveEntry(EURO_FOR_DOLLAR_TXT);
             if (withExplicitUnicodeExtra
-                && !zipEncoding.canEncode(ze.getName())) {
+                    && !zipEncoding.canEncode(ze.getName())) {
 
                 final ByteBuffer en = zipEncoding.encode(ze.getName());
 
                 ze.addExtraField(new UnicodePathExtraField(ze.getName(),
-                                                           en.array(),
-                                                           en.arrayOffset(),
-                                                           en.limit()
-                                                           - en.position()));
+                        en.array(),
+                        en.arrayOffset(),
+                        en.limit()
+                                - en.position()));
             }
 
             zos.putArchiveEntry(ze);
@@ -129,15 +127,15 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
             ze = new ZipArchiveEntry(ASCII_TXT);
 
             if (withExplicitUnicodeExtra
-                && !zipEncoding.canEncode(ze.getName())) {
+                    && !zipEncoding.canEncode(ze.getName())) {
 
                 final ByteBuffer en = zipEncoding.encode(ze.getName());
 
                 ze.addExtraField(new UnicodePathExtraField(ze.getName(),
-                                                           en.array(),
-                                                           en.arrayOffset(),
-                                                           en.limit()
-                                                           - en.position()));
+                        en.array(),
+                        en.arrayOffset(),
+                        en.limit()
+                                - en.position()));
             }
 
             zos.putArchiveEntry(ze);
@@ -145,12 +143,6 @@ public class UTF8ZipFilesTest extends AbstractTestCase {
             zos.closeArchiveEntry();
 
             zos.finish();
-        } finally {
-            if (zos != null) {
-                try {
-                    zos.close();
-                } catch (final IOException e) { /* swallow */ }
-            }
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/zip/Zip64SupportIT.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/Zip64SupportIT.java
@@ -152,7 +152,7 @@ public class Zip64SupportIT {
         try (InputStream fin = Files.newInputStream(f.toPath());
                 ZipArchiveInputStream zin = new ZipArchiveInputStream(fin)) {
             int files = 0;
-            ZipArchiveEntry zae = null;
+            ZipArchiveEntry zae;
             while ((zae = zin.getNextZipEntry()) != null) {
                 if (!zae.isDirectory()) {
                     files++;
@@ -532,7 +532,7 @@ public class Zip64SupportIT {
         write3EntriesCreatingBigArchiveToStream(final ZipArchiveOutputStream zos)
         throws IOException {
         final byte[] buf = new byte[ONE_MILLION];
-        ZipArchiveEntry zae = null;
+        ZipArchiveEntry zae;
         for (int i = 0; i < 2; i++) {
             zae = new ZipArchiveEntry(String.valueOf(i));
             zae.setSize(FIVE_BILLION / 2);

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileIgnoringLocalFileHeaderTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileIgnoringLocalFileHeaderTest.java
@@ -80,7 +80,7 @@ public class ZipFileIgnoringLocalFileHeaderTest {
     public void testPhysicalOrder() throws IOException {
         try (final ZipFile zf = openZipWithoutLFH("ordertest.zip")) {
             final Enumeration<ZipArchiveEntry> e = zf.getEntriesInPhysicalOrder();
-            ZipArchiveEntry ze = null;
+            ZipArchiveEntry ze;
             do {
                 ze = e.nextElement();
             } while (e.hasMoreElements());

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
@@ -397,7 +397,7 @@ public class ZipFileTest extends AbstractTestCase {
 
     @Test
     public void testCDOrderInMemory() throws Exception {
-        byte[] data = null;
+        byte[] data;
         try (InputStream fis = newInputStream("ordertest.zip")) {
             data = IOUtils.toByteArray(fis);
         }
@@ -463,7 +463,7 @@ public class ZipFileTest extends AbstractTestCase {
     @Test
     public void testConcurrentReadSeekable() throws Exception {
         // mixed.zip contains both inflated and stored files
-        byte[] data = null;
+        byte[] data;
         try (InputStream fis = newInputStream("mixed.zip")) {
             data = IOUtils.toByteArray(fis);
         }

--- a/src/test/java/org/apache/commons/compress/changes/ChangeSetTestCase.java
+++ b/src/test/java/org/apache/commons/compress/changes/ChangeSetTestCase.java
@@ -233,7 +233,6 @@ public final class ChangeSetTestCase extends AbstractTestCase {
 
             final ChangeSetPerformer performer = new ChangeSetPerformer(changes);
             performer.perform(ais, out);
-            is.close();
         }
 
         this.checkArchiveContent(result, archiveList);
@@ -276,7 +275,6 @@ public final class ChangeSetTestCase extends AbstractTestCase {
             archiveList.add("bla/test.txt");
             final ChangeSetPerformer performer = new ChangeSetPerformer(changes);
             performer.perform(ais, out);
-            is.close();
         }
 
         this.checkArchiveContent(result, archiveList);
@@ -838,7 +836,7 @@ public final class ChangeSetTestCase extends AbstractTestCase {
         final File result = File.createTempFile("test", "." + archivename);
         result.deleteOnExit();
 
-        File testtxt = null;
+        File testtxt;
         try (ArchiveInputStream ais = factory.createArchiveInputStream(archivename, Files.newInputStream(input));
                 ArchiveOutputStream out = factory.createArchiveOutputStream(archivename, Files.newOutputStream(result.toPath()))) {
 
@@ -857,10 +855,9 @@ public final class ChangeSetTestCase extends AbstractTestCase {
         }
 
         // Checks
-        File check = null;
         try (BufferedInputStream buf = new BufferedInputStream(Files.newInputStream(result.toPath()));
                 ArchiveInputStream in = factory.createArchiveInputStream(buf)) {
-            check = this.checkArchiveContent(in, archiveList, false);
+            File check = this.checkArchiveContent(in, archiveList, false);
             final File test3xml = new File(check, "result/test/test3.xml");
             assertEquals(testtxt.length(), test3xml.length());
 
@@ -871,8 +868,8 @@ public final class ChangeSetTestCase extends AbstractTestCase {
                     "111111111111111111111111111000101011".equals(str);
                 }
             }
+            rmdir(check);
         }
-        rmdir(check);
     }
 
     /**
@@ -880,11 +877,9 @@ public final class ChangeSetTestCase extends AbstractTestCase {
      *
      * mv dir1/test.text dir2/test.txt + delete dir1 Moves the file to dir2 and
      * deletes everything in dir1
-     *
-     * @throws Exception
      */
     @Test
-    public void testRenameAndDelete() throws Exception {
+    public void testRenameAndDelete() {
     }
 
 }

--- a/src/test/java/org/apache/commons/compress/compressors/BZip2TestCase.java
+++ b/src/test/java/org/apache/commons/compress/compressors/BZip2TestCase.java
@@ -43,7 +43,7 @@ public final class BZip2TestCase extends AbstractTestCase {
 
     @Test
     public void testBzipCreation() throws Exception {
-        File output = null;
+        File output;
         final File input = getFile("test.txt");
         {
             output = new File(dir, "test.txt.bz2");

--- a/src/test/java/org/apache/commons/compress/compressors/DetectCompressorTestCase.java
+++ b/src/test/java/org/apache/commons/compress/compressors/DetectCompressorTestCase.java
@@ -96,12 +96,10 @@ public final class DetectCompressorTestCase {
     };
 
     private String detect(final String testFileName) throws IOException, CompressorException {
-        String name = null;
         try (InputStream is = new BufferedInputStream(
                 Files.newInputStream(getFile(testFileName).toPath()))) {
-            name = CompressorStreamFactory.detect(is);
+            return CompressorStreamFactory.detect(is);
         }
-        return name;
     }
 
     private CompressorInputStream getStreamFor(final String resource)

--- a/src/test/java/org/apache/commons/compress/compressors/pack200/Pack200UtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/pack200/Pack200UtilsTest.java
@@ -54,7 +54,6 @@ public final class Pack200UtilsTest extends AbstractTestCase {
                     entry = in.getNextEntry();
                 }
 
-                in.close();
             }
         } finally {
             output[1].delete();

--- a/src/test/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStreamTest.java
@@ -52,7 +52,6 @@ public final class FramedSnappyCompressorInputStreamTest extends AbstractTestCas
             IOUtils.toByteArray(in);
             assertEquals(-1, in.read(buf));
             assertEquals(-1, in.read(buf));
-            in.close();
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentConstantPoolArrayCacheTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/tests/SegmentConstantPoolArrayCacheTest.java
@@ -29,54 +29,54 @@ public class SegmentConstantPoolArrayCacheTest {
     @Test
     public void testMultipleArrayMultipleHit() {
         final SegmentConstantPoolArrayCache arrayCache = new SegmentConstantPoolArrayCache();
-        final String arrayOne[] = {"Zero", "Shared", "Two", "Shared", "Shared"};
-        final String arrayTwo[] = {"Shared", "One", "Shared", "Shared", "Shared"};
+        final String[] arrayOne = {"Zero", "Shared", "Two", "Shared", "Shared"};
+        final String[] arrayTwo = {"Shared", "One", "Shared", "Shared", "Shared"};
 
-        List listOne = arrayCache.indexesForArrayKey(arrayOne, "Shared");
-        List listTwo = arrayCache.indexesForArrayKey(arrayTwo, "Shared");
+        List<Integer> listOne = arrayCache.indexesForArrayKey(arrayOne, "Shared");
+        List<Integer> listTwo = arrayCache.indexesForArrayKey(arrayTwo, "Shared");
         // Make sure we're using the cached values. First trip
         // through builds the cache.
         listOne = arrayCache.indexesForArrayKey(arrayOne, "Two");
         listTwo = arrayCache.indexesForArrayKey(arrayTwo, "Shared");
 
         assertEquals(1, listOne.size());
-        assertEquals(2, ((Integer)listOne.get(0)).intValue());
+        assertEquals(2, listOne.get(0).intValue());
 
         // Now look for a different element in list one
         listOne = arrayCache.indexesForArrayKey(arrayOne, "Shared");
         assertEquals(3, listOne.size());
-        assertEquals(1, ((Integer)listOne.get(0)).intValue());
-        assertEquals(3, ((Integer)listOne.get(1)).intValue());
-        assertEquals(4, ((Integer)listOne.get(2)).intValue());
+        assertEquals(1, listOne.get(0).intValue());
+        assertEquals(3, listOne.get(1).intValue());
+        assertEquals(4, listOne.get(2).intValue());
 
         assertEquals(4, listTwo.size());
-        assertEquals(0, ((Integer)listTwo.get(0)).intValue());
-        assertEquals(2, ((Integer)listTwo.get(1)).intValue());
-        assertEquals(3, ((Integer)listTwo.get(2)).intValue());
-        assertEquals(4, ((Integer)listTwo.get(3)).intValue());
+        assertEquals(0, listTwo.get(0).intValue());
+        assertEquals(2, listTwo.get(1).intValue());
+        assertEquals(3, listTwo.get(2).intValue());
+        assertEquals(4, listTwo.get(3).intValue());
 
-        final List listThree = arrayCache.indexesForArrayKey(arrayOne, "Not found");
+        final List<Integer> listThree = arrayCache.indexesForArrayKey(arrayOne, "Not found");
         assertEquals(0, listThree.size());
     }
 
     @Test
     public void testSingleMultipleHitArray() {
         final SegmentConstantPoolArrayCache arrayCache = new SegmentConstantPoolArrayCache();
-        final String array[] = {"Zero", "OneThreeFour", "Two", "OneThreeFour", "OneThreeFour"};
-        final List list = arrayCache.indexesForArrayKey(array, "OneThreeFour");
+        final String[] array = {"Zero", "OneThreeFour", "Two", "OneThreeFour", "OneThreeFour"};
+        final List<Integer> list = arrayCache.indexesForArrayKey(array, "OneThreeFour");
         assertEquals(3, list.size());
-        assertEquals(1, ((Integer)list.get(0)).intValue());
-        assertEquals(3, ((Integer)list.get(1)).intValue());
-        assertEquals(4, ((Integer)list.get(2)).intValue());
+        assertEquals(1, list.get(0).intValue());
+        assertEquals(3, list.get(1).intValue());
+        assertEquals(4, list.get(2).intValue());
     }
 
     @Test
     public void testSingleSimpleArray() {
         final SegmentConstantPoolArrayCache arrayCache = new SegmentConstantPoolArrayCache();
-        final String array[] = {"Zero", "One", "Two", "Three", "Four"};
-        final List list = arrayCache.indexesForArrayKey(array, "Three");
+        final String[] array = {"Zero", "One", "Two", "Three", "Four"};
+        final List<Integer> list = arrayCache.indexesForArrayKey(array, "Three");
         assertEquals(1, list.size());
-        assertEquals(3, ((Integer)list.get(0)).intValue());
+        assertEquals(3, list.get(0).intValue());
     }
 
 }


### PR DESCRIPTION
Change
-
- removes redundant (null) initializations
- removes redundant int initializations
- removes redundant close() methods from try-with-resources handled code blocks
- clears some unused imports