### PR TITLE
ZipArchiveOutputStream.addRawArchiveEntry() should check is2PhaseSource

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream.java
@@ -505,7 +505,7 @@ public class ZipArchiveOutputStream extends ArchiveOutputStream<ZipArchiveEntry>
         final boolean is2PhaseSource = ae.getCrc() != ZipArchiveEntry.CRC_UNKNOWN && ae.getSize() != ArchiveEntry.SIZE_UNKNOWN
                 && ae.getCompressedSize() != ArchiveEntry.SIZE_UNKNOWN;
         putArchiveEntry(ae, is2PhaseSource);
-        copyFromZipInputStream(rawStream);
+        copyFromZipInputStream(rawStream, is2PhaseSource);
         closeCopiedEntry(is2PhaseSource);
     }
 
@@ -622,11 +622,13 @@ public class ZipArchiveOutputStream extends ArchiveOutputStream<ZipArchiveEntry>
         entry = null;
     }
 
-    private void copyFromZipInputStream(final InputStream src) throws IOException {
+    private void copyFromZipInputStream(final InputStream src, boolean phased) throws IOException {
         if (entry == null) {
             throw new IllegalStateException("No current entry");
         }
-        ZipUtil.checkRequestedFeatures(entry.entry);
+        if (!phased) {
+            ZipUtil.checkRequestedFeatures(entry.entry);
+        }
         entry.hasWritten = true;
         int length;
         while ((length = src.read(copyBuffer)) >= 0) {

--- a/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
@@ -738,6 +738,19 @@ public final class ZipTest extends AbstractTest {
         }
     }
 
+    @Test
+    public void testUnsupportedCompressionMethodInAddRaw() throws IOException {
+        final File file1 = createTempFile("unsupportedCompressionMethod.", ".zip");
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(file1)) {
+            final ZipArchiveEntry archiveEntry = new ZipArchiveEntry("fred");
+            archiveEntry.setMethod(Integer.MAX_VALUE);
+            archiveEntry.setSize(3);
+            archiveEntry.setCompressedSize(3);
+            archiveEntry.setCrc(0);
+            zos.addRawArchiveEntry(archiveEntry, new ByteArrayInputStream("fud".getBytes()));
+        }
+    }
+
     /**
      * Archives 2 files and unarchives it again. If the file length of result and source is the same, it looks like the operations have worked
      *


### PR DESCRIPTION
This allows users to add manually compressed raw data to the zip file under an unsupported compression method (e.g., XZ) or encrypt method.

Sample usage:

```kotlin
val data = "hello world".toByteArray()
ZipArchiveOutputStream(File("test.zip")).use { zip ->
    val entry = ZipArchiveEntry("test")
    entry.method = ZipMethod.XZ.code
    entry.crc = CRC32().apply { update(data) }.value
    ByteArrayOutputStream().use { os ->
        XZCompressorOutputStream(os).use {
            it.write(data)
        }
        entry.size = data.size.toLong()
        entry.compressedSize = os.size().toLong()
        zip.addRawArchiveEntry(entry, ByteArrayInputStream(os.toByteArray()))
    }
}
```

Previously these codes would throw an exception about the unsupported compression method.