### PR TITLE
Uniform handling of special tar records in `TarFile` and `TarArchiveInputStream`

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -88,6 +88,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add org.apache.commons.compress.archivers.ArchiveException.addExact(long, long).</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add org.apache.commons.compress.archivers.ArchiveException.toIntExact(long).</action>
       <!-- UPDATE -->
+      <action type="update" dev="pkarwasz">Uniform handling of special tar records in `TarFile` and `TarArchiveInputStream`.</action>
     </release>
     <release version="1.28.0" date="2025-07-26" description="This is a feature and maintenance release. Java 8 or later is required.">
       <!-- FIX -->

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveEntry.java
@@ -1473,8 +1473,20 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
         }
     }
 
-    private int parseTarHeaderBlock(final byte[] header, final ZipEncoding encoding, final boolean oldStyle, final boolean lenient, int offset)
+    /**
+     * Parses a UNIX V7 tar header block.
+     *
+     * @param header The tar entry header buffer to get information from.
+     * @param encoding The encoding to use for file names.
+     * @param oldStyle If {@code true}, file names are parsed using the old style, i.e. without encoding.
+     * @param lenient If {@code true}, parsing of numeric fields is lenient, i.e. it will not throw an exception if the field is not a valid octal number.
+     * @return The offset at which the UNIX V7 tar header block ends.
+     * @throws IllegalArgumentException If any of the numeric fields have an invalid format and lenient is {@code false}.
+     * @throws IOException If an encoding error occurs while parsing the file name or if the header is malformed.
+     */
+    private int parseTarHeaderBlock(final byte[] header, final ZipEncoding encoding, final boolean oldStyle, final boolean lenient)
             throws IOException {
+        int offset = 0;
         name = oldStyle ? TarUtils.parseName(header, offset, NAMELEN) : TarUtils.parseName(header, offset, NAMELEN, encoding);
         offset += NAMELEN;
         mode = (int) parseOctalOrBinary(header, offset, MODELEN, lenient);
@@ -1494,14 +1506,35 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
         offset += CHKSUMLEN;
         linkFlag = header[offset++];
         linkName = oldStyle ? TarUtils.parseName(header, offset, NAMELEN) : TarUtils.parseName(header, offset, NAMELEN, encoding);
+        offset += NAMELEN;
         return offset;
     }
 
+    /**
+     * Parses a POSIX.1-1988 UStar format header block or one of its variants.
+     * <p>
+     *     The supported variants and extensions are:
+     * </p>
+     * <ul>
+     *     <li>POSIX.1-1988</li>
+     *     <li>Old GNU tar format (pre-PAX)</li>
+     *     <li>POSIX.1-2001 pax interchange format</li>
+     *     <li>STAR format (Schily tar)</li>
+     * </ul>
+     *
+     * @param globalPaxHeaders Global PAX headers that appeared before this entry in the archive.
+     * @param header The tar entry header buffer to get information from.
+     * @param encoding The encoding to use for file names.
+     * @param oldStyle If {@code true}, file names are parsed using the old style, i.e. without encoding.
+     * @param lenient If {@code true}, parsing of numeric fields is lenient, i.e. it will not throw an exception if the field is not a valid octal number.
+     * @throws IllegalArgumentException If any of the numeric fields have an invalid format and lenient is {@code false}.
+     * @throws IOException If an encoding error occurs while parsing the file name or if the header is malformed.
+     */
     private void parseUstarHeaderBlock(final Map<String, String> globalPaxHeaders, final byte[] header, final ZipEncoding encoding, final boolean oldStyle,
             final boolean lenient) throws IOException {
-        int offset = 0;
-        offset = parseTarHeaderBlock(header, encoding, oldStyle, lenient, offset);
-        offset += NAMELEN;
+        // Parses the UNIX V7 tar header block.
+        int offset = parseTarHeaderBlock(header, encoding, oldStyle, lenient);
+        // Parses the UStar header block.
         magic = TarUtils.parseName(header, offset, MAGICLEN);
         offset += MAGICLEN;
         version = TarUtils.parseName(header, offset, VERSIONLEN);
@@ -1520,47 +1553,54 @@ public class TarArchiveEntry implements ArchiveEntry, TarConstants, EntryStreamO
         }
         final int type = evaluateType(globalPaxHeaders, header);
         switch (type) {
-        case FORMAT_OLDGNU: {
-            aTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, ATIMELEN_GNU, lenient));
-            offset += ATIMELEN_GNU;
-            cTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, CTIMELEN_GNU, lenient));
-            offset += CTIMELEN_GNU;
-            offset += OFFSETLEN_GNU;
-            offset += LONGNAMESLEN_GNU;
-            offset += PAD2LEN_GNU;
-            sparseHeaders = new ArrayList<>(TarUtils.readSparseStructs(header, offset, SPARSE_HEADERS_IN_OLDGNU_HEADER));
-            offset += SPARSELEN_GNU;
-            isExtended = TarUtils.parseBoolean(header, offset);
-            offset += ISEXTENDEDLEN_GNU;
-            realSize = TarUtils.parseOctal(header, offset, REALSIZELEN_GNU);
-            offset += REALSIZELEN_GNU; // NOSONAR - assignment as documentation
-            break;
-        }
-        case FORMAT_XSTAR: {
-            final String xstarPrefix = oldStyle ? TarUtils.parseName(header, offset, PREFIXLEN_XSTAR)
-                    : TarUtils.parseName(header, offset, PREFIXLEN_XSTAR, encoding);
-            offset += PREFIXLEN_XSTAR;
-            if (!xstarPrefix.isEmpty()) {
-                name = xstarPrefix + "/" + name;
+            // GNU format as before 1.12
+            case FORMAT_OLDGNU: {
+                aTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, ATIMELEN_GNU, lenient));
+                offset += ATIMELEN_GNU;
+                cTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, CTIMELEN_GNU, lenient));
+                offset += CTIMELEN_GNU;
+                offset += OFFSETLEN_GNU;
+                offset += LONGNAMESLEN_GNU;
+                offset += PAD2LEN_GNU;
+                sparseHeaders =
+                        new ArrayList<>(TarUtils.readSparseStructs(header, offset, SPARSE_HEADERS_IN_OLDGNU_HEADER));
+                offset += SPARSELEN_GNU;
+                isExtended = TarUtils.parseBoolean(header, offset);
+                offset += ISEXTENDEDLEN_GNU;
+                realSize = TarUtils.parseOctal(header, offset, REALSIZELEN_GNU);
+                offset += REALSIZELEN_GNU; // NOSONAR - assignment as documentation
+                break;
             }
-            aTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, ATIMELEN_XSTAR, lenient));
-            offset += ATIMELEN_XSTAR;
-            cTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, CTIMELEN_XSTAR, lenient));
-            offset += CTIMELEN_XSTAR; // NOSONAR - assignment as documentation
-            break;
-        }
-        case FORMAT_POSIX:
-        default: {
-            final String prefix = oldStyle ? TarUtils.parseName(header, offset, PREFIXLEN) : TarUtils.parseName(header, offset, PREFIXLEN, encoding);
-            offset += PREFIXLEN; // NOSONAR - assignment as documentation
-            // SunOS tar -E does not add / to directory names, so fix up to be consistent
-            if (isDirectory() && !name.endsWith("/")) {
-                name += "/";
+            // Star format (Schily tar)
+            case FORMAT_XSTAR: {
+                final String xstarPrefix = oldStyle
+                        ? TarUtils.parseName(header, offset, PREFIXLEN_XSTAR)
+                        : TarUtils.parseName(header, offset, PREFIXLEN_XSTAR, encoding);
+                offset += PREFIXLEN_XSTAR;
+                if (!xstarPrefix.isEmpty()) {
+                    name = xstarPrefix + "/" + name;
+                }
+                aTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, ATIMELEN_XSTAR, lenient));
+                offset += ATIMELEN_XSTAR;
+                cTime = fileTimeFromOptionalSeconds(parseOctalOrBinary(header, offset, CTIMELEN_XSTAR, lenient));
+                offset += CTIMELEN_XSTAR; // NOSONAR - assignment as documentation
+                break;
             }
-            if (!prefix.isEmpty()) {
-                name = prefix + "/" + name;
+            // Pure POSIX.1-1988 UStar format
+            case FORMAT_POSIX:
+            default: {
+                final String prefix = oldStyle
+                        ? TarUtils.parseName(header, offset, PREFIXLEN)
+                        : TarUtils.parseName(header, offset, PREFIXLEN, encoding);
+                offset += PREFIXLEN; // NOSONAR - assignment as documentation
+                // SunOS tar -E does not add / to directory names, so fix up to be consistent
+                if (isDirectory() && !name.endsWith("/")) {
+                    name += "/";
+                }
+                if (!prefix.isEmpty()) {
+                    name = prefix + "/" + name;
+                }
             }
-        }
         }
     }
 

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -51,8 +51,6 @@ import org.apache.commons.io.input.BoundedInputStream;
  */
 public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
 
-    private static final int MAX_PAX_HEADER_DEPTH = Integer.getInteger("TarArchiveInputStream.MAX_PAX_HEADER_DEPTH", 850);
-
     /**
      * IBM AIX <a href=""https://www.ibm.com/docs/sv/aix/7.2.0?topic=files-tarh-file">tar.h</a>: "This field is terminated with a space only."
      */
@@ -124,14 +122,12 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
     private final ZipEncoding zipEncoding;
 
     /** The global PAX header. */
-    private Map<String, String> globalPaxHeaders = new HashMap<>();
+    private final Map<String, String> globalPaxHeaders = new HashMap<>();
 
     /** The global sparse headers, this is only used in PAX Format 0.X. */
     private final List<TarArchiveStructSparse> globalSparseHeaders = new ArrayList<>();
 
     private final boolean lenient;
-
-    private int paxHeaderDepth;
 
     /**
      * Constructs a new instance.
@@ -374,7 +370,10 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      *
      * @return The next entry in the archive as long name data, or null.
      * @throws IOException on error
+     *
+     * @deprecated Since 1.29.0 without replacement.
      */
+    @Deprecated
     protected byte[] getLongNameData() throws IOException {
         // read in the name
         final ByteArrayOutputStream longName = new ByteArrayOutputStream();
@@ -401,14 +400,81 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
     }
 
     /**
-     * Gets the next TarArchiveEntry in this stream.
+     * Advances to the next file entry in the tar archive.
+     * <p>
+     *     Skips any remaining data in the current entry, then reads and returns the next file entry.
+     *     Handles special records (PAX, GNU long name, sparse, etc.) and applies PAX headers as needed.
+     * </p>
      *
-     * @return the next entry, or {@code null} if there are no more entries
-     * @throws IOException if the next entry could not be read
+     * @return the next file entry, or {@code null} if there are no more entries
+     * @throws IOException if the next entry could not be read or the archive is malformed
      */
     @Override
     public TarArchiveEntry getNextEntry() throws IOException {
-        return getNextTarEntry();
+        if (isAtEOF()) {
+            return null;
+        }
+        final Map<String, String> paxHeaders = new HashMap<>();
+        final List<TarArchiveStructSparse> sparseHeaders = new ArrayList<>();
+        int specialRecordCount = 0;
+
+        while (true) {
+            // If there is a current entry, skip any unread data and padding
+            if (currEntry != null) {
+                IOUtils.skip(this, Long.MAX_VALUE); // Skip to end of current entry
+                skipRecordPadding(); // Skip padding to align to the next record
+            }
+
+            // Read the next header record
+            final byte[] headerBuf = getRecord();
+            if (headerBuf == null) {
+                // If we encountered special records but no file entry, the archive is malformed
+                if (specialRecordCount > 0) {
+                    throw new ArchiveException(
+                            "Premature end of tar archive. Didn't find any file entry after GNU or PAX record.");
+                }
+                currEntry = null;
+                return null; // End of archive
+            }
+
+            // Parse the header into a new entry
+            currEntry = new TarArchiveEntry(globalPaxHeaders, headerBuf, zipEncoding, lenient);
+            entryOffset = 0;
+            entrySize = currEntry.getSize();
+
+            if (TarUtils.isSpecialTarRecord(currEntry)) {
+                // Handle PAX, GNU long name, or other special records
+                TarUtils.handleSpecialTarRecord(
+                        this, zipEncoding, currEntry, paxHeaders, sparseHeaders, globalPaxHeaders, globalSparseHeaders);
+                specialRecordCount++;
+                continue; // Continue to next header, as this is not a file entry
+            }
+
+            // Apply global and local PAX headers
+            TarUtils.applyPaxHeadersToEntry(
+                    currEntry, paxHeaders, sparseHeaders, globalPaxHeaders, globalSparseHeaders);
+
+            // Handle sparse files
+            if (currEntry.isSparse()) {
+                if (currEntry.isOldGNUSparse()) {
+                    readOldGNUSparse();
+                } else if (currEntry.isPaxGNU1XSparse()) {
+                    currEntry.setSparseHeaders(TarUtils.parsePAX1XSparseHeaders(in, getRecordSize()));
+                }
+                // sparse headers are all done reading, we need to build
+                // sparse input streams using these sparse headers
+                buildSparseInputStreams();
+            }
+
+            // Ensure directory names end with a slash
+            if (currEntry.isDirectory() && !currEntry.getName().endsWith("/")) {
+                currEntry.setName(currEntry.getName() + "/");
+            }
+
+            // Update entry size in case it changed due to PAX headers
+            entrySize = currEntry.getSize();
+            return currEntry;
+        }
     }
 
     /**
@@ -422,72 +488,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      */
     @Deprecated
     public TarArchiveEntry getNextTarEntry() throws IOException {
-        if (isAtEOF()) {
-            return null;
-        }
-        if (currEntry != null) {
-            /* Skip will only go to the end of the current entry */
-            IOUtils.skip(this, Long.MAX_VALUE);
-            /* skip to the end of the last record */
-            skipRecordPadding();
-        }
-        final byte[] headerBuf = getRecord();
-        if (headerBuf == null) {
-            /* hit EOF */
-            currEntry = null;
-            return null;
-        }
-        try {
-            currEntry = new TarArchiveEntry(globalPaxHeaders, headerBuf, zipEncoding, lenient);
-        } catch (final IllegalArgumentException e) {
-            throw new ArchiveException("Error detected parsing the header", (Throwable) e);
-        }
-        entryOffset = 0;
-        entrySize = currEntry.getSize();
-        if (currEntry.isGNULongLinkEntry()) {
-            final byte[] longLinkData = getLongNameData();
-            if (longLinkData == null) {
-                // Bugzilla: 40334
-                // Malformed tar file - long link entry name not followed by entry
-                return null;
-            }
-            currEntry.setLinkName(zipEncoding.decode(longLinkData));
-        }
-        if (currEntry.isGNULongNameEntry()) {
-            final byte[] longNameData = getLongNameData();
-            if (longNameData == null) {
-                // Bugzilla: 40334
-                // Malformed tar file - long entry name not followed by entry
-                return null;
-            }
-            // COMPRESS-509 : the name of directories should end with '/'
-            final String name = zipEncoding.decode(longNameData);
-            currEntry.setName(name);
-            if (currEntry.isDirectory() && !name.endsWith("/")) {
-                currEntry.setName(name + "/");
-            }
-        }
-        if (currEntry.isGlobalPaxHeader()) { // Process Global PAX headers
-            readGlobalPaxHeaders();
-        }
-        try {
-            if (currEntry.isPaxHeader()) { // Process PAX headers
-                paxHeaders();
-            } else if (!globalPaxHeaders.isEmpty()) {
-                applyPaxHeadersToCurrentEntry(globalPaxHeaders, globalSparseHeaders);
-            }
-        } catch (final NumberFormatException e) {
-            throw new ArchiveException("Error detected parsing the pax header", (Throwable) e);
-        }
-        if (currEntry.isOldGNUSparse()) { // Process sparse files
-            readOldGNUSparse();
-        }
-        // If the size of the next element in the archive has changed
-        // due to a new size being reported in the POSIX header
-        // information, we update entrySize here so that it contains
-        // the correct value.
-        entrySize = currEntry.getSize();
-        return currEntry;
+        return getNextEntry();
     }
 
     /**
@@ -564,52 +565,6 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
     }
 
     /**
-     * For PAX Format 0.0, the sparse headers({@code GNU.sparse.offset} and {@code GNU.sparse.numbytes}) may appear multi times, and they look like:
-     *
-     * <pre>
-     * GNU.sparse.size=size GNU.sparse.numblocks=numblocks repeat numblocks times GNU.sparse.offset=offset GNU.sparse.numbytes=numbytes end repeat
-     * </pre>
-     * <p>
-     * For PAX Format 0.1, the sparse headers are stored in a single variable: {@code GNU.sparse.map}
-     * </p>
-     * <p>
-     * {@code GNU.sparse.map} is a map of non-null data chunks. It is a string consisting of comma-separated values {@code "offset,size[,offset-1,size-1...]"}
-     * </p>
-     * <p>
-     * For PAX Format 1.X: The sparse map itself is stored in the file data block, preceding the actual file data. It consists of a series of decimal numbers
-     * delimited by newlines. The map is padded with nulls to the nearest block boundary. The first number gives the number of entries in the map. Following are
-     * map entries, each one consisting of two numbers giving the offset and size of the data block it describes.
-     * </p>
-     *
-     * @throws IOException if an I/O error occurs.
-     */
-    private void paxHeaders() throws IOException {
-        if (paxHeaderDepth++ > MAX_PAX_HEADER_DEPTH) {
-            // TODO Consider not using recursion.
-            throw new ArchiveException("paxHeaderDepth = %,d", paxHeaderDepth);
-        }
-        List<TarArchiveStructSparse> sparseHeaders = new ArrayList<>();
-        final Map<String, String> headers = TarUtils.parsePaxHeaders(this, sparseHeaders, globalPaxHeaders, entrySize);
-        // for 0.1 PAX Headers
-        if (headers.containsKey(TarGnuSparseKeys.MAP)) {
-            sparseHeaders = new ArrayList<>(TarUtils.parseFromPAX01SparseHeaders(headers.get(TarGnuSparseKeys.MAP)));
-        }
-        getNextEntry(); // Get the actual file entry
-        if (currEntry == null) {
-            throw new ArchiveException("Premature end of tar archive. Didn't find any entry after PAX header.");
-        }
-        applyPaxHeadersToCurrentEntry(headers, sparseHeaders);
-        // for 1.0 PAX Format, the sparse map is stored in the file data block
-        if (currEntry.isPaxGNU1XSparse()) {
-            sparseHeaders = TarUtils.parsePAX1XSparseHeaders(in, getRecordSize());
-            currEntry.setSparseHeaders(sparseHeaders);
-        }
-        // sparse headers are all done reading, we need to build
-        // sparse input streams using these sparse headers
-        buildSparseInputStreams();
-    }
-
-    /**
      * Reads bytes from the current tar archive entry.
      * <p>
      * This method is aware of the boundaries of the current entry in the archive and will deal with them as if they were this stream's start and EOF.
@@ -653,14 +608,6 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
             entryOffset += totalRead;
         }
         return totalRead;
-    }
-
-    private void readGlobalPaxHeaders() throws IOException {
-        globalPaxHeaders = TarUtils.parsePaxHeaders(this, globalSparseHeaders, globalPaxHeaders, entrySize);
-        getNextEntry(); // Get the actual file entry
-        if (currEntry == null) {
-            throw new ArchiveException("Error detected parsing the pax header");
-        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -831,8 +831,131 @@ public class TarUtils {
         return storedSum == unsignedSum || storedSum == signedSum;
     }
 
-    /** Prevents instantiation. */
-    private TarUtils() {
+    /**
+     * Determines if the given tar entry is a special tar record.
+     * <p>
+     *     Special tar records are used to store metadata such as long file names, long link names, or PAX headers
+     *     that apply to the entire archive or to the next file entry.
+     * </p>
+     *
+     * @param entry the tar record to check
+     * @return {@code true} if the entry is a special tar record, {@code false} otherwise
+     */
+    static boolean isSpecialTarRecord(final TarArchiveEntry entry) {
+        return entry.isGNULongLinkEntry()
+                || entry.isGNULongNameEntry()
+                || entry.isGlobalPaxHeader()
+                || entry.isPaxHeader();
     }
 
+    /**
+     * Processes a special tar record and updates the provided PAX global and per entry headers.
+     * <p>
+     *     This method reads the content of the special entry from the input stream and updates the relevant metadata structures.
+     * </p>
+     * <p>
+     *     GNU long file and link names are translated to their equivalent PAX headers.
+     * </p>
+     *
+     * @param input the input stream from which to read the special tar entry content
+     * @param encoding the encoding to use for reading names
+     * @param entry the tar entry to handle
+     * @param paxHeaders the map to update with PAX headers
+     * @param sparseHeaders the list to update with sparse headers
+     * @param globalPaxHeaders the map to update with global PAX headers
+     * @param globalSparseHeaders the list to update with global sparse headers
+     * @throws IOException if an I/O error occurs while reading the entry
+     */
+    static void handleSpecialTarRecord(
+            final InputStream input,
+            final ZipEncoding encoding,
+            final TarArchiveEntry entry,
+            final Map<String, String> paxHeaders,
+            final List<TarArchiveStructSparse> sparseHeaders,
+            final Map<String, String> globalPaxHeaders,
+            final List<TarArchiveStructSparse> globalSparseHeaders)
+            throws IOException {
+        if (entry.isGNULongLinkEntry()) {
+            // GNU long link entry: read and store the link path
+            final String longLinkName = readLongName(input, encoding, entry);
+            paxHeaders.put("linkpath", longLinkName);
+        } else if (entry.isGNULongNameEntry()) {
+            // GNU long name entry: read and store the file path
+            final String longName = readLongName(input, encoding, entry);
+            paxHeaders.put("path", longName);
+        } else if (entry.isGlobalPaxHeader()) {
+            // Global PAX header: clear and update global PAX and sparse headers
+            globalSparseHeaders.clear();
+            globalPaxHeaders.clear();
+            globalPaxHeaders.putAll(parsePaxHeaders(input, globalSparseHeaders, globalPaxHeaders, entry.getSize()));
+        } else if (entry.isPaxHeader()) {
+            // PAX header: clear and update local PAX and sparse headers, parse GNU sparse headers if present
+            sparseHeaders.clear();
+            paxHeaders.clear();
+            paxHeaders.putAll(parsePaxHeaders(input, sparseHeaders, globalPaxHeaders, entry.getSize()));
+            if (paxHeaders.containsKey(TarGnuSparseKeys.MAP)) {
+                sparseHeaders.addAll(parseFromPAX01SparseHeaders(paxHeaders.get(TarGnuSparseKeys.MAP)));
+            }
+        }
+    }
+
+    /**
+     * Applies the PAX headers and sparse headers to the given tar entry.
+     *
+     * @param entry the tar entry to handle
+     * @param paxHeaders per file PAX headers
+     * @param sparseHeaders per file sparse headers
+     * @param globalPaxHeaders global PAX headers
+     * @param globalSparseHeaders global sparse headers
+     * @throws IOException if an I/O error occurs while reading the entry
+     */
+    static void applyPaxHeadersToEntry(
+            final TarArchiveEntry entry,
+            final Map<String, String> paxHeaders,
+            final List<TarArchiveStructSparse> sparseHeaders,
+            final Map<String, String> globalPaxHeaders,
+            final List<TarArchiveStructSparse> globalSparseHeaders) throws IOException {
+        // Apply PAX headers to the entry
+        entry.updateEntryFromPaxHeaders(globalPaxHeaders);
+        entry.updateEntryFromPaxHeaders(paxHeaders);
+        // Apply sparse headers to the entry, unless it is a pre-pax GNU sparse entry
+        if (!entry.isOldGNUSparse()) {
+            entry.setSparseHeaders(globalSparseHeaders);
+            if (!sparseHeaders.isEmpty()) {
+                // If there are local sparse headers, they override the global ones
+                entry.setSparseHeaders(sparseHeaders);
+            }
+        }
+    }
+
+    /**
+     * Reads a long name (file or link name) from the input stream for a special tar record.
+     *
+     * @param input the input stream from which to read the long name
+     * @param encoding the encoding to use for reading the name
+     * @param entry the tar entry containing the long name
+     * @return the decoded long name, with trailing NULs removed
+     * @throws IOException if an I/O error occurs or the entry is truncated
+     * @throws ArchiveException if the entry size is invalid
+     */
+    private static String readLongName(final InputStream input, final ZipEncoding encoding, final TarArchiveEntry entry)
+            throws IOException {
+        final long size = entry.getSize();
+        if (size < 0 || size > Integer.MAX_VALUE) {
+            throw new ArchiveException("Invalid long name size: " + entry.getSize());
+        }
+        final int sizeInt = (int) size;
+        final byte[] buffer = new byte[sizeInt];
+        if (IOUtils.readFully(input, buffer, 0, sizeInt) < buffer.length) {
+            throw new ArchiveException("TAR entry is truncated.");
+        }
+        int length = buffer.length;
+        while (length > 0 && buffer[length - 1] == 0) {
+            length--;
+        }
+        return encoding.decode(Arrays.copyOf(buffer, length));
+    }
+
+    /** Prevents instantiation. */
+    private TarUtils() {}
 }


### PR DESCRIPTION
This refactor unifies and streamlines how `TarFile` and `TarArchiveInputStream` process special archive members, ensuring consistent interpretation across both APIs.

**Key changes:**

* Extracted the shared logic for interpreting GNU long name/long link records and POSIX/PAX extended headers into `TarUtils`.
* Added translation of legacy GNU long name/long link records into equivalent PAX extended header records for a unified internal representation.
* Kept `TarArchiveInputStream.getLongNameData` for backward compatibility (it is `protected`), but **deprecates** it.

**Benefits:**

* Single point of maintenance for special record parsing.
* Consistent behavior between streaming and file-based tar readers.
* Simplifies adding support for new record types or extensions in the future.

This change does **not** introduce new functionality, so the existing unit test suite should be sufficient to validate correctness. If any coverage gaps are identified during review or CI runs, I will add targeted test cases to address the uncovered scenarios.

Before you push a pull request, review this list:

- [x] I used AI to proofread the changes.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
