### PR TITLE
Use correct offset when previous entry is a directory.

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarFile.java
@@ -458,7 +458,7 @@ public class TarFile implements Closeable {
 
         if (currEntry != null) {
             // Skip to the end of the entry
-            repositionForwardTo(currEntry.getDataOffset() + currEntry.getSize());
+            repositionForwardTo(currEntry.getDataOffset() + (currEntry.isDirectory() ? 0 : currEntry.getSize()));
             throwExceptionIfPositionIsNotInArchive();
             skipRecordPadding();
         }


### PR DESCRIPTION
Current implementation cannot read tar-files with folders.
This can easily be tested either by using commons-compress or any other valid tar-tool.
Create a simple folder-structure containing two folders, with a single file in each, create a uncompressed tar-file.
Reading back the file will cause a "Corrupted TAR archive" from TarArchiveEntry:1464, since the incorrect data has been read into the current buffer, it's offset by the previous 'folder-size' too much. The header can thus not be correctly parsed and the code crashes.