### PR TITLE
fix: Restore incremental file name handling

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -890,7 +890,7 @@ public class TarUtils {
         final long size = entry.getSize();
         // The encoding requires a byte array, whose size must be a positive int.
         if (size > Integer.MAX_VALUE) {
-            throw new ArchiveException("Invalid long name entry: size %d exceeds maximum allowed.", entry.getSize());
+            throw new ArchiveException("Invalid long name entry: size %,d exceeds maximum allowed.", entry.getSize());
         }
         // Read the long name incrementally to limit memory allocation in case of a corrupted entry.
         final BoundedInputStream boundedInput = BoundedInputStream.builder()
@@ -903,7 +903,7 @@ public class TarUtils {
                 .get();
         final long read = org.apache.commons.io.IOUtils.copyLarge(boundedInput, outputStream);
         if (read != size) {
-            throw new ArchiveException("Truncated long name entry: expected %d bytes, read %d bytes.", size, read);
+            throw new ArchiveException("Truncated long name entry: expected %,d bytes, read %,d bytes.", size, read);
         }
         final byte[] name = outputStream.toByteArray();
         int length = name.length;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -898,9 +898,7 @@ public class TarUtils {
                 .setMaxCount(size)
                 .setPropagateClose(false)
                 .get();
-        final UnsynchronizedByteArrayOutputStream outputStream = UnsynchronizedByteArrayOutputStream.builder()
-                .setBufferSize(org.apache.commons.io.IOUtils.DEFAULT_BUFFER_SIZE)
-                .get();
+        final UnsynchronizedByteArrayOutputStream outputStream = UnsynchronizedByteArrayOutputStream.builder().get();
         final long read = org.apache.commons.io.IOUtils.copyLarge(boundedInput, outputStream);
         if (read != size) {
             throw new ArchiveException("Truncated long name entry: expected %,d bytes, read %,d bytes.", size, read);

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -38,7 +38,9 @@ import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
 import org.apache.commons.compress.utils.ArchiveUtils;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.utils.ParsingUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 
 /**
  * This class provides static utility methods to work with byte streams.
@@ -883,22 +885,32 @@ public class TarUtils {
      * @throws IOException if an I/O error occurs or the entry is truncated.
      * @throws ArchiveException if the entry size is invalid.
      */
-    private static String readLongName(final InputStream input, final ZipEncoding encoding, final TarArchiveEntry entry)
+    static String readLongName(final InputStream input, final ZipEncoding encoding, final TarArchiveEntry entry)
             throws IOException {
         final long size = entry.getSize();
+        // The encoding requires a byte array, whose size must be a positive int.
         if (size > Integer.MAX_VALUE) {
-            throw new ArchiveException("Invalid long name size: " + entry.getSize());
+            throw new ArchiveException("Invalid long name size: %d.", entry.getSize());
         }
-        final int sizeInt = (int) size;
-        final byte[] buffer = new byte[sizeInt];
-        if (IOUtils.readFully(input, buffer, 0, sizeInt) < sizeInt) {
-            throw new ArchiveException("TAR entry is truncated.");
+        // Read the long name incrementally to limit memory allocation in case of a corrupted entry.
+        final BoundedInputStream boundedInput = BoundedInputStream.builder()
+                .setInputStream(input)
+                .setMaxCount(size)
+                .setPropagateClose(false)
+                .get();
+        final UnsynchronizedByteArrayOutputStream outputStream = UnsynchronizedByteArrayOutputStream.builder()
+                .setBufferSize(org.apache.commons.io.IOUtils.DEFAULT_BUFFER_SIZE)
+                .get();
+        final long read = org.apache.commons.io.IOUtils.copyLarge(boundedInput, outputStream);
+        if (read != size) {
+            throw new ArchiveException("Truncated long name entry: Expected %d bytes, read %d bytes.", size, read);
         }
-        int length = buffer.length;
-        while (length > 0 && buffer[length - 1] == 0) {
+        final byte[] name = outputStream.toByteArray();
+        int length = name.length;
+        while (length > 0 && name[length - 1] == 0) {
             length--;
         }
-        return encoding.decode(Arrays.copyOf(buffer, length));
+        return encoding.decode(Arrays.copyOf(name, length));
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -890,7 +890,7 @@ public class TarUtils {
         final long size = entry.getSize();
         // The encoding requires a byte array, whose size must be a positive int.
         if (size > Integer.MAX_VALUE) {
-            throw new ArchiveException("Invalid long name size: %d.", entry.getSize());
+            throw new ArchiveException("Invalid long name entry: size %d exceeds maximum allowed.", entry.getSize());
         }
         // Read the long name incrementally to limit memory allocation in case of a corrupted entry.
         final BoundedInputStream boundedInput = BoundedInputStream.builder()
@@ -903,7 +903,7 @@ public class TarUtils {
                 .get();
         final long read = org.apache.commons.io.IOUtils.copyLarge(boundedInput, outputStream);
         if (read != size) {
-            throw new ArchiveException("Truncated long name entry: Expected %d bytes, read %d bytes.", size, read);
+            throw new ArchiveException("Truncated long name entry: expected %d bytes, read %d bytes.", size, read);
         }
         final byte[] name = outputStream.toByteArray();
         int length = name.length;

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -720,7 +720,7 @@ class TarUtilsTest extends AbstractTest {
                     actualMessage.contains(expectedMessage),
                     () -> "Expected exception message to contain '" + expectedMessage + "', but got: " + actualMessage);
             assertTrue(
-                    actualMessage.contains(Long.toString(size)),
+                    actualMessage.contains(String.format("%,d", size)),
                     () -> "Expected exception message to mention '" + size + "', but got: " + actualMessage);
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -667,7 +667,7 @@ class TarUtilsTest extends AbstractTest {
         return Arrays.copyOf(bytes, ((bytes.length + blockSize - 1) / blockSize) * blockSize);
     }
 
-    static Stream<Arguments> readLongNameHandlesLimits() {
+    static Stream<Arguments> testReadLongNameHandlesLimits() {
         final String empty = "";
         final String ntfsLongName = createNtfsLongNameByUtf16Units(32767);
         final String posixLongName = createPosixLongNameByUtf8Bytes(4095);
@@ -682,7 +682,7 @@ class TarUtilsTest extends AbstractTest {
 
     @ParameterizedTest(name = "{0} long name is read correctly")
     @MethodSource
-    void readLongNameHandlesLimits(final String kind, final String expectedName, final byte[] data) throws IOException {
+    void testReadLongNameHandlesLimits(final String kind, final String expectedName, final byte[] data) throws IOException {
         final TarArchiveEntry entry = new TarArchiveEntry("test");
         entry.setSize(data.length);
         // Lets add a trailing "garbage" to ensure we only read what we should
@@ -698,7 +698,7 @@ class TarUtilsTest extends AbstractTest {
         }
     }
 
-    static Stream<Arguments> readLongNameThrowsOnTruncation() {
+    static Stream<Arguments> testReadLongNameThrowsOnTruncation() {
         return Stream.of(
                 Arguments.of(Integer.MAX_VALUE, "truncated long name"),
                 Arguments.of(Long.MAX_VALUE, "invalid long name"));
@@ -706,14 +706,14 @@ class TarUtilsTest extends AbstractTest {
 
     @ParameterizedTest(name = "readLongName of {0} bytes throws ArchiveException")
     @MethodSource
-    void readLongNameThrowsOnTruncation(final long size, final CharSequence expectedMessage) throws IOException {
+    void testReadLongNameThrowsOnTruncation(final long size, final CharSequence expectedMessage) throws IOException {
         final TarArchiveEntry entry = new TarArchiveEntry("test");
         entry.setSize(size); // absurdly large so any finite stream truncates
         try (InputStream in = new NullInputStream()) {
             final ArchiveException ex = assertThrows(
                     ArchiveException.class,
                     () -> TarUtils.readLongName(in, TarUtils.DEFAULT_ENCODING, entry),
-                    "Expected ArchiveExcepti" + "on due to truncated long name, but no exception was thrown");
+                    "Expected ArchiveException due to truncated long name, but no exception was thrown");
             final String actualMessage = StringUtils.toRootLowerCase(ex.getMessage());
             assertNotNull(actualMessage, "Exception message should not be null");
             assertTrue(

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -615,12 +615,11 @@ class TarUtilsTest extends AbstractTest {
         final String extension = ".txt";
 
         // U+2605 BLACK STAR (BMP, 1 UTF-16 unit, 3 UTF-8 bytes) => lets us pack 255 units per segment easily
-        final String segment = StringUtils.repeat("★", 255);
-        assertEquals(255, segment.length(), "Segment length should be 255 UTF-16 code units");
+        final String segment = StringUtils.repeat("★", 255) + '\\';
 
         final StringBuilder sb = new StringBuilder(prefix);
         while (sb.length() + extension.length() < totalUnits) {
-            sb.append(segment).append('\\');
+            sb.append(segment);
         }
 
         // Trim to exact totalUnits (UTF-16 units), then append extension
@@ -636,13 +635,13 @@ class TarUtilsTest extends AbstractTest {
     private static String createPosixLongNameByUtf8Bytes(final int totalBytes) {
         final String extension = ".txt";
         // U+2605 BLACK STAR (BMP, 1 UTF-16 unit, 3 UTF-8 bytes) => 85 * 3 UTF-8 bytes = 255 bytes
-        final String segment = StringUtils.repeat("★", 85);
-        assertEquals(255, utf8Len(segment), "Segment length should be 255 bytes in UTF-8");
+        final String segment = StringUtils.repeat("★", 85) + '/';
+        assertEquals(256, utf8Len(segment), "Segment length with separator should be 256 bytes in UTF-8");
 
         final StringBuilder sb = new StringBuilder();
         int count = totalBytes / 256; // how many full 256-byte chunks can we fit?
         while (count-- > 0) {
-            sb.append(segment).append('/');
+            sb.append(segment);
         }
         count = totalBytes - utf8Len(sb) - utf8Len(extension);
         while (count-- > 0) {


### PR DESCRIPTION
The refactoring in #684 (never released) inadvertently dropped a critical part of long file name handling: names must be read incrementally to prevent excessive memory allocation if an entry is corrupted.

This change restores the previous safe behavior and adds two unit tests to ensure:

* POSIX and NTFS file names up to the maximum allowed length are handled correctly.
* Corrupted entries are detected and throw an `ArchiveException`.

Before you push a pull request, review this list:

- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to improve the unit tests.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
