### PR TITLE
COMPRESS-664 - return null value from getNextEntry() for empty file

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -1012,10 +1012,10 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * Fills the given array with the first local file header and deals with splitting/spanning markers that may prefix the first LFH.
      */
     private boolean readFirstLocalFileHeader() throws IOException {
+        // for empty archive, we may get only EOCD size:
+        final byte[] header = new byte[Math.min(LFH_LEN, ZipFile.MIN_EOCD_SIZE)];
+        readFully(header);
         try {
-            // for empty archive, we may get only EOCD size:
-            final byte[] header = new byte[Math.min(LFH_LEN, ZipFile.MIN_EOCD_SIZE)];
-            readFully(header);
             READ_LOOP: for (int i = 0; ; ) {
                 for (int j = 0; i <= PREAMBLE_GARBAGE_MAX_SIZE - 4 && j <= header.length - 4; ++j, ++i) {
                     final ZipLong sig = new ZipLong(header, j);

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -772,4 +772,13 @@ public class ZipArchiveInputStreamTest extends AbstractTest {
             // Ignore expected exception
         }
     }
+
+    @Test
+    public void testGetFirstEntryEmptyZip() throws IOException {
+        try (ZipArchiveInputStream zin = new ZipArchiveInputStream(new ByteArrayInputStream(ByteUtils.EMPTY_BYTE_ARRAY))) {
+            ZipArchiveEntry entry = zin.getNextEntry();
+            assertNull(entry);
+        }
+    }
+
 }


### PR DESCRIPTION
Fix regression error in case when getNextEntry() method is invoked on empty file (zero size) to get first entry. Till version 1.25.0, null value was returned (like is done in standard java ZipInputStream too). The regression was caused by implementing 'Support preamble garbage in ZipArchiveInputStream' feature (PR 471).
 - https://github.com/apache/commons-compress/pull/471