### PR TITLE
Remove Commons Lang dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,12 +208,13 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.17.0</version>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.17.0</version>
-    </dependency>    
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <scm>

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -48,12 +48,12 @@ import java.util.stream.Collectors;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.EntryStreamOffsets;
 import org.apache.commons.compress.archivers.zip.ZipEncoding;
+import org.apache.commons.compress.internal.lang3.SystemProperties;
 import org.apache.commons.compress.utils.ArchiveUtils;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.utils.ParsingUtils;
 import org.apache.commons.compress.utils.TimeUtils;
 import org.apache.commons.io.file.attribute.FileTimes;
-import org.apache.commons.lang3.SystemProperties;
 
 /**
  * An entry in a <a href="https://www.gnu.org/software/tar/manual/html_node/Standard.html">Tar archive</a>.

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStream.java
@@ -38,12 +38,12 @@ import java.util.Map;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipEncoding;
 import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
+import org.apache.commons.compress.internal.lang3.ArrayFill;
 import org.apache.commons.compress.utils.Charsets;
 import org.apache.commons.compress.utils.FixedLengthBlockOutputStream;
 import org.apache.commons.compress.utils.TimeUtils;
 import org.apache.commons.io.file.attribute.FileTimes;
 import org.apache.commons.io.output.CountingOutputStream;
-import org.apache.commons.lang3.ArrayFill;
 
 /**
  * The TarOutputStream writes a UNIX tar archive as an OutputStream. Methods are provided to put entries, and then write their contents by writing to this

--- a/src/main/java/org/apache/commons/compress/archivers/zip/BinaryTree.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/BinaryTree.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.lang3.ArrayFill;
+import org.apache.commons.compress.internal.lang3.ArrayFill;
 
 /**
  * Binary tree of positive values.

--- a/src/main/java/org/apache/commons/compress/archivers/zip/BinaryTree.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/BinaryTree.java
@@ -23,8 +23,8 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.internal.lang3.ArrayFill;
+import org.apache.commons.compress.utils.IOUtils;
 
 /**
  * Binary tree of positive values.

--- a/src/main/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoder.java
+++ b/src/main/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoder.java
@@ -28,10 +28,10 @@ import java.io.InputStream;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import org.apache.commons.compress.internal.lang3.ArrayFill;
 import org.apache.commons.compress.utils.BitInputStream;
 import org.apache.commons.compress.utils.ByteUtils;
 import org.apache.commons.compress.utils.ExactMath;
-import org.apache.commons.lang3.ArrayFill;
 
 /**
  * TODO This class can't be final because it is mocked by Mockito.

--- a/src/main/java/org/apache/commons/compress/compressors/lz77support/LZ77Compressor.java
+++ b/src/main/java/org/apache/commons/compress/compressors/lz77support/LZ77Compressor.java
@@ -21,7 +21,7 @@ package org.apache.commons.compress.compressors.lz77support;
 import java.io.IOException;
 import java.util.Objects;
 
-import org.apache.commons.lang3.ArrayFill;
+import org.apache.commons.compress.internal.lang3.ArrayFill;
 
 /**
  * Helper class for compression algorithms that use the ideas of LZ77.

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/Pack200UnpackerAdapter.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/Pack200UnpackerAdapter.java
@@ -31,10 +31,10 @@ import java.util.jar.JarOutputStream;
 
 import org.apache.commons.compress.harmony.pack200.Pack200Adapter;
 import org.apache.commons.compress.harmony.pack200.Pack200Exception;
+import org.apache.commons.compress.internal.lang3.reflect.FieldUtils;
 import org.apache.commons.compress.java.util.jar.Pack200.Unpacker;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.io.input.CloseShieldInputStream;
-import org.apache.commons.lang3.reflect.FieldUtils;
 
 /**
  * This class provides the binding between the standard Pack200 interface and the internal interface for (un)packing.

--- a/src/main/java/org/apache/commons/compress/internal/lang3/ArrayFill.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/ArrayFill.java
@@ -22,16 +22,16 @@ import java.util.Arrays;
 
 public final class ArrayFill {
 
-  public static int[] fill(final int[] a, final int val) {
-    Arrays.fill(a, val);
-    return a;
-  }
+    public static int[] fill(final int[] a, final int val) {
+        Arrays.fill(a, val);
+        return a;
+    }
 
-  public static byte[] fill(final byte[] a, final byte val) {
-    Arrays.fill(a, val);
-    return a;
-  }
+    public static byte[] fill(final byte[] a, final byte val) {
+        Arrays.fill(a, val);
+        return a;
+    }
 
-  private ArrayFill() {
-  }
+    private ArrayFill() {
+    }
 }

--- a/src/main/java/org/apache/commons/compress/internal/lang3/ArrayFill.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/ArrayFill.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.internal.lang3;
+
+import java.util.Arrays;
+
+public final class ArrayFill {
+
+  public static int[] fill(final int[] a, final int val) {
+    Arrays.fill(a, val);
+    return a;
+  }
+
+  public static byte[] fill(final byte[] a, final byte val) {
+    Arrays.fill(a, val);
+    return a;
+  }
+
+  private ArrayFill() {
+  }
+}

--- a/src/main/java/org/apache/commons/compress/internal/lang3/SystemProperties.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/SystemProperties.java
@@ -20,14 +20,10 @@ package org.apache.commons.compress.internal.lang3;
 
 public final class SystemProperties {
 
-  public static String getOsName() {
-    try {
-      return System.getProperty("os.name");
-    } catch (final SecurityException e) {
-      return null;
+    public static String getOsName() {
+        return System.getProperty("os.name");
     }
-  }
 
-  private SystemProperties() {
-  }
+    private SystemProperties() {
+    }
 }

--- a/src/main/java/org/apache/commons/compress/internal/lang3/SystemProperties.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/SystemProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.internal.lang3;
+
+public final class SystemProperties {
+
+  public static String getOsName() {
+    try {
+      return System.getProperty("os.name");
+    } catch (final SecurityException e) {
+      return null;
+    }
+  }
+
+  private SystemProperties() {
+  }
+}

--- a/src/main/java/org/apache/commons/compress/internal/lang3/package-info.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Private copies of methods from Commons Lang.
+ * <p>
+ *   These methods currently account to less then 1% of the size of Commons Lang.
+ *   They have been copied to prevent the addition of Commons Lang as a dependency.
+ * </p>
+ * <p>If the size of this package becomes larger than 1% of the size of Commons Lang:</p>
+ * <ol>
+ *   <li>Consider shading of up to 10% of the size of Commons Lang.</li>
+ *   <li>If that does not work include Commons Lang as dependency.</li>
+ * </ol>
+ */
+package org.apache.commons.compress.internal.lang3;

--- a/src/main/java/org/apache/commons/compress/internal/lang3/reflect/FieldUtils.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/reflect/FieldUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.internal.lang3.reflect;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.Field;
+
+public final class FieldUtils {
+
+  public static Object readField(final Object target, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
+    requireNonNull(target, "target");
+    requireNonNull(fieldName, "fieldName");
+    final Class<?> cls = target.getClass();
+    final Field field = getField(cls, fieldName, forceAccess);
+    if (field == null) {
+      throw new IllegalArgumentException(String.format("Cannot locate field %s on %s", fieldName, cls));
+    }
+    return field.get(target);
+  }
+
+  private static Field getField(final Class<?> cls, final String fieldName, final boolean forceAccess) {
+    requireNonNull(cls, "cls");
+    requireNonNull(fieldName, "fieldName");
+    Class<?> currentClass = cls;
+    while (currentClass != null) {
+      try {
+        final Field field = currentClass.getDeclaredField(fieldName);
+        // getDeclaredField checks for non-public scopes as well
+        // and it returns accurate results
+        if (forceAccess && !field.isAccessible()) {
+          field.setAccessible(true);
+        }
+        return field;
+      } catch (final NoSuchFieldException ignored) {
+        // ignore
+      }
+      currentClass = currentClass.getSuperclass();
+    }
+    return null;
+  }
+
+  private FieldUtils() {
+  }
+}

--- a/src/main/java/org/apache/commons/compress/internal/lang3/reflect/FieldUtils.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/reflect/FieldUtils.java
@@ -24,38 +24,38 @@ import java.lang.reflect.Field;
 
 public final class FieldUtils {
 
-  public static Object readField(final Object target, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
-    requireNonNull(target, "target");
-    requireNonNull(fieldName, "fieldName");
-    final Class<?> cls = target.getClass();
-    final Field field = getField(cls, fieldName, forceAccess);
-    if (field == null) {
-      throw new IllegalArgumentException(String.format("Cannot locate field %s on %s", fieldName, cls));
-    }
-    return field.get(target);
-  }
-
-  private static Field getField(final Class<?> cls, final String fieldName, final boolean forceAccess) {
-    requireNonNull(cls, "cls");
-    requireNonNull(fieldName, "fieldName");
-    Class<?> currentClass = cls;
-    while (currentClass != null) {
-      try {
-        final Field field = currentClass.getDeclaredField(fieldName);
-        // getDeclaredField checks for non-public scopes as well
-        // and it returns accurate results
-        if (forceAccess && !field.isAccessible()) {
-          field.setAccessible(true);
+    public static Object readField(final Object target, final String fieldName, final boolean forceAccess) throws IllegalAccessException {
+        requireNonNull(target, "target");
+        requireNonNull(fieldName, "fieldName");
+        final Class<?> cls = target.getClass();
+        final Field field = getField(cls, fieldName, forceAccess);
+        if (field == null) {
+            throw new IllegalArgumentException(String.format("Cannot locate field %s on %s", fieldName, cls));
         }
-        return field;
-      } catch (final NoSuchFieldException ignored) {
-        // ignore
-      }
-      currentClass = currentClass.getSuperclass();
+        return field.get(target);
     }
-    return null;
-  }
 
-  private FieldUtils() {
-  }
+    private static Field getField(final Class<?> cls, final String fieldName, final boolean forceAccess) {
+        requireNonNull(cls, "cls");
+        requireNonNull(fieldName, "fieldName");
+        Class<?> currentClass = cls;
+        while (currentClass != null) {
+            try {
+                final Field field = currentClass.getDeclaredField(fieldName);
+                // getDeclaredField checks for non-public scopes as well
+                // and it returns accurate results
+                if (forceAccess && !field.isAccessible()) {
+                    field.setAccessible(true);
+                }
+                return field;
+            } catch (final NoSuchFieldException ignored) {
+                // ignore
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+        return null;
+    }
+
+    private FieldUtils() {
+    }
 }

--- a/src/main/java/org/apache/commons/compress/internal/lang3/reflect/package-info.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/reflect/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * A private copy of methods from Commons Lang.
+ * <p>
+ *   See
+ *   <a href="{@docRoot}/org/apache/commons/compress/internal/lang3/package-summary.html#package_description>{@code org.apache.commons.compress.internal.lang3} package description</a>
+ *   for more information.
+ * </p>
+ */
+package org.apache.commons.compress.internal.lang3.reflect;

--- a/src/main/java/org/apache/commons/compress/internal/lang3/reflect/package-info.java
+++ b/src/main/java/org/apache/commons/compress/internal/lang3/reflect/package-info.java
@@ -20,7 +20,9 @@
  * A private copy of methods from Commons Lang.
  * <p>
  *   See
- *   <a href="{@docRoot}/org/apache/commons/compress/internal/lang3/package-summary.html#package_description>{@code org.apache.commons.compress.internal.lang3} package description</a>
+ *   <a href="{@docRoot}/org/apache/commons/compress/internal/lang3/package-summary.html#package_description>
+ *     {@code org.apache.commons.compress.internal.lang3} package description
+ *   </a>
  *   for more information.
  * </p>
  */


### PR DESCRIPTION
Commons Compress version 1.26.0 depends on Commons Lang, which is a 650 KiB dependency. In reality, however, only 4 methods accounting for less than 1% of Commons Lang are used.

We replace the dependency on `commons-lang3` with a local copy of these 4 methods.