### PR TITLE
Remove unused variables in tests

### DIFF
--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -190,12 +190,15 @@ public class TarUtilsTest extends AbstractTest {
         final byte[] buffer3 = "abcdef ".getBytes(UTF_8); // Invalid input
         assertThrows(IllegalArgumentException.class, () -> TarUtils.parseOctal(buffer3, 0, buffer3.length), "Expected IllegalArgumentException");
 
-        final byte[] buffer4 = " 0 07 ".getBytes(UTF_8); // Invalid - embedded space
-        assertThrows(IllegalArgumentException.class, () -> TarUtils.parseOctal(buffer4, 0, buffer3.length),
-                "Expected IllegalArgumentException - embedded space");
-
         final byte[] buffer5 = " 0\00007 ".getBytes(UTF_8); // Invalid - embedded NUL
         assertThrows(IllegalArgumentException.class, () -> TarUtils.parseOctal(buffer5, 0, buffer5.length), "Expected IllegalArgumentException - embedded NUL");
+    }
+
+    @Test
+    public void testParseOctalEmbeddedSpace() {
+        final byte[] buffer4 = " 0 07 ".getBytes(UTF_8); // Invalid - embedded space
+        assertThrows(IllegalArgumentException.class, () -> TarUtils.parseOctal(buffer4, 0, buffer4.length),
+                "Expected IllegalArgumentException - embedded space");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -191,7 +191,7 @@ public class TarUtilsTest extends AbstractTest {
         assertThrows(IllegalArgumentException.class, () -> TarUtils.parseOctal(buffer3, 0, buffer3.length), "Expected IllegalArgumentException");
 
         final byte[] buffer4 = " 0 07 ".getBytes(UTF_8); // Invalid - embedded space
-        assertThrows(IllegalArgumentException.class, () -> TarUtils.parseOctal(buffer3, 0, buffer3.length),
+        assertThrows(IllegalArgumentException.class, () -> TarUtils.parseOctal(buffer4, 0, buffer3.length),
                 "Expected IllegalArgumentException - embedded space");
 
         final byte[] buffer5 = " 0\00007 ".getBytes(UTF_8); // Invalid - embedded NUL

--- a/src/test/java/org/apache/commons/compress/compressors/FramedSnappyTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/FramedSnappyTest.java
@@ -58,14 +58,11 @@ public final class FramedSnappyTest extends AbstractTest {
     }
 
     private void testRoundtrip(final File input) throws Exception {
-        final long start = System.currentTimeMillis();
         final File outputSz = newTempFile(input.getName() + ".sz");
         try (OutputStream os = Files.newOutputStream(outputSz.toPath());
                 CompressorOutputStream sos = new CompressorStreamFactory().createCompressorOutputStream("snappy-framed", os)) {
             Files.copy(input.toPath(), sos);
         }
-        // System.err.println(input.getName() + " written, uncompressed bytes: " + input.length()
-        // + ", compressed bytes: " + outputSz.length() + " after " + (System.currentTimeMillis() - start) + "ms");
         try (InputStream is = Files.newInputStream(input.toPath());
                 CompressorInputStream sis = new CompressorStreamFactory().createCompressorInputStream("snappy-framed",
                         Files.newInputStream(outputSz.toPath()))) {
@@ -84,7 +81,6 @@ public final class FramedSnappyTest extends AbstractTest {
                 fs.write(r.nextInt(256));
             }
         }
-        final long start = System.currentTimeMillis();
         final File outputSz = newTempFile(input.getName() + ".sz");
         try (InputStream is = Files.newInputStream(input.toPath());
                 OutputStream os = Files.newOutputStream(outputSz.toPath());
@@ -93,8 +89,6 @@ public final class FramedSnappyTest extends AbstractTest {
             sos.write(b[0]);
             sos.write(b, 1, b.length - 1); // must be split into multiple compressed chunks
         }
-        // System.err.println(input.getName() + " written, uncompressed bytes: " + input.length()
-        // + ", compressed bytes: " + outputSz.length() + " after " + (System.currentTimeMillis() - start) + "ms");
         try (InputStream is = Files.newInputStream(input.toPath());
                 CompressorInputStream sis = new CompressorStreamFactory().createCompressorInputStream("snappy-framed",
                         Files.newInputStream(outputSz.toPath()))) {

--- a/src/test/java/org/apache/commons/compress/compressors/lz4/BlockLZ4CompressorRoundtripTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/lz4/BlockLZ4CompressorRoundtripTest.java
@@ -65,23 +65,17 @@ public final class BlockLZ4CompressorRoundtripTest extends AbstractTest {
 
     private void roundTripTest(final String testFile, final String config, final Parameters params) throws IOException {
         final File input = getFile(testFile);
-        long start = System.currentTimeMillis();
         final File outputSz = newTempFile(input.getName() + ".block.lz4");
         try (OutputStream os = Files.newOutputStream(outputSz.toPath());
                 BlockLZ4CompressorOutputStream los = new BlockLZ4CompressorOutputStream(os, params)) {
             Files.copy(input.toPath(), los);
         }
-        // System.err.println("Configuration: " + config);
-        // System.err.println(input.getName() + " written, uncompressed bytes: " + input.length()
-        // + ", compressed bytes: " + outputSz.length() + " after " + (System.currentTimeMillis() - start) + "ms");
-        start = System.currentTimeMillis();
         try (InputStream is = Files.newInputStream(input.toPath());
                 BlockLZ4CompressorInputStream sis = new BlockLZ4CompressorInputStream(Files.newInputStream(outputSz.toPath()))) {
             final byte[] expected = IOUtils.toByteArray(is);
             final byte[] actual = IOUtils.toByteArray(sis);
             assertArrayEquals(expected, actual);
         }
-        // System.err.println(outputSz.getName() + " read after " + (System.currentTimeMillis() - start) + "ms");
     }
 
 }

--- a/src/test/java/org/apache/commons/compress/compressors/lz4/FactoryTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/lz4/FactoryTest.java
@@ -34,22 +34,17 @@ public class FactoryTest extends AbstractTest {
 
     private void roundtripViaFactory(final String format) throws Exception {
         final Path input = getPath("bla.tar");
-        long start = System.currentTimeMillis();
         final Path outputSz = getTempDirFile().toPath().resolve(input.getFileName() + "." + format + ".lz4");
         try (OutputStream os = Files.newOutputStream(outputSz);
                 OutputStream los = new CompressorStreamFactory().createCompressorOutputStream(format, os)) {
             Files.copy(input, los);
         }
-        // System.err.println(input.getName() + " written, uncompressed bytes: " + input.length()
-        // + ", compressed bytes: " + outputSz.length() + " after " + (System.currentTimeMillis() - start) + "ms");
-        start = System.currentTimeMillis();
         try (InputStream is = Files.newInputStream(input);
                 InputStream sis = new CompressorStreamFactory().createCompressorInputStream(format, Files.newInputStream(outputSz))) {
             final byte[] expected = IOUtils.toByteArray(is);
             final byte[] actual = IOUtils.toByteArray(sis);
             assertArrayEquals(expected, actual);
         }
-        // System.err.println(outputSz.getName() + " read after " + (System.currentTimeMillis() - start) + "ms");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/compressors/lz4/FramedLZ4CompressorRoundtripTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/lz4/FramedLZ4CompressorRoundtripTest.java
@@ -76,8 +76,6 @@ public final class FramedLZ4CompressorRoundtripTest extends AbstractTest {
 
     private void roundTripTest(final String testFile, final FramedLZ4CompressorOutputStream.Parameters params) throws IOException {
         final File input = getFile(testFile);
-        long start = System.currentTimeMillis();
-        final File outputSz = newTempFile(input.getName() + ".framed.lz4");
         byte[] expected;
         try (InputStream is = Files.newInputStream(input.toPath())) {
             expected = IOUtils.toByteArray(is);
@@ -86,15 +84,10 @@ public final class FramedLZ4CompressorRoundtripTest extends AbstractTest {
         try (FramedLZ4CompressorOutputStream los = new FramedLZ4CompressorOutputStream(bos, params)) {
             IOUtils.copy(new ByteArrayInputStream(expected), los);
         }
-        // System.err.println(input.getName() + " written, uncompressed bytes: " + input.length()
-        // + ", compressed bytes: " + outputSz.length() + " after " + (System.currentTimeMillis() - start) + "ms");
-        start = System.currentTimeMillis();
         try (FramedLZ4CompressorInputStream sis = new FramedLZ4CompressorInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
             final byte[] actual = IOUtils.toByteArray(sis);
             assertArrayEquals(expected, actual);
         }
-
-        // System.err.println(outputSz.getName() + " read after " + (System.currentTimeMillis() - start) + "ms");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/compressors/snappy/SnappyRoundtripTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/snappy/SnappyRoundtripTest.java
@@ -43,37 +43,27 @@ public final class SnappyRoundtripTest extends AbstractTest {
     }
 
     private void roundTripTest(final byte[] input, final Parameters params) throws IOException {
-        long start = System.currentTimeMillis();
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
         try (SnappyCompressorOutputStream sos = new SnappyCompressorOutputStream(os, input.length, params)) {
             sos.write(input);
         }
-        // System.err.println("byte array" + " written, uncompressed bytes: " + input.length
-        // + ", compressed bytes: " + os.size() + " after " + (System.currentTimeMillis() - start) + "ms");
-        start = System.currentTimeMillis();
         try (SnappyCompressorInputStream sis = new SnappyCompressorInputStream(new ByteArrayInputStream(os.toByteArray()), params.getWindowSize())) {
             final byte[] actual = IOUtils.toByteArray(sis);
             assertArrayEquals(input, actual);
         }
-        // System.err.println("byte array" + " read after " + (System.currentTimeMillis() - start) + "ms");
     }
 
     private void roundTripTest(final Path input, final Parameters params) throws IOException {
-        long start = System.currentTimeMillis();
         final File outputSz = newTempFile(input.getFileName() + ".raw.sz");
         try (OutputStream os = Files.newOutputStream(outputSz.toPath());
                 SnappyCompressorOutputStream sos = new SnappyCompressorOutputStream(os, Files.size(input), params)) {
             Files.copy(input, sos);
         }
-        // System.err.println(input.getName() + " written, uncompressed bytes: " + input.length()
-        // + ", compressed bytes: " + outputSz.length() + " after " + (System.currentTimeMillis() - start) + "ms");
-        start = System.currentTimeMillis();
         try (SnappyCompressorInputStream sis = new SnappyCompressorInputStream(Files.newInputStream(outputSz.toPath()), params.getWindowSize())) {
             final byte[] expected = Files.readAllBytes(input);
             final byte[] actual = IOUtils.toByteArray(sis);
             assertArrayEquals(expected, actual);
         }
-        // System.err.println(outputSz.getName() + " read after " + (System.currentTimeMillis() - start) + "ms");
     }
 
     private void roundTripTest(final String testFile) throws IOException {
@@ -125,7 +115,6 @@ public final class SnappyRoundtripTest extends AbstractTest {
         // Start with the four byte sequence 0000 after that add > 64k
         // of random noise that doesn't contain any 0000 at all, then
         // add 0000.
-        final File f = newTempFile("reallyBigOffsetTest");
         final ByteArrayOutputStream fs = new ByteArrayOutputStream((1 << 16) + 1024);
         fs.write(0);
         fs.write(0);

--- a/src/test/java/org/apache/commons/compress/compressors/zstandard/ZstdRoundtripTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/zstandard/ZstdRoundtripTest.java
@@ -42,21 +42,16 @@ public class ZstdRoundtripTest extends AbstractTest {
 
     private void roundtrip(final OutputStreamCreator oc) throws IOException {
         final Path input = getPath("bla.tar");
-        long start = System.currentTimeMillis();
         final File output = newTempFile(input.getFileName() + ".zstd");
         try (FileOutputStream os = new FileOutputStream(output);
                 ZstdCompressorOutputStream zos = oc.wrap(os)) {
             Files.copy(input, zos);
         }
-        // System.err.println(input.getName() + " written, uncompressed bytes: " + input.length()
-        // + ", compressed bytes: " + output.length() + " after " + (System.currentTimeMillis() - start) + "ms");
-        start = System.currentTimeMillis();
         try (ZstdCompressorInputStream zis = new ZstdCompressorInputStream(Files.newInputStream(output.toPath()))) {
             final byte[] expected = Files.readAllBytes(input);
             final byte[] actual = IOUtils.toByteArray(zis);
             assertArrayEquals(expected, actual);
         }
-        // System.err.println(output.getName() + " read after " + (System.currentTimeMillis() - start) + "ms");
     }
 
     @Test
@@ -67,13 +62,11 @@ public class ZstdRoundtripTest extends AbstractTest {
     @Test
     public void testFactoryRoundtrip() throws Exception {
         final Path input = getPath("bla.tar");
-        long start = System.currentTimeMillis();
         final File output = newTempFile(input.getFileName() + ".zstd");
         try (OutputStream os = Files.newOutputStream(output.toPath());
                 CompressorOutputStream zos = new CompressorStreamFactory().createCompressorOutputStream("zstd", os)) {
             Files.copy(input, zos);
         }
-        start = System.currentTimeMillis();
         try (InputStream inputStream = Files.newInputStream(output.toPath());
                 CompressorInputStream zis = new CompressorStreamFactory().createCompressorInputStream("zstd", inputStream)) {
             final byte[] expected = Files.readAllBytes(input);


### PR DESCRIPTION
This found a bug in the tests. Also, unit tests and benchmarks are different things. @garydgregory 