### PR TITLE
feat: enforce 20-bit Huffman code-length limit consistently

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -58,7 +58,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="ggregory" due-to="Gary Gregory">Don't loose precision while reading folders from a SevenZFile.</action>
       <action type="fix" dev="ggregory" due-to="Roel van Dijk, Gary Gregory">Improve some exception messages in TarUtils and TarArchiveEntry.</action>
       <!-- FIX bzip2 -->      
-      <action type="fix" dev="ggregory" due-to="Tyler Nighswander, Gary Gregory">org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream constructors now throws CompressorException instead of ArrayIndexOutOfBoundsException.</action>
+      <action type="fix" dev="pkarwasz" due-to="Tyler Nighswander, Piotr P. Karwasz, Gary Gregory">Enforce 20-bit Huffman code-length limit consistently in BZip2.</action>
       <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream throws CompressorException (an IOException subclass) instead of IOException when it encounters formatting problems.</action>
       <!-- FIX dump -->      
       <action type="fix" dev="pkarwasz" due-to="Tyler Nighswander">Align DUMP archive block size with Linux `dump` utility.</action>

--- a/src/main/java/org/apache/commons/compress/compressors/bzip2/BZip2Constants.java
+++ b/src/main/java/org/apache/commons/compress/compressors/bzip2/BZip2Constants.java
@@ -35,9 +35,19 @@ interface BZip2Constants {
     int MAX_ALPHA_SIZE = 258;
 
     /**
-     * Constant {@value}.
+     * Maximum allowed length of a Huffman code in BZip2.
+     * <p>
+     *     In the original bzip2 C implementation, a defensive limit of 23 is set to prevent buffer overflows
+     *     (see <a href="https://github.com/libarchive/bzip2/blob/master/bzlib_private.h">{@code bzip_private.h}</a>).
+     *     However, the actual enforced maximum during decompression is 20
+     *     (see <a href="https://github.com/libarchive/bzip2/blob/master/decompress.c">BZ2_decompress in {@code decompress.c}</a>),
+     *     and since version 1.0.6, compression uses a maximum of 17.
+     * </p>
+     * <p>
+     *     The Java implementation does not require the higher defensive limit, so this constant is set to the true maximum of 20.
+     * </p>
      */
-    int MAX_CODE_LEN = 23;
+    int MAX_CODE_LEN = 20;
 
     /**
      * Constant {@value}.


### PR DESCRIPTION
This PR improves `BZip2CompressorInputStream` by enforcing the mandated Huffman code-length bound and right-sizing related tables. It aligns behavior with the reference C implementation’s intent while avoiding its historical over-allocation.

## Why

The reference C code deliberately **over-sizes** its Huffman structures as a defensive programming technique: e.g., it defines `BZ_MAX_CODE_LEN = 23` and sizes length-indexed tables by `BZ_MAX_ALPHA_SIZE` rather than the code-length bound to provide safety margins. However, the bzip2 bitstream only permits code lengths ≤ 20 (and the 1.0.6 implementation effectively tightens this to 17), so carrying those defensive constants forward in our code obscures the true limit and keeps arrays larger than necessary.

## What’s changed

* **Set the true limit**: `MAX_CODE_LEN` now equals **20** (the format maximum).

* **Validate inputs**: code lengths are checked explicitly; any value **outside `[1, 20]`** triggers a clear exception early in decoding.

* **Right-size arrays**: Huffman tables and auxiliary arrays are sized to the minimum required for the 20-bit limit, reducing footprint and clarifying invariants.

* **Tests**: add a unit test that exercises the maximum alphabet size across boundary code lengths.

## Maintenance & performance

* Clearer invariants (the limit you see is the limit you enforce).
* Slightly lower memory usage due to smaller tables.
* Easier reasoning about bounds and indexing during review and future changes.

## References

* [bzip2/huffman.c](https://github.com/libarchive/bzip2/blob/master/huffman.c)
* [bzip2/bzlib_private.h](https://github.com/libarchive/bzip2/blob/master/bzlib_private.h)
 
The reference implementation uses over-sized constants for safety but enforces an effective 20-bit maximum.
