### PR TITLE
[COMPRESS-655] FramedSnappyCompressorOutputStream produces incorrect output when writing a large buffer

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorOutputStream.java
@@ -127,7 +127,7 @@ public class FramedSnappyCompressorOutputStream extends CompressorOutputStream {
     public void write(final byte[] data, int off, int len) throws IOException {
         int blockDataRemaining = buffer.length - currentIndex;
         while (len > 0) {
-            int copyLen = Math.min(len, blockDataRemaining);
+            final int copyLen = Math.min(len, blockDataRemaining);
             System.arraycopy(data, off, buffer, currentIndex, copyLen);
             off += copyLen;
             blockDataRemaining -= copyLen;

--- a/src/main/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorOutputStream.java
@@ -104,12 +104,13 @@ public class FramedSnappyCompressorOutputStream extends CompressorOutputStream {
      * @throws IOException if an error occurs
      */
     public void finish() throws IOException {
-        if (currentIndex > 0) {
-            flushBuffer();
-        }
+        flushBuffer();
     }
 
     private void flushBuffer() throws IOException {
+        if (currentIndex == 0) {
+            return;
+        }
         out.write(FramedSnappyCompressorInputStream.COMPRESSED_CHUNK_TYPE);
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (OutputStream o = new SnappyCompressorOutputStream(baos, currentIndex, params)) {
@@ -124,18 +125,19 @@ public class FramedSnappyCompressorOutputStream extends CompressorOutputStream {
 
     @Override
     public void write(final byte[] data, int off, int len) throws IOException {
-        if (currentIndex + len > MAX_COMPRESSED_BUFFER_SIZE) {
-            flushBuffer();
-            while (len > MAX_COMPRESSED_BUFFER_SIZE) {
-                System.arraycopy(data, off, buffer, 0, MAX_COMPRESSED_BUFFER_SIZE);
-                off += MAX_COMPRESSED_BUFFER_SIZE;
-                len -= MAX_COMPRESSED_BUFFER_SIZE;
-                currentIndex = MAX_COMPRESSED_BUFFER_SIZE;
+        int blockDataRemaining = buffer.length - currentIndex;
+        while (len > 0) {
+            int copyLen = Math.min(len, blockDataRemaining);
+            System.arraycopy(data, off, buffer, currentIndex, copyLen);
+            off += copyLen;
+            blockDataRemaining -= copyLen;
+            len -= copyLen;
+            currentIndex += copyLen;
+            if (blockDataRemaining == 0) {
                 flushBuffer();
+                blockDataRemaining = buffer.length;
             }
         }
-        System.arraycopy(data, off, buffer, currentIndex, len);
-        currentIndex += len;
     }
 
     @Override

--- a/src/test/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStreamTest.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 
 import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.archivers.zip.ZipFile;
@@ -194,7 +193,7 @@ public final class FramedSnappyCompressorInputStreamTest extends AbstractTest {
             }
             decompressed = decompressedOutputStream.toByteArray();
         }
-        assertTrue(Arrays.equals(data, decompressed));
+        assertArrayEquals(data, decompressed);
     }
 
     private static byte[] generateTestData(int inputSize) {
@@ -231,7 +230,7 @@ public final class FramedSnappyCompressorInputStreamTest extends AbstractTest {
             }
             compressor.finish();
         }
-        assertTrue(Arrays.equals(bulkOutput, buffer.toByteArray()));
+        assertArrayEquals(bulkOutput, buffer.toByteArray());
     }
 
 }


### PR DESCRIPTION
Fix and tests for https://issues.apache.org/jira/browse/COMPRESS-655.