### PR TITLE
(doc) fix gzip compressor incorrect MTIME value which is already in seconds

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
@@ -227,7 +227,7 @@ public class GzipCompressorInputStream extends CompressorInputStream implements 
             throw new IOException("Reserved flags are set in the .gz header");
         }
 
-        parameters.setModificationTime(ByteUtils.fromLittleEndian(inData, 4) * 1000);
+        parameters.setModificationTime(ByteUtils.fromLittleEndian(inData, 4));
         switch (inData.readUnsignedByte()) { // extra flags
         case 2:
             parameters.setCompressionLevel(Deflater.BEST_COMPRESSION);

--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorOutputStream.java
@@ -178,7 +178,7 @@ public class GzipCompressorOutputStream extends CompressorOutputStream<OutputStr
         buffer.putShort((short) GZIPInputStream.GZIP_MAGIC);
         buffer.put((byte) Deflater.DEFLATED); // compression method (8: deflate)
         buffer.put((byte) ((extra != null ? FEXTRA : 0) | (fileName != null ? FNAME : 0) | (comment != null ? FCOMMENT : 0))); // flags
-        buffer.putInt((int) (parameters.getModificationTime() / 1000));
+        buffer.putInt((int) (parameters.getModificationTime()));
         // extra flags
         final int compressionLevel = parameters.getCompressionLevel();
         if (compressionLevel == Deflater.BEST_COMPRESSION) {


### PR DESCRIPTION
Fix the gzip compressor inputstream and outputstream incorrect MTIME value which is already in seconds.
They should not divide or multiply by 1000.
