### PR TITLE
[COMPRESS-702] Performance issue in SevenZFile

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
@@ -874,6 +874,7 @@ public class SevenZFile implements Closeable {
                     .setChecksum(new CRC32())
                     .setInputStream(fileStream)
                     .setExpectedChecksumValue(file.getCrcValue())
+                    .setCountThreshold(file.getSize())
                     .get();
             // @formatter:on
         }

--- a/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
@@ -57,6 +57,7 @@ import org.apache.commons.compress.PasswordRequiredException;
 import org.apache.commons.compress.utils.MultiReadOnlySeekableByteChannel;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.ChecksumInputStream;
 import org.junit.jupiter.api.Test;
 
 class SevenZFileTest extends AbstractTest {
@@ -947,5 +948,22 @@ class SevenZFileTest extends AbstractTest {
         assertFalse(SevenZFile.matches(new byte[] { 1, 2, 3, 4, 5, 6 }, 6));
         assertTrue(SevenZFile.matches(new byte[] { '7', 'z', (byte) 0xBC, (byte) 0xAF, 0x27, 0x1C }, 6));
         assertFalse(SevenZFile.matches(new byte[] { '7', 'z', (byte) 0xBC, (byte) 0xAF, 0x27, 0x1D }, 6));
+    }
+
+    @Test
+    void testRemainingBytesUnchangedAfterRead() throws Exception {
+        try (SevenZFile sevenZFile = getSevenZFile("COMPRESS-256.7z")) {
+            for (final SevenZArchiveEntry entry : sevenZFile.getEntries()) {
+                final InputStream inputStream = sevenZFile.getInputStream(entry);
+                if (!(inputStream instanceof ChecksumInputStream)) {
+                    continue;
+                }
+                assertEquals(entry.getSize(), ((ChecksumInputStream) inputStream).getRemaining());
+                // read 10 byte
+                final byte[] bytes = new byte[10];
+                inputStream.read(bytes);
+                assertNotEquals(entry.getSize(), ((ChecksumInputStream) inputStream).getRemaining());
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

In version 1.27.1 of Apache Commons Compress, the `buildDecodingStream()` method did not pass the `countThreshold ` parameter into the `ChecksumInputStream` constructor, resulting in the `getRemaining()` method of `ChecksumInputStream` returning an incorrect number of remaining bytes. This will affect `SevenZfile` # `getInputStream()` 's judgment of `hasCurrentIndexBeeReyad()` and `skipEnteriesWhenNeed()` in random access mode, resulting in the system being unable to determine whether the current entry has been read, and re extracting the entire folder content from the file header every time, seriously affecting performance. By displaying the call to. `setCountThreshold (file. getSize())` during stream construction, it is possible to ensure accurate calculation of remaining bytes, thereby correctly skipping processed entries and significantly improving random access performance.
