### PR TITLE
[COMPRESS-708] Fix ZstdCompressorInputStream closing underlying stream

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
@@ -24,8 +24,8 @@ import java.io.InputStream;
 
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.utils.InputStreamStatistics;
-import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.commons.io.input.CloseShieldInputStream;
 
 import com.github.luben.zstd.BufferPool;
 import com.github.luben.zstd.ZstdInputStream;
@@ -67,7 +67,7 @@ public class ZstdCompressorInputStream extends CompressorInputStream implements 
      * @throws IOException if an I/O error occurs.
      */
     public ZstdCompressorInputStream(final InputStream in, final BufferPool bufferPool) throws IOException {
-        CloseShieldInputStream closeShieldInputStream = CloseShieldInputStream.wrap(in);
+        final CloseShieldInputStream closeShieldInputStream = CloseShieldInputStream.wrap(in);
         this.decIS = new ZstdInputStream(countingStream = BoundedInputStream.builder().setInputStream(closeShieldInputStream).get(), bufferPool);
     }
 

--- a/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.input.BoundedInputStream;
 
 import com.github.luben.zstd.BufferPool;
 import com.github.luben.zstd.ZstdInputStream;
+import org.apache.commons.io.input.CloseShieldInputStream;
 
 /**
  * {@link CompressorInputStream} implementation to decode Zstandard encoded stream.
@@ -53,7 +54,8 @@ public class ZstdCompressorInputStream extends CompressorInputStream implements 
      * @throws IOException if an I/O error occurs.
      */
     public ZstdCompressorInputStream(final InputStream in) throws IOException {
-        this.decIS = new ZstdInputStream(countingStream = BoundedInputStream.builder().setInputStream(in).get());
+        CloseShieldInputStream closeShieldInputStream = CloseShieldInputStream.wrap(in);
+        this.decIS = new ZstdInputStream(countingStream = BoundedInputStream.builder().setInputStream(closeShieldInputStream).get());
     }
 
     /**
@@ -65,7 +67,8 @@ public class ZstdCompressorInputStream extends CompressorInputStream implements 
      * @throws IOException if an I/O error occurs.
      */
     public ZstdCompressorInputStream(final InputStream in, final BufferPool bufferPool) throws IOException {
-        this.decIS = new ZstdInputStream(countingStream = BoundedInputStream.builder().setInputStream(in).get(), bufferPool);
+        CloseShieldInputStream closeShieldInputStream = CloseShieldInputStream.wrap(in);
+        this.decIS = new ZstdInputStream(countingStream = BoundedInputStream.builder().setInputStream(closeShieldInputStream).get(), bufferPool);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/zstandard/ZstdCompressorInputStream.java
@@ -24,11 +24,11 @@ import java.io.InputStream;
 
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.utils.InputStreamStatistics;
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.io.input.BoundedInputStream;
 
 import com.github.luben.zstd.BufferPool;
 import com.github.luben.zstd.ZstdInputStream;
-import org.apache.commons.io.input.CloseShieldInputStream;
 
 /**
  * {@link CompressorInputStream} implementation to decode Zstandard encoded stream.
@@ -54,7 +54,7 @@ public class ZstdCompressorInputStream extends CompressorInputStream implements 
      * @throws IOException if an I/O error occurs.
      */
     public ZstdCompressorInputStream(final InputStream in) throws IOException {
-        CloseShieldInputStream closeShieldInputStream = CloseShieldInputStream.wrap(in);
+        final CloseShieldInputStream closeShieldInputStream = CloseShieldInputStream.wrap(in);
         this.decIS = new ZstdInputStream(countingStream = BoundedInputStream.builder().setInputStream(closeShieldInputStream).get());
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
@@ -244,9 +244,9 @@ class ZipFileTest extends AbstractTest {
     @Test
     void testZstdInputStreamErrorCloseWhenGc() throws Exception  {
         final File archive = getFile("COMPRESS-692/compress-692.zip");
-        for (int i =0; i< 500;i++) {
+        for (int i = 0; i < 500;i++) {
             try (FileInputStream fileInputStream = new FileInputStream(archive);
-                 ZipArchiveInputStream zipArchiveInputStream = new ZipArchiveInputStream(fileInputStream)){
+                ZipArchiveInputStream zipArchiveInputStream = new ZipArchiveInputStream(fileInputStream)){
                 ArchiveEntry entry;
                 while ((entry = zipArchiveInputStream.getNextEntry()) != null) {
                     if (entry.isDirectory()) {
@@ -256,7 +256,7 @@ class ZipFileTest extends AbstractTest {
                     IOUtils.toByteArray(zipArchiveInputStream);
                 }
             } catch (IOException e) {
-                fail("testZstdInputStreamErrorCloseWhenGc error, test error at batch " + (i+1), e);
+                fail("testZstdInputStreamErrorCloseWhenGc error, test error at batch " + (i + 1), e);
             }
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.FileInputStream;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -244,9 +244,9 @@ class ZipFileTest extends AbstractTest {
     @Test
     void testZstdInputStreamErrorCloseWhenGc() throws Exception  {
         final File archive = getFile("COMPRESS-692/compress-692.zip");
-        for (int i = 0; i < 500;i++) {
+        for (int i = 0; i < 500; i++) {
             try (FileInputStream fileInputStream = new FileInputStream(archive);
-                ZipArchiveInputStream zipArchiveInputStream = new ZipArchiveInputStream(fileInputStream)){
+                ZipArchiveInputStream zipArchiveInputStream = new ZipArchiveInputStream(fileInputStream)) {
                 ArchiveEntry entry;
                 while ((entry = zipArchiveInputStream.getNextEntry()) != null) {
                     if (entry.isDirectory()) {


### PR DESCRIPTION
I fixed the issue where ZstdCompressorInputStream closes the underlying stream.

1. The bug occurred because the ZstdInputStream used in ZstdCompressorInputStream would close the underlying InputStream during GC, which in turn caused errors like "stream closed" for other wrapper streams (such as ZipArchiveInputStream) that depend on this underlying stream.
2.  The principle to fix this bug is to wrap the InputStream passed to ZstdInputStream with CloseShieldInputStream.
3. I wrote the testZstdInputStreamErrorCloseWhenGc method for testing, and in this method, I called System.gc(); to quickly trigger Java's GC to reproduce the bug.