### PR TITLE
COMPRESS-653: Fix split archive updating incorrect file

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/FileRandomAccessOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/FileRandomAccessOutputStream.java
@@ -1,0 +1,79 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+
+/**
+ * {@link RandomAccessOutputStream} implementation based on Path file.
+ */
+class FileRandomAccessOutputStream extends RandomAccessOutputStream {
+
+    private final FileChannel channel;
+
+    private long position = 0L;
+
+    FileRandomAccessOutputStream(final Path file) throws IOException {
+        this(file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+    }
+
+    FileRandomAccessOutputStream(final Path file, OpenOption... options) throws IOException {
+        this(FileChannel.open(file, options));
+    }
+
+    FileRandomAccessOutputStream(final FileChannel channel) throws IOException {
+        this.channel = channel;
+    }
+
+    FileChannel channel() {
+        return channel;
+    }
+
+    @Override
+    public synchronized void write(final byte[] b, final int off, final int len) throws IOException {
+        ZipIoUtil.writeFully(this.channel, ByteBuffer.wrap(b, off, len));
+        position += len;
+    }
+
+    @Override
+    public synchronized long position() {
+        return position;
+    }
+
+    @Override
+    public void writeFullyAt(final byte[] b, final int off, final int len, final long atPosition) throws IOException {
+        ByteBuffer buf = ByteBuffer.wrap(b, off, len);
+        for (long currentPos = atPosition; buf.hasRemaining(); ) {
+            int written = this.channel.write(buf, currentPos);
+            if (written <= 0) {
+                throw new IOException("Failed to fully write to file: written=" + written);
+            }
+            currentPos += written;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/src/main/java/org/apache/commons/compress/archivers/zip/FileRandomAccessOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/FileRandomAccessOutputStream.java
@@ -31,7 +31,7 @@ class FileRandomAccessOutputStream extends RandomAccessOutputStream {
 
     private final FileChannel channel;
 
-    private long position = 0L;
+    private long position;
 
     FileRandomAccessOutputStream(final Path file) throws IOException {
         this(file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);

--- a/src/main/java/org/apache/commons/compress/archivers/zip/RandomAccessOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/RandomAccessOutputStream.java
@@ -1,0 +1,70 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Abstraction over OutputStream which also allows random access writes.
+ */
+abstract class RandomAccessOutputStream extends OutputStream {
+
+    /**
+     * Provides current position in output.
+     *
+     * @return
+     *      current position.
+     */
+    public abstract long position() throws IOException;
+
+    /**
+     * Writes given data to specific position.
+     *
+     * @param position
+     *      position in the stream
+     * @param b
+     *      data to write
+     * @throws IOException
+     *      when write fails.
+     */
+    public void writeFullyAt(final byte[] b, final long position) throws IOException {
+        writeFullyAt(b, 0, b.length, position);
+    }
+
+    /**
+     * Writes given data to specific position.
+     *
+     * @param position
+     *      position in the stream
+     * @param b
+     *      data to write
+     * @param off
+     *      offset of the start of data in param b
+     * @param len
+     *      the length of data to write
+     * @throws IOException
+     *      when write fails.
+     */
+    abstract void writeFullyAt(byte[] b, int off, int len, long position) throws IOException;
+
+    @Override
+    public void write(final int b) throws IOException {
+        write(new byte[]{ (byte) b });
+    }
+}

--- a/src/main/java/org/apache/commons/compress/archivers/zip/SeekableChannelRandomAccessOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/SeekableChannelRandomAccessOutputStream.java
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+
+
+/**
+ * {@link RandomAccessOutputStream} implementation for SeekableByteChannel.
+ */
+class SeekableChannelRandomAccessOutputStream extends RandomAccessOutputStream {
+
+    private final SeekableByteChannel channel;
+
+    private long position;
+
+    SeekableChannelRandomAccessOutputStream(final SeekableByteChannel channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public synchronized void write(final byte[] b, final int off, final int len) throws IOException {
+        ZipIoUtil.writeFully(this.channel, ByteBuffer.wrap(b, off, len));
+    }
+
+    @Override
+    public synchronized long position() throws IOException {
+        return channel.position();
+    }
+
+    @Override
+    public synchronized void writeFullyAt(final byte[] b, final int off, final int len, final long position) throws IOException {
+        long saved = channel.position();
+        try {
+            channel.position(position);
+            ZipIoUtil.writeFully(channel, ByteBuffer.wrap(b, off, len));
+        } finally {
+            channel.position(saved);
+        }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        channel.close();
+    }
+}

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipIoUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipIoUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+
+
+/**
+ * IO utilities for Zip operations.
+ *
+ * Package private to potentially move to something reusable.
+ */
+class ZipIoUtil {
+    /**
+     * Writes full buffer to channel.
+     *
+     * @param channel
+     *      channel to write to
+     * @param buf
+     *      buffer to write
+     * @throws IOException
+     *      when writing fails or fails to write fully
+     */
+    static void writeFully(SeekableByteChannel channel, ByteBuffer buf) throws IOException {
+        while (buf.hasRemaining()) {
+            int remaining = buf.remaining();
+            int written = channel.write(buf);
+            if (written <= 0) {
+                throw new IOException("Failed to fully write: channel=" + channel + " length=" + remaining + " written=" + written);
+            }
+        }
+    }
+
+    /**
+     * Writes full buffer to channel at specified position.
+     *
+     * @param channel
+     *      channel to write to
+     * @param buf
+     *      buffer to write
+     * @param position
+     *      position to write at
+     * @throws IOException
+     *      when writing fails or fails to write fully
+     */
+    static void writeFullyAt(FileChannel channel, ByteBuffer buf, long position) throws IOException {
+        for (long currentPosition = position; buf.hasRemaining(); ) {
+            int remaining = buf.remaining();
+            int written = channel.write(buf, currentPosition);
+            if (written <= 0) {
+                throw new IOException("Failed to fully write: channel=" + channel + " length=" + remaining + " written=" + written);
+            }
+            currentPosition += written;
+        }
+    }
+
+    private ZipIoUtil() {
+    }
+}

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -203,9 +204,24 @@ public class ZipSplitReadOnlySeekableByteChannel extends MultiReadOnlySeekableBy
      * @since 1.22
      */
     public static SeekableByteChannel forPaths(final Path... paths) throws IOException {
+        return forPaths(Arrays.asList(paths), new OpenOption[]{ StandardOpenOption.READ });
+    }
+
+    /**
+     * Concatenates the given file paths.
+     *
+     * @param paths the file paths to concatenate, note that the LAST FILE of files should be the LAST SEGMENT(.zip) and these files should be added in correct
+     *              order (e.g.: .z01, .z02... .z99, .zip)
+     * @return SeekableByteChannel that concatenates all provided files
+     * @throws NullPointerException if files is null
+     * @throws IOException          if opening a channel for one of the files fails
+     * @throws IOException          if the first channel doesn't seem to hold the beginning of a split archive
+     * @since 1.22
+     */
+    public static SeekableByteChannel forPaths(final List<Path> paths, OpenOption[] openOptions) throws IOException {
         final List<SeekableByteChannel> channels = new ArrayList<>();
         for (final Path path : Objects.requireNonNull(paths, "paths must not be null")) {
-            channels.add(Files.newByteChannel(path, StandardOpenOption.READ));
+            channels.add(Files.newByteChannel(path, openOptions));
         }
         if (channels.size() == 1) {
             return channels.get(0);

--- a/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
@@ -280,7 +280,11 @@ public final class ZipTest extends AbstractTest {
             zipArchiveOutputStream.closeArchiveEntry();
         }
 
-        try (ZipFile zipFile = new ZipFile(outputZipFile)) {
+        try (ZipFile zipFile = ZipFile.builder()
+                .setPath(outputZipFile.toPath())
+                .setMaxNumberOfDisks(Integer.MAX_VALUE)
+                .get()
+        ) {
             assertArrayEquals(createArtificialData(65536), IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file01"))));
             assertArrayEquals(createArtificialData(65536), IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file02"))));
         }
@@ -308,7 +312,11 @@ public final class ZipTest extends AbstractTest {
             zipArchiveOutputStream.closeArchiveEntry();
         }
 
-        try (ZipFile zipFile = new ZipFile(outputZipFile)) {
+        try (ZipFile zipFile = ZipFile.builder()
+                .setPath(outputZipFile.toPath())
+                .setMaxNumberOfDisks(Integer.MAX_VALUE)
+                .get()
+        ) {
             assertArrayEquals(data, IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file01"))));
             assertArrayEquals(data, IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file02"))));
         }
@@ -357,7 +365,11 @@ public final class ZipTest extends AbstractTest {
             zipArchiveOutputStream.closeArchiveEntry();
         }
 
-        try (ZipFile zipFile = new ZipFile(outputZipFile)) {
+        try (ZipFile zipFile = ZipFile.builder()
+                .setPath(outputZipFile.toPath())
+                .setMaxNumberOfDisks(Integer.MAX_VALUE)
+                .get()
+        ) {
             assertArrayEquals(data1, IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file01"))));
             assertArrayEquals(data2, IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file02"))));
             assertArrayEquals(data3, IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file03"))));
@@ -387,7 +399,11 @@ public final class ZipTest extends AbstractTest {
 
         assertEquals(64 * 1024L - 1, Files.size(outputZipFile.toPath().getParent().resolve("artificialSplitZip.z01")));
 
-        try (ZipFile zipFile = new ZipFile(outputZipFile)) {
+        try (ZipFile zipFile = ZipFile.builder()
+                .setPath(outputZipFile.toPath())
+                .setMaxNumberOfDisks(Integer.MAX_VALUE)
+                .get()
+        ) {
             assertArrayEquals(data1, IOUtils.toByteArray(zipFile.getInputStream(zipFile.getEntry("file01"))));
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
@@ -137,7 +137,7 @@ public final class ZipTest extends AbstractTest {
     }
 
     private byte[] createArtificialData(int size) {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
         for (int i = 0; i < size; i += 1) {
             output.write((byte) ((i & 1) == 0 ? (i / 2 % 256) : (i / 2 / 256)));
         }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/FileRandomAccessOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/FileRandomAccessOutputStreamTest.java
@@ -1,0 +1,150 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.apache.commons.compress.AbstractTempDirTest;
+import org.junit.jupiter.api.Test;
+
+
+public class FileRandomAccessOutputStreamTest extends AbstractTempDirTest {
+    @Test
+    public void testChannelReturn() throws IOException {
+        Path file = newTempPath("testChannel");
+        try (FileRandomAccessOutputStream stream = new FileRandomAccessOutputStream(file)) {
+            assertNotNull(stream.channel());
+        }
+    }
+
+    @Test
+    public void testWrite() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+        FileRandomAccessOutputStream stream = new FileRandomAccessOutputStream(channel);
+        when(channel.write((ByteBuffer) any()))
+            .thenAnswer(answer -> {
+                ((ByteBuffer) answer.getArgument(0)).position(5);
+                return 5;
+            })
+        .thenAnswer(answer -> {
+            ((ByteBuffer) answer.getArgument(0)).position(6);
+            return 6;
+        });
+        stream.write("hello".getBytes(StandardCharsets.UTF_8));
+        stream.write("world\n".getBytes(StandardCharsets.UTF_8));
+        verify(channel, times(2))
+            .write((ByteBuffer) any());
+
+        assertEquals(11, stream.position());
+    }
+
+    @Test
+    public void testWriteFullyAt_whenFullAtOnce_thenSucceed() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+        FileRandomAccessOutputStream stream = new FileRandomAccessOutputStream(channel);
+        when(channel.write((ByteBuffer) any(), eq(20L)))
+            .thenAnswer(answer -> {
+                ((ByteBuffer) answer.getArgument(0)).position(5);
+                return 5;
+            });
+        when(channel.write((ByteBuffer) any(), eq(30L)))
+            .thenAnswer(answer -> {
+                ((ByteBuffer) answer.getArgument(0)).position(6);
+                return 6;
+            });
+        stream.writeFullyAt("hello".getBytes(StandardCharsets.UTF_8), 20);
+        stream.writeFullyAt("world\n".getBytes(StandardCharsets.UTF_8), 30);
+
+        verify(channel, times(1))
+            .write((ByteBuffer) any(), eq(20L));
+        verify(channel, times(1))
+            .write((ByteBuffer) any(), eq(30L));
+
+        assertEquals(0, stream.position());
+    }
+
+    @Test
+    public void testWriteFullyAt_whenFullButPartial_thenSucceed() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+        FileRandomAccessOutputStream stream = new FileRandomAccessOutputStream(channel);
+        when(channel.write((ByteBuffer) any(), eq(20L)))
+            .thenAnswer(answer -> {
+                ((ByteBuffer) answer.getArgument(0)).position(3);
+                return 3;
+            });
+        when(channel.write((ByteBuffer) any(), eq(23L)))
+            .thenAnswer(answer -> {
+                ((ByteBuffer) answer.getArgument(0)).position(5);
+                return 2;
+            });
+        when(channel.write((ByteBuffer) any(), eq(30L)))
+            .thenAnswer(answer -> {
+                ((ByteBuffer) answer.getArgument(0)).position(6);
+                return 6;
+            });
+        stream.writeFullyAt("hello".getBytes(StandardCharsets.UTF_8), 20);
+        stream.writeFullyAt("world\n".getBytes(StandardCharsets.UTF_8), 30);
+
+        verify(channel, times(1))
+            .write((ByteBuffer) any(), eq(20L));
+        verify(channel, times(1))
+            .write((ByteBuffer) any(), eq(23L));
+        verify(channel, times(1))
+            .write((ByteBuffer) any(), eq(30L));
+
+        assertEquals(0, stream.position());
+    }
+
+    @Test
+    public void testWriteFullyAt_whenPartial_thenFail() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+        FileRandomAccessOutputStream stream = new FileRandomAccessOutputStream(channel);
+        when(channel.write((ByteBuffer) any(), eq(20L)))
+            .thenAnswer(answer -> {
+                ((ByteBuffer) answer.getArgument(0)).position(3);
+                return 3;
+            });
+        when(channel.write((ByteBuffer) any(), eq(23L)))
+            .thenAnswer(answer -> {
+                return 0;
+            });
+        assertThrows(IOException.class, () -> stream.writeFullyAt("hello".getBytes(StandardCharsets.UTF_8), 20));
+
+        verify(channel, times(1))
+            .write((ByteBuffer) any(), eq(20L));
+        verify(channel, times(1))
+            .write((ByteBuffer) any(), eq(23L));
+        verify(channel, times(0))
+            .write((ByteBuffer) any(), eq(25L));
+
+        assertEquals(0, stream.position());
+    }
+}

--- a/src/test/java/org/apache/commons/compress/archivers/zip/RandomAccessOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/RandomAccessOutputStreamTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+
+import org.apache.commons.compress.AbstractTempDirTest;
+import org.junit.jupiter.api.Test;
+
+
+public class RandomAccessOutputStreamTest extends AbstractTempDirTest {
+
+    @Test
+    public void testWrite() throws IOException {
+        RandomAccessOutputStream delegate = mock(RandomAccessOutputStream.class);
+
+        RandomAccessOutputStream stream = new RandomAccessOutputStream() {
+            @Override
+            public long position() throws IOException {
+                return delegate.position();
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                delegate.write(b, off, len);
+            }
+
+            @Override
+            void writeFullyAt(byte[] b, int off, int len, long position) throws IOException {
+                delegate.writeFullyAt(b, off, len, position);
+            }
+        };
+
+        stream.write('\n');
+
+        verify(delegate, times(1))
+                .write(any(), eq(0), eq(1));
+    }
+}

--- a/src/test/java/org/apache/commons/compress/archivers/zip/SeekableChannelRandomAccessOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/SeekableChannelRandomAccessOutputStreamTest.java
@@ -1,0 +1,168 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.apache.commons.compress.AbstractTempDirTest;
+import org.junit.jupiter.api.Test;
+
+
+public class SeekableChannelRandomAccessOutputStreamTest extends AbstractTempDirTest {
+
+    @Test
+    public void testInitialization() throws IOException {
+        Path file = newTempPath("testChannel");
+        try (SeekableChannelRandomAccessOutputStream stream = new SeekableChannelRandomAccessOutputStream(
+                Files.newByteChannel(file, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
+    )) {
+            assertEquals(0, stream.position());
+        }
+    }
+
+    @Test
+    public void testWrite() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+        SeekableChannelRandomAccessOutputStream stream = new SeekableChannelRandomAccessOutputStream(channel);
+
+        when(channel.position())
+                .thenReturn(11L);
+        when(channel.write((ByteBuffer) any()))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(5);
+                    return 5;
+                })
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(6);
+                    return 6;
+                });
+
+        stream.write("hello".getBytes(StandardCharsets.UTF_8));
+        stream.write("world\n".getBytes(StandardCharsets.UTF_8));
+
+        verify(channel, times(2))
+                .write((ByteBuffer) any());
+
+        assertEquals(11, stream.position());
+    }
+
+    @Test
+    public void testWriteFullyAt_whenFullAtOnce_thenSucceed() throws IOException {
+        SeekableByteChannel channel = mock(SeekableByteChannel.class);
+        SeekableChannelRandomAccessOutputStream stream = new SeekableChannelRandomAccessOutputStream(channel);
+
+        when(channel.position())
+                .thenReturn(50L)
+                .thenReturn(60L);
+        when(channel.write((ByteBuffer) any()))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(5);
+                    return 5;
+                })
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(6);
+                    return 6;
+                });
+
+        stream.writeFullyAt("hello".getBytes(StandardCharsets.UTF_8), 20);
+        stream.writeFullyAt("world\n".getBytes(StandardCharsets.UTF_8), 30);
+
+        verify(channel, times(2))
+                .write((ByteBuffer) any());
+        verify(channel, times(1))
+                .position(eq(50L));
+        verify(channel, times(1))
+                .position(eq(60L));
+
+        assertEquals(60L, stream.position());
+    }
+
+    @Test
+    public void testWriteFullyAt_whenFullButPartial_thenSucceed() throws IOException {
+        SeekableByteChannel channel = mock(SeekableByteChannel.class);
+        SeekableChannelRandomAccessOutputStream stream = new SeekableChannelRandomAccessOutputStream(channel);
+
+        when(channel.position())
+                .thenReturn(50L)
+                .thenReturn(60L);
+        when(channel.write((ByteBuffer) any()))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(3);
+                    return 3;
+                })
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(5);
+                    return 2;
+                })
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(6);
+                    return 6;
+                });
+
+        stream.writeFullyAt("hello".getBytes(StandardCharsets.UTF_8), 20);
+        stream.writeFullyAt("world\n".getBytes(StandardCharsets.UTF_8), 30);
+
+        verify(channel, times(3))
+                .write((ByteBuffer) any());
+        verify(channel, times(1))
+                .position(eq(50L));
+        verify(channel, times(1))
+                .position(eq(60L));
+
+        assertEquals(60L, stream.position());
+    }
+
+    @Test
+    public void testWriteFullyAt_whenPartial_thenFail() throws IOException {
+        SeekableByteChannel channel = mock(SeekableByteChannel.class);
+        SeekableChannelRandomAccessOutputStream stream = new SeekableChannelRandomAccessOutputStream(channel);
+
+        when(channel.position())
+                .thenReturn(50L);
+        when(channel.write((ByteBuffer) any()))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(3);
+                    return 3;
+                })
+                .thenAnswer(answer -> {
+                    return 0;
+                });
+
+        assertThrows(IOException.class, () -> stream.writeFullyAt("hello".getBytes(StandardCharsets.UTF_8), 20));
+
+        verify(channel, times(2))
+                .write((ByteBuffer) any());
+
+        assertEquals(50L, stream.position());
+    }
+}

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStreamTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.commons.compress.AbstractTempDirTest;
+import org.junit.jupiter.api.Test;
+
+
+public class ZipArchiveOutputStreamTest extends AbstractTempDirTest {
+
+    @Test
+    public void testOutputStreamBasics() throws IOException {
+        try (ZipArchiveOutputStream stream = new ZipArchiveOutputStream(new ByteArrayOutputStream())) {
+            assertFalse(stream.isSeekable());
+        }
+    }
+
+    @Test
+    public void testFileBasics() throws IOException {
+        try (ZipArchiveOutputStream stream = new ZipArchiveOutputStream(createTempFile())) {
+            assertTrue(stream.isSeekable());
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipIoUtilTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipIoUtilTest.java
@@ -1,0 +1,184 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.compress.AbstractTempDirTest;
+import org.junit.jupiter.api.Test;
+
+
+public class ZipIoUtilTest extends AbstractTempDirTest {
+
+    @Test
+    public void testWriteFully_whenFullAtOnce_thenSucceed() throws IOException {
+        SeekableByteChannel channel = mock(SeekableByteChannel.class);
+
+        when(channel.write((ByteBuffer) any()))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(5);
+                    return 5;
+                })
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(6);
+                    return 6;
+                });
+
+        ZipIoUtil.writeFully(channel, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+        ZipIoUtil.writeFully(channel, ByteBuffer.wrap("world\n".getBytes(StandardCharsets.UTF_8)));
+
+        verify(channel, times(2))
+                .write((ByteBuffer) any());
+    }
+
+    @Test
+    public void testWriteFully_whenFullButPartial_thenSucceed() throws IOException {
+        SeekableByteChannel channel = mock(SeekableByteChannel.class);
+
+        when(channel.write((ByteBuffer) any()))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(3);
+                    return 3;
+                })
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(5);
+                    return 2;
+                })
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(6);
+                    return 6;
+                });
+
+        ZipIoUtil.writeFully(channel, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+        ZipIoUtil.writeFully(channel, ByteBuffer.wrap("world\n".getBytes(StandardCharsets.UTF_8)));
+
+        verify(channel, times(3))
+                .write((ByteBuffer) any());
+    }
+
+    @Test
+    public void testWriteFully_whenPartial_thenFail() throws IOException {
+        SeekableByteChannel channel = mock(SeekableByteChannel.class);
+
+        when(channel.write((ByteBuffer) any()))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(3);
+                    return 3;
+                })
+                .thenAnswer(answer -> {
+                    return 0;
+                });
+
+        assertThrows(IOException.class, () ->
+                ZipIoUtil.writeFully(channel, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)))
+        );
+
+        verify(channel, times(2))
+                .write((ByteBuffer) any());
+    }
+
+    @Test
+    public void testWriteFullyAt_whenFullAtOnce_thenSucceed() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+
+        when(channel.write((ByteBuffer) any(), eq(20L)))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(5);
+                    return 5;
+                });
+        when(channel.write((ByteBuffer) any(), eq(30L)))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(6);
+                    return 6;
+                });
+
+        ZipIoUtil.writeFullyAt(channel, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), 20);
+        ZipIoUtil.writeFullyAt(channel, ByteBuffer.wrap("world\n".getBytes(StandardCharsets.UTF_8)), 30);
+
+        verify(channel, times(1))
+                .write((ByteBuffer) any(), eq(20L));
+        verify(channel, times(1))
+                .write((ByteBuffer) any(), eq(30L));
+    }
+
+    @Test
+    public void testWriteFullyAt_whenFullButPartial_thenSucceed() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+
+        when(channel.write((ByteBuffer) any(), eq(20L)))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(3);
+                    return 3;
+                });
+        when(channel.write((ByteBuffer) any(), eq(23L)))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(5);
+                    return 2;
+                });
+        when(channel.write((ByteBuffer) any(), eq(30L)))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(6);
+                    return 6;
+                });
+
+        ZipIoUtil.writeFullyAt(channel, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), 20);
+        ZipIoUtil.writeFullyAt(channel, ByteBuffer.wrap("world\n".getBytes(StandardCharsets.UTF_8)), 30);
+
+        verify(channel, times(1))
+                .write((ByteBuffer) any(), eq(20L));
+        verify(channel, times(1))
+                .write((ByteBuffer) any(), eq(23L));
+        verify(channel, times(1))
+                .write((ByteBuffer) any(), eq(30L));
+    }
+
+    @Test
+    public void testWriteFullyAt_whenPartial_thenFail() throws IOException {
+        FileChannel channel = mock(FileChannel.class);
+
+        when(channel.write((ByteBuffer) any(), eq(20L)))
+                .thenAnswer(answer -> {
+                    ((ByteBuffer) answer.getArgument(0)).position(3);
+                    return 3;
+                });
+        when(channel.write((ByteBuffer) any(), eq(23L)))
+                .thenAnswer(answer -> {
+                    return 0;
+                });
+        assertThrows(IOException.class, () ->
+                ZipIoUtil.writeFullyAt(channel, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), 20));
+
+        verify(channel, times(1))
+                .write((ByteBuffer) any(), eq(20L));
+        verify(channel, times(1))
+                .write((ByteBuffer) any(), eq(23L));
+        verify(channel, times(0))
+                .write((ByteBuffer) any(), eq(25L));
+    }
+}

--- a/src/test/java/org/apache/commons/compress/utils/ZipSplitReadOnlySeekableByteChannelTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/ZipSplitReadOnlySeekableByteChannelTest.java
@@ -156,7 +156,7 @@ public class ZipSplitReadOnlySeekableByteChannelTest {
 
     @Test
     public void testForPathsOfTwoParametersThrowsOnNullArg() {
-        assertThrows(NullPointerException.class, () -> ZipSplitReadOnlySeekableByteChannel.forPaths(null, null));
+        assertThrows(NullPointerException.class, () -> ZipSplitReadOnlySeekableByteChannel.forPaths((Path) null, null));
     }
 
     @Test


### PR DESCRIPTION
Updates local file header metadata even for split archive, so it's readable by `zip -FF` utility.
