### PR TITLE
Update outdated descriptions in IOUtils and IOUtilsTest

### DIFF
--- a/src/main/java/org/apache/commons/compress/utils/IOUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/IOUtils.java
@@ -292,7 +292,7 @@ public final class IOUtils {
      * @param input the {@code InputStream} to read from
      * @return the requested byte array
      * @throws NullPointerException if the input is null
-     * @throws IOException          if an I/O error occurs
+     * @throws IOException          if an I/O error occurs or reads more than {@link Integer#MAX_VALUE} occurs
      * @since 1.5
      * @deprecated Use {@link org.apache.commons.io.IOUtils#toByteArray(InputStream)}.
      */

--- a/src/main/java/org/apache/commons/compress/utils/IOUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/IOUtils.java
@@ -76,9 +76,10 @@ public final class IOUtils {
      * Copies the content of a InputStream into an OutputStream. Uses a default buffer size of 8024 bytes.
      *
      * @param input  the InputStream to copy
-     * @param output the target, may be null to simulate output to dev/null on Linux and NUL on Windows
+     * @param output the target
      * @return the number of bytes copied
      * @throws IOException if an error occurs
+     * @throws NullPointerException if the {@code input} or the {@code output} is {@code null}
      * @deprecated Use {@link org.apache.commons.io.IOUtils#copy(InputStream, OutputStream)}.
      */
     @Deprecated
@@ -90,11 +91,11 @@ public final class IOUtils {
      * Copies the content of a InputStream into an OutputStream
      *
      * @param input      the InputStream to copy
-     * @param output     the target, may be null to simulate output to dev/null on Linux and NUL on Windows
+     * @param output     the target
      * @param bufferSize the buffer size to use, must be bigger than 0
      * @return the number of bytes copied
      * @throws IOException              if an error occurs
-     * @throws IllegalArgumentException if bufferSize is smaller than or equal to 0
+     * @throws NullPointerException if the {@code input} or the {@code output} is {@code null}
      * @deprecated Use {@link org.apache.commons.io.IOUtils#copy(InputStream, OutputStream, int)}.
      */
     @Deprecated

--- a/src/main/java/org/apache/commons/compress/utils/IOUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/IOUtils.java
@@ -73,11 +73,11 @@ public final class IOUtils {
     }
 
     /**
-     * Copies the content of a InputStream into an OutputStream. Uses a default buffer size of 8024 bytes.
+     * Copies the content of a InputStream into an OutputStream. Uses a default buffer size of 8192 bytes.
      *
      * @param input  the InputStream to copy
      * @param output the target
-     * @return the number of bytes copied
+     * @return the number of bytes copied, or -1 if greater than {@link Integer#MAX_VALUE}
      * @throws IOException if an error occurs
      * @throws NullPointerException if the {@code input} or the {@code output} is {@code null}
      * @deprecated Use {@link org.apache.commons.io.IOUtils#copy(InputStream, OutputStream)}.
@@ -104,7 +104,7 @@ public final class IOUtils {
     }
 
     /**
-     * Copies part of the content of a InputStream into an OutputStream. Uses a default buffer size of 8024 bytes.
+     * Copies part of the content of a InputStream into an OutputStream. Uses a default buffer size of 8192 bytes.
      *
      * @param input  the InputStream to copy
      * @param output the target Stream

--- a/src/test/java/org/apache/commons/compress/utils/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/utils/IOUtilsTest.java
@@ -107,7 +107,7 @@ public class IOUtilsTest {
     }
 
     @Test
-    public void testCopyThrowsOnZeroBufferSize() throws IOException {
+    public void testCopyOnZeroBufferSize() throws IOException {
         assertEquals(0, IOUtils.copy(new ByteArrayInputStream(ByteUtils.EMPTY_BYTE_ARRAY), new ByteArrayOutputStream(), 0));
     }
 


### PR DESCRIPTION
When I was trying to move away from commons-io and commons-lang in my fork, I noticed some subtle behavior changes in IOUtils , but the description was not updated in time.

While I think it would be best to revert the code to restore the behavior, I figured that upstream might not be willing to continue maintaining the deprecated code, so I just updated the documentation to match the behavior.