### PR TITLE
[COMPRESS-695] Ability to use different InputStreams for Zstd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+	<dependency>
+	    <groupId>io.airlift</groupId>
+	    <artifactId>aircompressor</artifactId>
+	    <version>0.26</version>
+	    <scope>test</scope>
+	</dependency>
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,12 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
-	<dependency>
-	    <groupId>io.airlift</groupId>
-	    <artifactId>aircompressor</artifactId>
-	    <version>0.26</version>
-	    <scope>test</scope>
-	</dependency>
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+      <version>0.26</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -794,14 +794,14 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
 
     /**
      * Creates the appropriate InputStream for the ZSTD compression method.
-     * @param bis the input stream which should be used for compression
-     * @return the {@link InputStream} for handling the Zstd compression
-     * @throws IOException can be thrown by the Inner {@link ZstdInputStream}.
      *
+     * @param in the input stream which should be used for compression.
+     * @return the {@link InputStream} for handling the Zstd compression.
+     * @throws IOException if an I/O error occurs.
      * @since 1.28.0
      */
-    protected InputStream createZstdInputStream(final InputStream bis) throws IOException {
-        return new ZstdCompressorInputStream(bis);
+    protected InputStream createZstdInputStream(final InputStream in) throws IOException {
+        return new ZstdCompressorInputStream(in);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -51,8 +51,6 @@ import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.utils.InputStreamStatistics;
 import org.apache.commons.io.input.BoundedInputStream;
 
-import com.github.luben.zstd.ZstdInputStream;
-
 /**
  * Implements an input stream that can read Zip archives.
  * <p>

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -51,6 +51,8 @@ import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.utils.InputStreamStatistics;
 import org.apache.commons.io.input.BoundedInputStream;
 
+import com.github.luben.zstd.ZstdInputStream;
+
 /**
  * Implements an input stream that can read Zip archives.
  * <p>
@@ -773,7 +775,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
                     break;
                 case ZSTD:
                 case ZSTD_DEPRECATED:
-                    current.inputStream = new ZstdCompressorInputStream(bis);
+                    current.inputStream = createZstdInputStream(bis);
                     break;
                 default:
                     // we should never get here as all supported methods have been covered
@@ -788,6 +790,18 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
 
         entriesRead++;
         return current.entry;
+    }
+
+    /**
+     * Creates the appropriate InputStream for the ZSTD compression method.
+     * @param bis the input stream which should be used for compression
+     * @return the {@link InputStream} for handling the Zstd compression
+     * @throws IOException can be thrown by the Inner {@link ZstdInputStream}.
+     *
+     * @since 1.28.0
+     */
+    protected InputStream createZstdInputStream(final InputStream bis) throws IOException {
+        return new ZstdCompressorInputStream(bis);
     }
 
     /**


### PR DESCRIPTION
Exposed the instantiation of Zstd InputStream. This should give the ability to override and use a different Zstd compressor library.
