### PR TITLE
Fix Maven site `GIT repository` link

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -107,7 +107,7 @@
             problems</a> page lists the currently known problems
             grouped by the format they apply to.</li>
             <li>The <a href="apidocs/index.html">Javadoc</a> of the latest GIT</li>
-            <li>The <a href="https://gitbox.apache.org/repos/asf?p=commons-compress.git;a=tree">GIT
+            <li>The <a href="https://gitbox.apache.org/repos/asf?p=commons-compress.git">GIT
                 repository</a> can be browsed.</li>
             </ul>
         </section>


### PR DESCRIPTION
The [Maven site documentation](https://commons.apache.org/proper/commons-compress/) provides [a link to the Git repository which does not work](https://gitbox.apache.org/repos/asf?p=commons-compress.git;a=tree).

This PR [updates the link to something that works](https://gitbox.apache.org/repos/asf?p=commons-compress.git), as already declared under `project/scm/url` in `pom.xml`.