### PR TITLE
Make `commons-lang3` optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.14.0</version>
+      <optional>true</optional>
     </dependency>    
     <dependency>
       <groupId>org.osgi</groupId>


### PR DESCRIPTION
Jenkins core ships `commons-compress` (where it is available to all Jenkins plugins) for historical reasons, but not `commons-lang3`. Instead we prefer to deliver `commons-lang3` through the Jenkins plugin system. `commons-compress` has recently sprouted a dependency on `commons-lang3`, which has forced us to start delivering `commons-lang3` in core, which we don't want to do. This library is only used in `org.apache.commons.compress.harmony.unpack200.Pack200UnpackerAdapter` which we don't use anyway, so make this an optional dependency. People who use `Pack200UnpackerAdapter` can include it, but those of us who would rather avoid it can do without.