### PR TITLE
Drop reflection from ExtraFieldUtils static initialization

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/AsiExtraField.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/AsiExtraField.java
@@ -61,7 +61,7 @@ import java.util.zip.ZipException;
  */
 public class AsiExtraField implements ZipExtraField, UnixStat, Cloneable {
 
-    private static final ZipShort HEADER_ID = new ZipShort(0x756E);
+    static final ZipShort HEADER_ID = new ZipShort(0x756E);
     private static final int MIN_SIZE = WORD + SHORT + WORD + SHORT + SHORT;
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ExtraFieldUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ExtraFieldUtils.java
@@ -19,10 +19,10 @@ package org.apache.commons.compress.archivers.zip;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.zip.ZipException;
 
@@ -119,7 +119,8 @@ public class ExtraFieldUtils {
     private static final Map<ZipShort, Supplier<ZipExtraField>> IMPLEMENTATIONS;
 
     static {
-        IMPLEMENTATIONS = new HashMap<>(); // it can't be used at runtime by design so no need to be concurrent
+        IMPLEMENTATIONS = new ConcurrentHashMap<>(); // it can't be used at runtime by design so no need to be concurrent
+        // IMPLEMENTATIONS = new HashMap<>(); // see register() comment
         IMPLEMENTATIONS.put(AsiExtraField.HEADER_ID, AsiExtraField::new);
         IMPLEMENTATIONS.put(X5455_ExtendedTimestamp.HEADER_ID, X5455_ExtendedTimestamp::new);
         IMPLEMENTATIONS.put(X7875_NewUnix.HEADER_ID, X7875_NewUnix::new);
@@ -346,7 +347,6 @@ public class ExtraFieldUtils {
     /**
      * Split the array into ExtraFields and populate them with the given data.
      *
-     * @param archive           {@link ZipArchiveInputStream} input
      * @param data              an array of bytes
      * @param local             whether data originates from the local file data or the central directory
      * @param onUnparseableData what to do if the extra field data cannot be parsed.
@@ -387,7 +387,7 @@ public class ExtraFieldUtils {
      * @deprecated use {@link ZipArchiveInputStream#setExtraFieldSupport} instead
      *             to not leak instances between archives and applications.
      */
-    @Deprecated
+    @Deprecated // note: when dropping update registration to move to a HashMap (static init)
     public static void register(final Class<?> c) {
         try {
             final Constructor<? extends ZipExtraField> constructor = c

--- a/src/main/java/org/apache/commons/compress/archivers/zip/JarMarker.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/JarMarker.java
@@ -27,7 +27,7 @@ import org.apache.commons.compress.utils.ByteUtils;
  */
 public final class JarMarker implements ZipExtraField {
 
-    private static final ZipShort ID = new ZipShort(0xCAFE);
+    static final ZipShort ID = new ZipShort(0xCAFE);
     private static final ZipShort NULL = new ZipShort(0);
     private static final JarMarker DEFAULT = new JarMarker();
 

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0014_X509Certificates.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0014_X509Certificates.java
@@ -44,8 +44,10 @@ package org.apache.commons.compress.archivers.zip;
  */
 public class X0014_X509Certificates extends PKWareExtraHeader {
 
+    static final ZipShort HEADER_ID = new ZipShort(0x0014);
+
     public X0014_X509Certificates() {
-        super(new ZipShort(0x0014));
+        super(HEADER_ID);
     }
 
 }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0015_CertificateIdForFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0015_CertificateIdForFile.java
@@ -47,12 +47,14 @@ import java.util.zip.ZipException;
  */
 public class X0015_CertificateIdForFile extends PKWareExtraHeader {
 
+    static final ZipShort HEADER_ID = new ZipShort(0x0015);
+
     private int rcount;
 
     private HashAlgorithm hashAlg;
 
     public X0015_CertificateIdForFile() {
-        super(new ZipShort(0x0015));
+        super(HEADER_ID);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0016_CertificateIdForCentralDirectory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0016_CertificateIdForCentralDirectory.java
@@ -48,12 +48,14 @@ import java.util.zip.ZipException;
  */
 public class X0016_CertificateIdForCentralDirectory extends PKWareExtraHeader {
 
+    static final ZipShort HEADER_ID = new ZipShort(0x0016);
+
     private int rcount;
 
     private HashAlgorithm hashAlg;
 
     public X0016_CertificateIdForCentralDirectory() {
-        super(new ZipShort(0x0016));
+        super(HEADER_ID);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0017_StrongEncryptionHeader.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0017_StrongEncryptionHeader.java
@@ -257,6 +257,8 @@ import java.util.zip.ZipException;
  */
 public class X0017_StrongEncryptionHeader extends PKWareExtraHeader {
 
+    static final ZipShort HEADER_ID = new ZipShort(0x0017);
+
     private int format; // TODO written but not read
 
     private EncryptionAlgorithm algId;
@@ -279,7 +281,7 @@ public class X0017_StrongEncryptionHeader extends PKWareExtraHeader {
     private byte[] vCRC32;
 
     public X0017_StrongEncryptionHeader() {
-        super(new ZipShort(0x0017));
+        super(HEADER_ID);
     }
 
     private void assertDynamicLengthFits(final String what, final int dynamicLength, final int prefixLength, final int length) throws ZipException {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0019_EncryptionRecipientCertificateList.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0019_EncryptionRecipientCertificateList.java
@@ -50,8 +50,10 @@ package org.apache.commons.compress.archivers.zip;
  */
 public class X0019_EncryptionRecipientCertificateList extends PKWareExtraHeader {
 
+    static final ZipShort HEADER_ID = new ZipShort(0x0019);
+
     public X0019_EncryptionRecipientCertificateList() {
-        super(new ZipShort(0x0019));
+        super(HEADER_ID);
     }
 
 }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X7875_NewUnix.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X7875_NewUnix.java
@@ -57,7 +57,7 @@ import org.apache.commons.compress.utils.ByteUtils;
  * @since 1.5
  */
 public class X7875_NewUnix implements ZipExtraField, Cloneable, Serializable {
-    private static final ZipShort HEADER_ID = new ZipShort(0x7875);
+    static final ZipShort HEADER_ID = new ZipShort(0x7875);
     private static final ZipShort ZERO = new ZipShort(0);
     private static final BigInteger ONE_THOUSAND = BigInteger.valueOf(1000);
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveEntry.java
@@ -293,8 +293,9 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      * @param extraFieldFactory custom lookup factory for extra fields or null
      * @param inputFile file to create the entry from
      * @param entryName name of the entry
+     * @since 1.26.0
      */
-    public ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory, final File inputFile, final String entryName) {
+    ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory, final File inputFile, final String entryName) {
         this(extraFieldFactory, inputFile.isDirectory() && !entryName.endsWith("/") ? entryName + "/" : entryName);
         try {
             setAttributes(inputFile.toPath());
@@ -342,12 +343,13 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      * Assumes the entry represents a directory if and only if the name ends with a forward slash "/".
      * </p>
      *
+     * @param extraFieldFactory the extra field lookup factory.
      * @param entry the entry to get fields from
      * @throws ZipException on error
      * @since 1.26.0
      */
-    public ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory,
-                           final java.util.zip.ZipEntry entry) throws ZipException {
+    ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory,
+                    final java.util.zip.ZipEntry entry) throws ZipException {
         super(entry);
         this.extraFieldFactory = extraFieldFactory;
         setName(entry.getName());
@@ -393,11 +395,11 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      * @param entryName name of the entry.
      * @param options   options indicating how symbolic links are handled.
      * @throws IOException if an I/O error occurs.
-     * @since 1.21
+     * @since 1.26.0
      */
-    public ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory,
-                           final Path inputPath, final String entryName, final LinkOption... options) throws IOException {
-        this(Files.isDirectory(inputPath, options) && !entryName.endsWith("/") ? entryName + "/" : entryName);
+    ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory,
+                    final Path inputPath, final String entryName, final LinkOption... options) throws IOException {
+        this(extraFieldFactory, Files.isDirectory(inputPath, options) && !entryName.endsWith("/") ? entryName + "/" : entryName);
         setAttributes(inputPath, options);
     }
 
@@ -409,6 +411,7 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      * </p>
      *
      * @param name the name of the entry
+     * @since 1.26.0
      */
     public ZipArchiveEntry(final String name) {
         this((Function<ZipShort, ZipExtraField>) null, name);
@@ -423,9 +426,10 @@ public class ZipArchiveEntry extends java.util.zip.ZipEntry implements ArchiveEn
      *
      * @param extraFieldFactory custom lookup factory for extra fields or null
      * @param name the name of the entry
+     * @since 1.26.0
      */
-    public ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory,
-                           final String name) {
+    ZipArchiveEntry(final Function<ZipShort, ZipExtraField> extraFieldFactory,
+                    final String name) {
         super(name);
         this.extraFieldFactory = extraFieldFactory;
         setName(name);

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -33,6 +33,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.zip.CRC32;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -293,6 +294,11 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
     private int entriesRead;
 
     /**
+     * The factory for extra fields or null.
+     */
+    private Function<ZipShort, ZipExtraField> extraFieldSupport;
+
+    /**
      * Constructs an instance using UTF-8 encoding
      *
      * @param inputStream the stream to wrap
@@ -358,6 +364,16 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
         this.skipSplitSig = skipSplitSig;
         // haven't read anything so far
         buf.limit(0);
+    }
+
+    /**
+     * Enable custom extra fields factory.
+     * @param extraFieldSupport the lookup function based on extra field header id.
+     * @return the archive.
+     */
+    public ZipArchiveInputStream setExtraFieldSupport(final Function<ZipShort, ZipExtraField> extraFieldSupport) {
+        this.extraFieldSupport = extraFieldSupport;
+        return this;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java
@@ -197,6 +197,7 @@ public class ZipSplitReadOnlySeekableByteChannel extends MultiReadOnlySeekableBy
      *
      * @param paths the file paths to concatenate, note that the LAST FILE of files should be the LAST SEGMENT(.zip) and these files should be added in correct
      *              order (e.g.: .z01, .z02... .z99, .zip)
+     * @param openOptions the options to open paths (shared by all paths).
      * @return SeekableByteChannel that concatenates all provided files
      * @throws NullPointerException if files is null
      * @throws IOException          if opening a channel for one of the files fails

--- a/src/test/java/org/apache/commons/compress/archivers/tar/FileTimesIT.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/FileTimesIT.java
@@ -52,7 +52,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/", e.getName());
+            assertEquals("test/", e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
@@ -62,7 +62,7 @@ public class FileTimesIT extends AbstractTest {
             e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals("test/test-times.txt", e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
@@ -81,7 +81,7 @@ public class FileTimesIT extends AbstractTest {
                 TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
-            assertEquals("name", "test/", e.getName());
+            assertEquals("test/", e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
@@ -90,7 +90,7 @@ public class FileTimesIT extends AbstractTest {
             assertNull(e.getCreationTime(), "birthtime");
             assertGlobalHeaders(e);
             e = tin.getNextTarEntry();
-            assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals("test/test-times.txt", e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
@@ -130,7 +130,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test-times.txt", e.getName());
+            assertEquals("test-times.txt", e.getName());
             assertEquals(toFileTime("2022-03-14T01:25:03Z"), e.getLastModifiedTime(), "mtime");
             assertNull(e.getLastAccessTime(), "atime");
             assertNull(e.getStatusChangeTime(), "ctime");
@@ -138,7 +138,7 @@ public class FileTimesIT extends AbstractTest {
             e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test-times.txt", e.getName());
+            assertEquals("test-times.txt", e.getName());
             assertEquals(toFileTime("2022-03-14T03:17:05Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-14T03:17:10Z"), e.getLastAccessTime(), "atime");
             assertEquals(toFileTime("2022-03-14T03:17:10Z"), e.getStatusChangeTime(), "ctime");
@@ -210,7 +210,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test-times.txt", e.getName());
+            assertEquals("test-times.txt", e.getName());
             assertEquals(toFileTime("2022-03-14T01:25:03Z"), e.getLastModifiedTime(), "mtime");
             assertNull(e.getLastAccessTime(), "atime");
             assertNull(e.getStatusChangeTime(), "ctime");
@@ -218,7 +218,7 @@ public class FileTimesIT extends AbstractTest {
             e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test-times.txt", e.getName());
+            assertEquals("test-times.txt", e.getName());
             assertEquals(toFileTime("2022-03-14T03:17:05Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-14T03:17:06Z"), e.getLastAccessTime(), "atime");
             assertEquals(toFileTime("2022-03-14T03:17:05Z"), e.getStatusChangeTime(), "ctime");
@@ -237,7 +237,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/", e.getName());
+            assertEquals("test/", e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
@@ -247,7 +247,7 @@ public class FileTimesIT extends AbstractTest {
             e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals("test/test-times.txt", e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");
@@ -286,7 +286,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/", e.getName());
+            assertEquals("test/", e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-16T10:19:43.382883700Z"), e.getLastModifiedTime(), "mtime");
@@ -296,7 +296,7 @@ public class FileTimesIT extends AbstractTest {
             e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals("test/test-times.txt", e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-16T10:21:00.249238500Z"), e.getLastModifiedTime(), "mtime");
@@ -334,7 +334,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/", e.getName());
+            assertEquals("test/", e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44Z"), e.getLastModifiedTime(), "mtime");
@@ -343,7 +343,7 @@ public class FileTimesIT extends AbstractTest {
             assertNull(e.getCreationTime(), "birthtime");
             e = tin.getNextTarEntry();
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals("test/test-times.txt", e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20Z"), e.getLastModifiedTime(), "mtime");
@@ -414,7 +414,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/", e.getName());
+            assertEquals("test/", e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44Z"), e.getLastModifiedTime(), "mtime");
@@ -422,7 +422,7 @@ public class FileTimesIT extends AbstractTest {
             assertEquals(toFileTime("2022-03-17T00:24:44Z"), e.getStatusChangeTime(), "ctime");
             assertNull(e.getCreationTime(), "birthtime");
             e = tin.getNextTarEntry();
-            assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals("test/test-times.txt", e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -443,7 +443,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test-times.txt", e.getName());
+            assertEquals("test-times.txt", e.getName());
             assertEquals(toFileTime("2022-03-14T04:03:29Z"), e.getLastModifiedTime(), "mtime");
             assertEquals(toFileTime("2022-03-14T04:03:29Z"), e.getLastAccessTime(), "atime");
             assertEquals(toFileTime("2022-03-14T04:03:29Z"), e.getStatusChangeTime(), "ctime");
@@ -486,7 +486,7 @@ public class FileTimesIT extends AbstractTest {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/", e.getName());
+            assertEquals("test/", e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
             assertTrue(e.isDirectory());
             assertEquals(toFileTime("2022-03-17T00:24:44.147126600Z"), e.getLastModifiedTime(), "mtime");
@@ -495,7 +495,7 @@ public class FileTimesIT extends AbstractTest {
             assertNull(e.getCreationTime(), "birthtime");
             e = tin.getNextTarEntry();
             assertTrue(e.getExtraPaxHeaders().isEmpty());
-            assertEquals("name", "test/test-times.txt", e.getName());
+            assertEquals("test/test-times.txt", e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
             assertTrue(e.isFile());
             assertEquals(toFileTime("2022-03-17T00:38:20.470751500Z"), e.getLastModifiedTime(), "mtime");


### PR DESCRIPTION
As of today to make [compress] run on native-image (GraalVM) you must reister all classes in IMPLEMENTATIONS map. With this PR this is no more needed and [compress] zip support comes OOTB.