### PR TITLE
[COMPRESS-695] Ability to use different InputStreams for Zstd

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -93,7 +93,9 @@ import org.apache.commons.io.input.BoundedInputStream;
  */
 public class ZipFile implements Closeable {
 
-    private static final IOFunction<InputStream, InputStream> DEFAULT_ZSTD_INPUT_STREAM_FACTORY = ZstdCompressorInputStream::new;
+    private static final IOFunction<InputStream, InputStream> DEFAULT_ZSTD_INPUT_STREAM_FACTORY = i -> {
+        return new ZstdCompressorInputStream(i);
+    };
 
     /**
      * Lock-free implementation of BoundedInputStream. The implementation uses positioned reads on the underlying archive file channel and therefore performs


### PR DESCRIPTION
* Change ZstdCompressorInputStream::new to lambda expression, because it accesses the ZstdCompressorInputStream directly and tries to access ZstdInputStream. Now it accesses only if the apply method was called.
