### PR TITLE
feat: Align DUMP archive block size with Linux `dump` utility

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -61,7 +61,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="ggregory" due-to="Tyler Nighswander, Gary Gregory">org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream constructors now throws CompressorException instead of ArrayIndexOutOfBoundsException.</action>
       <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream throws CompressorException (an IOException subclass) instead of IOException when it encounters formatting problems.</action>
       <!-- FIX dump -->      
-      <action type="fix" dev="ggregory" due-to="Tyler Nighswander, Gary Gregory">org.apache.commons.compress.archivers.dump.TapeInputStream.resetBlockSize(int, boolean) now throws a MemoryLimitException (an IOException subclass) instead of an OutOfMemoryError.</action>
+      <action type="fix" dev="pkarwasz" due-to="Tyler Nighswander">Align DUMP archive block size with Linux `dump` utility.</action>
       <action type="fix" dev="ggregory" due-to="Tyler Nighswander, Gary Gregory">org.apache.commons.compress.archivers.dump.DumpArchiveInputStream.getNextEntry() throws an ArchiveException instead of ArrayIndexOutOfBoundsException.</action>
       <!-- FIX zip -->      
       <action type="fix" dev="ggregory" due-to="Dominik Stadler, Gary Gregory" issue="COMPRESS-598">org.apache.commons.compress.archivers.zip.ZipArchiveInputStream.read(byte[], int, int) now throws an IOException instead of a NullPointerException.</action>

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveConstants.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveConstants.java
@@ -135,14 +135,31 @@ public final class DumpArchiveConstants {
     public static final int TP_SIZE = 1024;
 
     /**
-     * NTREC value {@value}.
+     * Minimum number of kilobytes per record: {@value}.
+     */
+    public static final int MIN_NTREC = 1;
+
+    /**
+     * Default number of kilobytes per record: {@value}.
      */
     public static final int NTREC = 10;
 
     /**
-     * HIGH_DENSITY_NTREC value {@value}.
+     * Number of kilobytes per record for high density tapes: {@value}.
      */
     public static final int HIGH_DENSITY_NTREC = 32;
+
+    /**
+     * Maximum number of kilobytes per record: {@value}.
+     * <p>
+     *     This limit matches the one used by the Linux ext2/3/4 dump/restore utilities.
+     *     For more details, see the
+     *     <a href="https://dump.sourceforge.io/">Linux dump/restore utilities documentation</a>
+     *     and the
+     *     <a href="https://manpages.debian.org/unstable/dump/dump.8.en.html#b,">dump(8) man page</a>.
+     * </p>
+     */
+    public static final int MAX_NTREC = 1024;
 
     /**
      * OFS_MAGIC value {@value}.

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveEntry.java
@@ -952,18 +952,4 @@ public class DumpArchiveEntry implements ArchiveEntry {
         return getName();
     }
 
-    /**
-     * Update entry with information from next tape segment header.
-     */
-    void update(final byte[] buffer) {
-        header.volume = DumpArchiveUtil.convert32(buffer, 16);
-        header.count = DumpArchiveUtil.convert32(buffer, 160);
-        header.holes = 0;
-        for (int i = 0; i < 512 && i < header.count; i++) {
-            if (buffer[164 + i] == 0) {
-                header.holes++;
-            }
-        }
-        System.arraycopy(buffer, 164, header.cdata, 0, 512);
-    }
 }

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveSummary.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveSummary.java
@@ -150,8 +150,11 @@ public class DumpArchiveSummary {
     }
 
     /**
-     * Gets the number of records per tape block. This is typically between 10 and 32.
-     *
+     * Gets the number of records per tape block.
+     * <p>
+     *     This is typically either {@value DumpArchiveConstants#NTREC} (for standard density tapes) or
+     *     {@value DumpArchiveConstants#HIGH_DENSITY_NTREC} (for high density tapes).
+     * </p>
      * @return the number of records per tape block
      */
     public int getNTRec() {

--- a/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveTestFactory.java
+++ b/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveTestFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers.dump;
+
+import org.apache.commons.compress.utils.ByteUtils;
+
+final class DumpArchiveTestFactory {
+    private static final int MAGIC_OFFSET = 24;
+    private static final int CHECKSUM_OFFSET = 28;
+    private static final int NTREC_OFFSET = 896;
+    private static final int SEGMENT_TYPE_OFFSET = 0;
+
+    static byte[] createSummary(final int ntrec) {
+        final byte[] buffer = new byte[DumpArchiveConstants.TP_SIZE];
+        // magic
+        convert32(DumpArchiveConstants.NFS_MAGIC, buffer, MAGIC_OFFSET);
+        // ntrec
+        convert32(ntrec, buffer, NTREC_OFFSET);
+        // checksum
+        final int checksum = DumpArchiveUtil.calculateChecksum(buffer);
+        convert32(checksum, buffer, CHECKSUM_OFFSET);
+        return buffer;
+    }
+
+    static byte[] createSegment(final DumpArchiveConstants.SEGMENT_TYPE segmentType) {
+        final byte[] buffer = new byte[DumpArchiveConstants.TP_SIZE];
+        // magic
+        convert32(DumpArchiveConstants.NFS_MAGIC, buffer, MAGIC_OFFSET);
+        // type
+        ByteUtils.toLittleEndian(buffer, segmentType.code, SEGMENT_TYPE_OFFSET, 2);
+        // checksum
+        final int checksum = DumpArchiveUtil.calculateChecksum(buffer);
+        convert32(checksum, buffer, CHECKSUM_OFFSET);
+        return buffer;
+    }
+
+    private static void convert32(final long value, final byte[] buffer, final int offset) {
+        ByteUtils.toLittleEndian(buffer, value, offset, 4);
+    }
+
+    private DumpArchiveTestFactory() {
+        // prevent instantiation
+    }
+}


### PR DESCRIPTION
This update standardizes the block size limit in `DumpArchiveInputStream` to match the value used by the Linux `dump` utility for ext2/3/4 filesystems.

By using the same limit as the reference implementation, we ensure consistent parsing behavior and improve compatibility with archives generated by standard `dump` tools.

- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to: proofread comments
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
