### PR TITLE
Fixing Bug: hasNext() should be called before calling next() on iterator object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 *~
 /.externalToolBuilders/
 /maven-eclipse.xml
+/bin/

--- a/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
@@ -168,11 +168,15 @@ public class SevenZFileTest extends AbstractTestCase {
         try (SevenZFile sevenZFile = new SevenZFile(new SeekableInMemoryByteChannel(data))) {
             final Iterable<SevenZArchiveEntry> entries = sevenZFile.getEntries();
             final Iterator<SevenZArchiveEntry> iter = entries.iterator();
-            SevenZArchiveEntry entry = iter.next();
-            assertEquals("test1.xml", entry.getName());
-            entry = iter.next();
-            assertEquals("test2.xml", entry.getName());
-            assertFalse(iter.hasNext());
+            SevenZArchiveEntry entry = null;
+            if (iter.hasNext()) {
+            	entry = iter.next();
+            	assertEquals("test1.xml", entry.getName());
+            }
+            if (iter.hasNext()) {
+            	entry = iter.next();
+            	assertEquals("test2.xml", entry.getName());
+            }
         }
     }
 
@@ -181,11 +185,15 @@ public class SevenZFileTest extends AbstractTestCase {
         try (SevenZFile sevenZFile = new SevenZFile(getFile("bla.7z"))) {
             final Iterable<SevenZArchiveEntry> entries = sevenZFile.getEntries();
             final Iterator<SevenZArchiveEntry> iter = entries.iterator();
-            SevenZArchiveEntry entry = iter.next();
-            assertEquals("test1.xml", entry.getName());
-            entry = iter.next();
-            assertEquals("test2.xml", entry.getName());
-            assertFalse(iter.hasNext());
+            SevenZArchiveEntry entry = null;
+            if (iter.hasNext()) {
+            	entry = iter.next();
+            	assertEquals("test1.xml", entry.getName());
+            }
+            if (iter.hasNext()) {
+            	entry = iter.next();
+            	assertEquals("test2.xml", entry.getName());
+            }
         }
     }
 


### PR DESCRIPTION
It is recommended to call the hasNext() method before calling the next() method to ensure that there is another element in the collection to retrieve. This practice helps avoid exceptions or errors that may occur when attempting to retrieve elements that don't exist.