### PR TITLE
Add a null check for the class loader of OsgiUtils

### DIFF
--- a/src/main/java/org/apache/commons/compress/utils/OsgiUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/OsgiUtils.java
@@ -27,8 +27,9 @@ public class OsgiUtils {
     private static final boolean inOsgiEnvironment;
 
     static {
-        final Class<?> classLoaderClass = OsgiUtils.class.getClassLoader().getClass();
-        inOsgiEnvironment = isBundleReference(classLoaderClass);
+        inOsgiEnvironment = OsgiUtils.class.getClassLoader() != null
+            ? isBundleReference(OsgiUtils.class.getClassLoader().getClass())
+            : false;
     }
 
     private static boolean isBundleReference(final Class<?> clazz) {


### PR DESCRIPTION
`org.apache.commons.compress.utils.OsgiUtils`, introduced by commit 30a7750, calls `OsgiUtils.class.getClassLoader()`.
This method can return `null` if the class is loaded by the bootstrap class loader.
When one of my CLI tools, which bundles commons-compress, used the `-Xbootclasspath/a` option for faster startup time, it started throwing a `NullPointerException` after upgrading commons-compress from 1.20 to 1.21. 

```
Caused by: java.lang.NullPointerException: Cannot invoke "Object.getClass()" because the return value of "java.lang.Class.getClassLoader()" is null
        at org.apache.commons.compress.utils.OsgiUtils.<clinit>(OsgiUtils.java:31)
```

This PR adds a null check for the class loader to avoid the `NullPointerException`.