### PR TITLE
Simplify `ArArchiveInputStream` special record handling

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,7 @@ The <action> type attribute can be add,update,fix,remove.
       <!-- FIX ar -->      
       <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.compress.archivers.ar.ArArchiveInputStream.readGNUStringTable(byte[], int, int) now provides a better exception message, wrapping the underlying exception.</action>
       <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.compress.archivers.ar.ArArchiveInputStream.read(byte[], int, int) now throws ArchiveException instead of ArithmeticException.</action>
+      <action type="fix" dev="pkarwasz" due-to="Tyler Nighswander">Simplify handling of special ar records in ArArchiveInputStream.</action>
       <!-- FIX unpack200 -->      
       <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.compress.harmony.unpack200 now throws Pack200Exception, IllegalArgumentException, and IllegalStateException instead of Error.</action>
       <!-- FIX pack200 -->      

--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveEntry.java
@@ -20,6 +20,7 @@ package org.apache.commons.compress.archivers.ar;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -60,6 +61,8 @@ public class ArArchiveEntry implements ArchiveEntry {
 
     /** The header for each entry */
     public static final String HEADER = "!<arch>\n";
+
+    static final byte[] HEADER_BYTES = HEADER.getBytes(StandardCharsets.US_ASCII);
 
     /** The trailer for each entry {@code 0x60 0x0A} */
     public static final String TRAILER = "`\012";

--- a/src/test/java/org/apache/commons/compress/archivers/ArTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ArTest.java
@@ -181,7 +181,7 @@ public final class ArTest extends AbstractTest {
         //
         final ArArchiveEntry out;
         try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
-            out = ais.getNextArEntry();
+            out = ais.getNextEntry();
         }
         assertNotNull(out);
         assertEquals("foo", out.getName());
@@ -202,7 +202,7 @@ public final class ArTest extends AbstractTest {
         }
         final ArArchiveEntry out;
         try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
-            out = ais.getNextArEntry();
+            out = ais.getNextEntry();
         }
         assertNotNull(out);
         assertEquals("foo", out.getName());
@@ -224,7 +224,7 @@ public final class ArTest extends AbstractTest {
         }
         final ArArchiveEntry out;
         try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
-            out = ais.getNextArEntry();
+            out = ais.getNextEntry();
         }
         assertNotNull(out);
         assertEquals("foo", out.getName());
@@ -249,7 +249,7 @@ public final class ArTest extends AbstractTest {
         }
         final ArArchiveEntry out;
         try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
-            out = ais.getNextArEntry();
+            out = ais.getNextEntry();
         }
         assertNotNull(out);
         assertEquals("foo/", out.getName());
@@ -274,7 +274,7 @@ public final class ArTest extends AbstractTest {
         }
         final ArArchiveEntry out;
         try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
-            out = ais.getNextArEntry();
+            out = ais.getNextEntry();
         }
         assertNotNull(out);
         assertEquals("foo/", out.getName());

--- a/src/test/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStreamTest.java
@@ -201,14 +201,14 @@ class ArArchiveInputStreamTest extends AbstractTest {
                     }
                 }) {
             try (ArArchiveInputStream archiveInputStream = new ArArchiveInputStream(simpleInputStream)) {
-                final ArArchiveEntry entry1 = archiveInputStream.getNextArEntry();
+                final ArArchiveEntry entry1 = archiveInputStream.getNextEntry();
                 assertNotNull(entry1);
                 assertEquals("test1.xml", entry1.getName());
                 assertEquals(610L, entry1.getLength());
-                final ArArchiveEntry entry2 = archiveInputStream.getNextArEntry();
+                final ArArchiveEntry entry2 = archiveInputStream.getNextEntry();
                 assertEquals("test2.xml", entry2.getName());
                 assertEquals(82L, entry2.getLength());
-                assertNull(archiveInputStream.getNextArEntry());
+                assertNull(archiveInputStream.getNextEntry());
             }
         }
     }


### PR DESCRIPTION
Refactors `ArArchiveInputStream.getNextEntry()` to follow the same structural approach as TarArchiveInputStream.getNextEntry()`, improving consistency and maintainability.

**Key changes:**

* Unifies parsing of the GNU string table with the pattern used for TAR special records.
* Replaces the _ad-hoc_ byte counter with the inherited `count()` method for more accurate and readable tracking.
* Adds a sanity check: throws an exception if a regular file entry does not follow a special AR member (GNU string table).v
* Consistently throws `EOFException` in case of truncated content.
* Improves consistency of error messages.

- [x] I used AI to proofread the pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
