### PR TITLE
Optimizing ZipEightByteInteger

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
@@ -64,6 +64,16 @@ public final class ZipEightByteInteger implements Serializable {
 
     public static final ZipEightByteInteger ZERO = new ZipEightByteInteger(0);
 
+    private static final BigInteger HIGHEST_BIT = BigInteger.ONE.shiftLeft(63);
+
+    static BigInteger toUnsignedBigInteger(final long value) {
+        if (value >= 0L) {
+            return BigInteger.valueOf(value);
+        } else {
+            return BigInteger.valueOf(value & Long.MAX_VALUE).add(HIGHEST_BIT);
+        }
+    }
+
     /**
      * Gets value as eight bytes in big-endian byte order.
      *

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
@@ -202,6 +202,6 @@ public final class ZipEightByteInteger implements Serializable {
 
     @Override
     public String toString() {
-        return "ZipEightByteInteger value: " + value;
+        return "ZipEightByteInteger value: " + Long.toUnsignedString(value);
     }
 }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
@@ -137,7 +137,7 @@ public final class ZipEightByteInteger implements Serializable {
      * @param offset the offset to start
      */
     public ZipEightByteInteger(final byte[] bytes, final int offset) {
-        value = getLongValue(bytes, offset);
+        this.value = getLongValue(bytes, offset);
     }
 
     /**
@@ -146,7 +146,7 @@ public final class ZipEightByteInteger implements Serializable {
      * @param value the long to store as a ZipEightByteInteger
      */
     public ZipEightByteInteger(final long value) {
-        this(BigInteger.valueOf(value));
+        this.value = value;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
@@ -160,7 +160,7 @@ public final class ZipEightByteInteger implements Serializable {
         if (!(o instanceof ZipEightByteInteger)) {
             return false;
         }
-        return value == (((ZipEightByteInteger) o).value);
+        return value == ((ZipEightByteInteger) o).value;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipEightByteInteger.java
@@ -35,6 +35,9 @@ public final class ZipEightByteInteger implements Serializable {
 
     private static final BigInteger HIGHEST_BIT = BigInteger.ONE.shiftLeft(63);
 
+    /**
+     * package private for tests only.
+     */
     static BigInteger toUnsignedBigInteger(final long value) {
         if (value >= 0L) {
             return BigInteger.valueOf(value);

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipEightByteIntegerTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipEightByteIntegerTest.java
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.Test;
  */
 public class ZipEightByteIntegerTest {
 
+    /**
+     * Test {@link ZipEightByteInteger#toUnsignedBigInteger(long)}.
+     */
     @Test
     public void testToUnsignedBigInteger() {
         assertEquals(BigInteger.valueOf(Long.MAX_VALUE), ZipEightByteInteger.toUnsignedBigInteger(Long.MAX_VALUE));

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipEightByteIntegerTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipEightByteIntegerTest.java
@@ -29,6 +29,12 @@ import org.junit.jupiter.api.Test;
  */
 public class ZipEightByteIntegerTest {
 
+    @Test
+    public void testToUnsignedBigInteger() {
+        assertEquals(BigInteger.valueOf(Long.MAX_VALUE), ZipEightByteInteger.toUnsignedBigInteger(Long.MAX_VALUE));
+        assertEquals(BigInteger.valueOf(Long.MAX_VALUE).shiftLeft(1), ZipEightByteInteger.toUnsignedBigInteger(0XFFFFFFFFFFFFFFFEL));
+    }
+
     /**
      * Test conversion from bytes.
      */

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipEightByteIntegerTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipEightByteIntegerTest.java
@@ -109,6 +109,16 @@ public class ZipEightByteIntegerTest {
     }
 
     /**
+     * Test conversion from bytes.
+     */
+    @Test
+    public void testBILongFromBytes() {
+        final byte[] val = { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+        final ZipEightByteInteger zl = new ZipEightByteInteger(val);
+        assertEquals(0XFFFFFFFFFFFFFFFFL, zl.getLongValue(), "longValue from bytes");
+    }
+
+    /**
      * Test conversion to bytes.
      */
     @Test
@@ -134,5 +144,15 @@ public class ZipEightByteIntegerTest {
         final ZipEightByteInteger zl = new ZipEightByteInteger(
                 new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF });
         assertEquals(BigInteger.valueOf(Long.MAX_VALUE).shiftLeft(1).setBit(0), zl.getValue());
+    }
+
+    /**
+     * Test {@link ZipEightByteInteger#toString()}.
+     */
+    @Test
+    public void testToString() {
+        final ZipEightByteInteger zipEightByteInteger = new ZipEightByteInteger(
+                new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF });
+        assertEquals("ZipEightByteInteger value: 18446744073709551615", zipEightByteInteger.toString());
     }
 }


### PR DESCRIPTION
Use unsigned long instead of BigInteger to simplify code and improve performance.