### PR TITLE
[COMPRESS-658] Fix formatting the lowest expressable DOS time

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipUtil.java
@@ -76,6 +76,9 @@ public abstract class ZipUtil {
      */
     private static final long DOSTIME_BEFORE_1980 = 1 << 21 | 1 << 16; // 0x210000
 
+    /** Java time representation of the smallest date/time ZIP can handle */
+    private static final long DOSTIME_BEFORE_1980_AS_JAVA_TIME = dosToJavaTime(DOSTIME_BEFORE_1980);
+
     /**
      * Approximately 128 years, in milliseconds (ignoring leap years, etc.).
      *
@@ -230,7 +233,8 @@ public abstract class ZipUtil {
      * @since 1.23
      */
     public static boolean isDosTime(final long time) {
-        return time <= UPPER_DOSTIME_BOUND && javaToDosTime(time) != DOSTIME_BEFORE_1980;
+        return time <= UPPER_DOSTIME_BOUND &&
+                (time == DOSTIME_BEFORE_1980_AS_JAVA_TIME || javaToDosTime(time) != DOSTIME_BEFORE_1980);
     }
 
     private static LocalDateTime javaEpochToLocalDateTime(final long time) {

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipUtilTest.java
@@ -160,6 +160,9 @@ public class ZipUtilTest {
         assertTrue(ZipUtil.isDosTime(toLocalInstant("1980-01-03T00:00:00").toEpochMilli()));
         assertTrue(ZipUtil.isDosTime(toLocalInstant("2097-11-27T00:00:00").toEpochMilli()));
         assertFalse(ZipUtil.isDosTime(toLocalInstant("2099-01-01T00:00:00").toEpochMilli()));
+        // The lowest data/time expressable as DOS Time, see comment in ZipUtil#DOSTIME_BEFORE_1980
+        long lowestExpressableDosTime = 1 << 21 | 1 << 16; // 0x210000
+        assertTrue(ZipUtil.isDosTime(ZipUtil.dosToJavaTime(lowestExpressableDosTime)));
     }
 
     @Test


### PR DESCRIPTION
Since COMPRESS-613, we add an 'extra time data' field when the ZIP entry timestamp is outside the range the DOS timestamp used in other parts of the header can handle.

Before, it incorrectly also added this header when the ZIP entry timestamp was exactly the lowest possible timestamp expressable as a DOS timestamp.

This had the consequence that, when reading a ZIP file with such entries and writing it back again, ZipEntry would 'invent' an 'extra time data' field where none was needed.

With this change, it correctly considers the lowest expressable date as expressable, and avoids inventing the extra time data field in this case.