### PR TITLE
COMPRESS-652: Support converting an existing ZIP file to a ZipArchiveOutputStream for appending

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/StreamCompressor.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/StreamCompressor.java
@@ -168,6 +168,22 @@ public abstract class StreamCompressor implements Closeable {
         return new SeekableByteChannelCompressor(deflater, os);
     }
 
+    /**
+     * Create a stream compressor with the given compression level that
+     * pretends to have written `count` bytes. Used by {@link ZipFile#append()}.
+     *
+     * @param os       The SeekableByteChannel to receive output
+     * @param deflater The deflater to use for the compressor
+     * @param count    The count to initialize
+     * @return A stream compressor
+     * @since 1.26
+     */
+    static StreamCompressor create(final SeekableByteChannel os, final Deflater deflater, final long count) {
+        StreamCompressor sc = create(os, deflater);
+        sc.totalWrittenToOutputStream = count;
+        return sc;
+    }
+
     private final Deflater def;
 
     private final CRC32 crc = new CRC32();

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -714,6 +714,21 @@ public class ZipFile implements Closeable {
     }
 
     /**
+     * Converts this archive to a ZipArchiveOutputStream that retains
+     * its contents. The archive gets closed and the resulting output
+     * stream should be used from here on.
+     *
+     * @throws IOException if creating the output stream fails
+     */
+    public ZipArchiveOutputStream append() throws IOException {
+        ZipArchiveOutputStream os = new ZipArchiveOutputStream(new File(archiveName).toPath(),
+                                                               entries,
+                                                               centralDirectoryStartOffset);
+        this.close();
+        return os;
+    }
+
+    /**
      * Transfer selected entries from this ZIP file to a given #ZipArchiveOutputStream. Compression and all other attributes will be as in this file.
      * <p>
      * This method transfers entries based on the central directory of the ZIP file.


### PR DESCRIPTION
Description and rationale in a JIRA ticket: https://issues.apache.org/jira/projects/COMPRESS/issues/COMPRESS-652.

In addition to adding a test, I’ve verified manually that this works both for small (non-zip64) files and zip64 files with >64K entries in them. While it works, instantiating a ZIPFile on the latter seems to have a significant memory overhead. I intend to improve it, perhaps in another PR.