### PR TITLE
Extend IOException

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveException.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveException.java
@@ -18,10 +18,12 @@
  */
 package org.apache.commons.compress.archivers;
 
+import java.io.IOException;
+
 /**
  * Signals that an Archive exception of some sort has occurred.
  */
-public class ArchiveException extends Exception {
+public class ArchiveException extends IOException {
 
     /** Serial. */
     private static final long serialVersionUID = 2772690708123267100L;

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -224,7 +224,7 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
             signatureLength = IOUtils.readFully(in, signature);
             in.reset();
         } catch (final IOException e) {
-            throw new ArchiveException("IOException while reading signature.", e);
+            throw new ArchiveException("Failure reading signature.", e);
         }
 
         // For now JAR files are detected as ZIP files.

--- a/src/main/java/org/apache/commons/compress/compressors/CompressorException.java
+++ b/src/main/java/org/apache/commons/compress/compressors/CompressorException.java
@@ -18,10 +18,12 @@
  */
 package org.apache.commons.compress.compressors;
 
+import java.io.IOException;
+
 /**
  * Signals that an Compressor exception of some sort has occurred.
  */
-public class CompressorException extends Exception {
+public class CompressorException extends IOException {
 
     /** Serial. */
     private static final long serialVersionUID = -2932901310255908814L;

--- a/src/main/java/org/apache/commons/compress/compressors/CompressorStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/compressors/CompressorStreamFactory.java
@@ -240,7 +240,7 @@ public class CompressorStreamFactory implements CompressorStreamProvider {
             signatureLength = IOUtils.readFully(inputStream, signature);
             inputStream.reset();
         } catch (final IOException e) {
-            throw new CompressorException("IOException while reading signature.", e);
+            throw new CompressorException("Failed to read signature.", e);
         }
         if (compressorNames.contains(BZIP2) && BZip2CompressorInputStream.matches(signature, signatureLength)) {
             return BZIP2;
@@ -632,7 +632,7 @@ public class CompressorStreamFactory implements CompressorStreamProvider {
                 return new ZstdCompressorOutputStream(out);
             }
         } catch (final IOException e) {
-            throw new CompressorException("Could not create CompressorOutputStream", e);
+            throw new CompressorException("Could not create CompressorOutputStream.", e);
         }
         final CompressorStreamProvider compressorStreamProvider = getCompressorOutputStreamProviders().get(toKey(name));
         if (compressorStreamProvider != null) {

--- a/src/test/java/org/apache/commons/compress/archivers/ArchiveStreamFactoryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ArchiveStreamFactoryTest.java
@@ -281,7 +281,7 @@ public class ArchiveStreamFactoryTest extends AbstractTest {
 
         final ArchiveException e3 = assertThrows(ArchiveException.class, () -> ArchiveStreamFactory.detect(new BufferedInputStream(new BrokenInputStream())),
                 "Expected ArchiveException");
-        assertEquals("IOException while reading signature.", e3.getMessage());
+        assertEquals("Failure reading signature.", e3.getMessage());
     }
 
     /**

--- a/src/test/java/org/apache/commons/compress/compressors/DetectCompressorTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/DetectCompressorTest.java
@@ -269,7 +269,7 @@ public final class DetectCompressorTest {
 
         final CompressorException ce = assertThrows(CompressorException.class,
                 () -> CompressorStreamFactory.detect(new BufferedInputStream(new BrokenInputStream())), "Expected IOException");
-        assertEquals("IOException while reading signature.", ce.getMessage());
+        assertEquals("Failed to read signature.", ce.getMessage());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
See https://github.com/apache/httpcomponents-client/pull/580, specifically https://github.com/apache/httpcomponents-client/pull/580#pullrequestreview-2437118648
- `ArchiveException` extends `IOException`
- `CompressorException` extends `IOException`

