### PR TITLE
Throw an IllegalArgumentException when a file name or comment in gzip parameters encodes to a byte array with a 0 byte

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipParameters.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipParameters.java
@@ -26,7 +26,7 @@ import java.util.zip.Deflater;
 
 import org.apache.commons.io.Charsets;
 import org.apache.commons.lang3.ArrayUtils;
-
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Parameters for the GZIP compressor.
@@ -300,11 +300,8 @@ public class GzipParameters {
     private int deflateStrategy = Deflater.DEFAULT_STRATEGY;
 
     private String requireNonNulByte(final String text) {
-        if (text != null && text.length() > 0) {
-            if (ArrayUtils.contains(text.getBytes(fileNameCharset), (byte) 0)) {
-                throw new IllegalArgumentException(
-                        "String encoded in Charset '" + fileNameCharset + "' contains the nul byte 0 which is not supported in gzip.");
-            }
+        if (StringUtils.isNotEmpty(text) && ArrayUtils.contains(text.getBytes(fileNameCharset), (byte) 0)) {
+            throw new IllegalArgumentException("String encoded in Charset '" + fileNameCharset + "' contains the nul byte 0 which is not supported in gzip.");
         }
         return text;
     }

--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipParameters.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipParameters.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.zip.Deflater;
 
 import org.apache.commons.io.Charsets;
+import org.apache.commons.lang3.ArrayUtils;
 
 
 /**
@@ -298,6 +299,16 @@ public class GzipParameters {
     private int bufferSize = 512;
     private int deflateStrategy = Deflater.DEFAULT_STRATEGY;
 
+    private String requireNonNulByte(final String text) {
+        if (text != null && text.length() > 0) {
+            if (ArrayUtils.contains(text.getBytes(fileNameCharset), (byte) 0)) {
+                throw new IllegalArgumentException(
+                        "String encoded in Charset '" + fileNameCharset + "' contains the nul byte 0 which is not supported in gzip.");
+            }
+        }
+        return text;
+    }
+
     /**
      * Gets size of the buffer used to retrieve compressed data.
      *
@@ -448,9 +459,10 @@ public class GzipParameters {
      * Sets an arbitrary user-defined comment.
      *
      * @param comment a user-defined comment.
+     * @throws IllegalArgumentException if the encoded bytes would contain a nul byte '\0' reserved for gzip field termination.
      */
     public void setComment(final String comment) {
-        this.comment = comment;
+        this.comment = requireNonNulByte(comment);
     }
 
     /**
@@ -495,20 +507,22 @@ public class GzipParameters {
      * Sets the name of the compressed file.
      *
      * @param fileName the name of the file without the directory path
+     * @throws IllegalArgumentException if the encoded bytes would contain a nul byte '\0' reserved for gzip field termination.
      * @deprecated Use {@link #setFileName(String)}.
      */
     @Deprecated
     public void setFilename(final String fileName) {
-        this.fileName = fileName;
+        setFileName(fileName);
     }
 
     /**
      * Sets the name of the compressed file.
      *
      * @param fileName the name of the file without the directory path
+     * @throws IllegalArgumentException if the encoded bytes would contain a nul byte '\0' reserved for gzip field termination.
      */
     public void setFileName(final String fileName) {
-        this.fileName = fileName;
+        this.fileName = requireNonNulByte(fileName);
     }
 
     /**

--- a/src/test/java/org/apache/commons/compress/compressors/gzip/GzipParametersTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/gzip/GzipParametersTest.java
@@ -52,14 +52,16 @@ public class GzipParametersTest {
     }
 
     @ParameterizedTest
-    @CsvSource({ //@formatter:off
+    //@formatter:off
+    @CsvSource({
         "          , helloworld",
-        "          , helloéworld",
+        "          , helloÃ©world",
         "ISO-8859-1, helloworld",
-        "ISO-8859-1, helloéworld",
+        "ISO-8859-1, helloÃ©world",
         "UTF-8     , helloworld",
-        "UTF-8     , helloéworld",
-    })//@formatter:on
+        "UTF-8     , helloÃ©world"
+    })
+    //@formatter:on
     public void testLegalCommentOrFileName(final String charset, final String text) {
         final GzipParameters p = new GzipParameters();
         if (charset != null) {
@@ -71,12 +73,14 @@ public class GzipParametersTest {
     }
 
     @ParameterizedTest
-    @CsvSource({ //@formatter:off
+    //@formatter:off
+    @CsvSource({
         "          , hello\0world, false",
         "ISO-8859-1, hello\0world, false",
         "UTF-8     , hello\0world, false",
-        "UTF-16BE  , helloworld, false",
-    })//@formatter:on
+        "UTF-16BE  , helloworld, false"
+    })
+    //@formatter:on
     public void testIllegalCommentOrFileName(final String charset, final String text) {
         final GzipParameters p = new GzipParameters();
         if (charset != null) {

--- a/src/test/java/org/apache/commons/compress/compressors/gzip/GzipParametersTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/gzip/GzipParametersTest.java
@@ -20,11 +20,15 @@
 package org.apache.commons.compress.compressors.gzip;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.Charset;
 import java.util.zip.Deflater;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests {@link GzipParameters}.
@@ -45,5 +49,41 @@ public class GzipParametersTest {
         assertTrue(gzipParameters.toString().contains("UNKNOWN"));
         gzipParameters.setOS(GzipParameters.OS.Z_SYSTEM);
         assertTrue(gzipParameters.toString().contains("Z_SYSTEM"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ //@formatter:off
+        "          , helloworld",
+        "          , helloéworld",
+        "ISO-8859-1, helloworld",
+        "ISO-8859-1, helloéworld",
+        "UTF-8     , helloworld",
+        "UTF-8     , helloéworld",
+    })//@formatter:on
+    public void testLegalCommentOrFileName(final String charset, final String text) {
+        final GzipParameters p = new GzipParameters();
+        if (charset != null) {
+            p.setFileNameCharset(Charset.forName(charset));
+        }
+        p.setComment(text);
+        p.setFilename(text);
+        p.setFileName(text);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ //@formatter:off
+        "          , hello\0world, false",
+        "ISO-8859-1, hello\0world, false",
+        "UTF-8     , hello\0world, false",
+        "UTF-16BE  , helloworld, false",
+    })//@formatter:on
+    public void testIllegalCommentOrFileName(final String charset, final String text) {
+        final GzipParameters p = new GzipParameters();
+        if (charset != null) {
+            p.setFileNameCharset(Charset.forName(charset));
+        }
+        assertThrows(IllegalArgumentException.class, () -> p.setComment(text));
+        assertThrows(IllegalArgumentException.class, () -> p.setFilename(text));
+        assertThrows(IllegalArgumentException.class, () -> p.setFileName(text));
     }
 }


### PR DESCRIPTION
When gzip parameters' filename or comment are encoded into bytes, no verification was made to avoid the \0 that internally terminates those gzip fields.

Thus, the string argument could have a \0, and/or encode into bytes that have a \0 (like with UTF-16 charsets).
This would silently corrupt the gzip member, as a reader would prematurely stop reading the filename or comment and begin reading the next piece, either the comment but inevitably the deflate stream, which would fail.

I thought also about limiting the length on write but the gzip spec has no limit. Limiting length on read (to protect memory) would be imposing an arbitrary limit too, like some gzip tools do. Either way, it would have to be an option like the charset on write, and it would be unusual to ask for such option on the GzipDecompressorInputStream. Using jdk 17 ScopedValues is not possible yet and it would be a very forgettable option to set anyway. Without some discussion, there is no point in placing another api facing change on constructors.