### PR TITLE
COMPRESS-632: Adding a check for invalid maxCodeSize

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/z/ZCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/z/ZCompressorInputStream.java
@@ -72,11 +72,6 @@ public class ZCompressorInputStream extends LZWInputStream {
         if (blockMode) {
             setClearCode(DEFAULT_CODE_SIZE);
         }
-        // maxCodeSize shifted cannot be less than 256, otherwise the loop in initializeTables() will throw an ArrayIndexOutOfBoundsException
-        // maxCodeSize cannot be smaller than getCodeSize(), otherwise addEntry() will throw an ArrayIndexOutOfBoundsException
-        if ((1 << maxCodeSize) < 256 || getCodeSize() > maxCodeSize) {
-            throw new IOException("Invalid maxCodeSize value: " + maxCodeSize);
-        }
         initializeTables(maxCodeSize, memoryLimitInKb);
         clearEntries();
     }


### PR DESCRIPTION
Adds a validation check and unit test for possible invalid values of maxCodeSize when parsing Z files. This was discovered as part of the fuzzing expansion covered in COMPRESS-632.

This addresses the fact the that maxCodeSize value that is used to initialize the decompression is based on raw byte read by ZCompressorInputStream without validation (unlike the UnshrinkingInputStream in ZIP where is it simply set to a default value). The validation adds three checks:
- Detect values less or equal to zero, otherwise initializeTables() in LZWInputStream will throw an IllegalArgumentException (lines 198-201)
- Detect that (1 << maxCodeSize) is less than 256, otherwise the loop in initializeTables() in LZWInputStream will throw array exceptions (lines 181-184)
- Detect that maxCodeSize is larger than codeSize, otherwise uncaught exceptions will be thrown when the stream is parsed. Specifically, addEntry() in LZWInputStream, lines 79-80.