### PR TITLE
[COMPRESS-695] Configure ZipFile with a custom Zstd input stream implementation

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/Attribute.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/Attribute.java
@@ -126,7 +126,7 @@ public abstract class Attribute extends ClassFileEntry {
      * Writes this body to the given output stream.
      *
      * @param out the output.
-     * @throws IOException
+     * @throws IOException if an I/O error occurs.
      */
     protected abstract void writeBody(DataOutputStream out) throws IOException;
 


### PR DESCRIPTION
Adjusted the ZipFile and the Builder. Added a Test for checking both.

Jira: https://issues.apache.org/jira/browse/COMPRESS-695


