### PR TITLE
feat: Introduce builders for all ArchiveInputStream implementations

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -115,8 +115,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="add" issue="COMPRESS-705" dev="ggregory" due-to="Gary Gregory">Add GzipCompressorInputStream.Builder.setIgnoreExtraField(boolean).</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add SnappyCompressorInputStream.getUncompressedSize() and deprecate getSize().</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add ArchiveInputStream.ArchiveInputStream(InputStream, Charset) as a public constructor, it was private.</action>
-      <action type="add" dev="ggregory" due-to="Gary Gregory">Add TarArchiveInputStream.builder().</action>
-      <action type="add" dev="ggregory" due-to="Gary Gregory">Add TarArchiveInputStream.Builder and deprecate all but one constructor.</action>
+      <action type="add" dev="ggregory" due-to="Gary Gregory, Piotr P. Karwasz">Introduce builders for all ArchiveInputStream implementations.</action>
       <!-- UPDATE -->
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-parent from 85 to 87.</action>
     </release>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -116,7 +116,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="add" issue="COMPRESS-705" dev="ggregory" due-to="Gary Gregory">Add GzipCompressorInputStream.Builder.setIgnoreExtraField(boolean).</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add SnappyCompressorInputStream.getUncompressedSize() and deprecate getSize().</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add ArchiveInputStream.ArchiveInputStream(InputStream, Charset) as a public constructor, it was private.</action>
-      <action type="add" dev="ggregory" due-to="Gary Gregory, Piotr P. Karwasz">Introduce builders for all ArchiveInputStream implementations.</action>
+      <action type="add" dev="ggregory" due-to="Gary Gregory, Piotr P. Karwasz">Introduce builders for all ArchiveInputStream implementations and deprecate some constructors.</action>
       <!-- UPDATE -->
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-parent from 85 to 87.</action>
       <action type="update" dev="ppkarwasz" due-to="Raeps">Extract duplicate code in org.apache.commons.compress.harmony.pack200.IntList.</action>

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
@@ -99,6 +99,9 @@ public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterI
     public abstract static class AbstractBuilder<T extends ArchiveInputStream<?>, B extends AbstractBuilder<T, B>>
             extends AbstractStreamBuilder<T, B> {
 
+        /**
+         * Constructs a new instance.
+         */
         protected AbstractBuilder() {
             // empty
         }

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Objects;
 
 import org.apache.commons.io.Charsets;
+import org.apache.commons.io.build.AbstractStreamBuilder;
 import org.apache.commons.io.function.IOConsumer;
 import org.apache.commons.io.function.IOIterator;
 import org.apache.commons.io.input.NullInputStream;
@@ -86,6 +87,20 @@ public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterI
             return null;
         }
 
+    }
+
+    /**
+     * Generic builder for ArchiveInputStream instances.
+     *
+     * @param <T> The type of {@link ArchiveInputStream} to build.
+     * @param <B> The type of the concrete Builder.
+     * @since 1.29.0
+     */
+    public abstract static class Builder<T extends ArchiveInputStream<?>, B extends Builder<T, B>> extends AbstractStreamBuilder<T, B> {
+
+        protected Builder() {
+            // empty
+        }
     }
 
     private static final int BYTE_MASK = 0xFF;
@@ -294,4 +309,5 @@ public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterI
     public synchronized void reset() throws IOException {
         // noop
     }
+
 }

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
@@ -93,12 +93,13 @@ public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterI
      * Generic builder for ArchiveInputStream instances.
      *
      * @param <T> The type of {@link ArchiveInputStream} to build.
-     * @param <B> The type of the concrete Builder.
+     * @param <B> The type of the concrete AbstractBuilder.
      * @since 1.29.0
      */
-    public abstract static class Builder<T extends ArchiveInputStream<?>, B extends Builder<T, B>> extends AbstractStreamBuilder<T, B> {
+    public abstract static class AbstractBuilder<T extends ArchiveInputStream<?>, B extends AbstractBuilder<T, B>>
+            extends AbstractStreamBuilder<T, B> {
 
-        protected Builder() {
+        protected AbstractBuilder() {
             // empty
         }
     }

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -440,10 +440,11 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
                 return (I) arjBuilder.get();
             }
             if (ZIP.equalsIgnoreCase(archiverName)) {
+                final ZipArchiveInputStream.Builder zipBuilder = ZipArchiveInputStream.builder().setInputStream(in);
                 if (actualEncoding != null) {
-                    return (I) new ZipArchiveInputStream(in, actualEncoding);
+                    zipBuilder.setCharset(actualEncoding);
                 }
-                return (I) new ZipArchiveInputStream(in);
+                return (I) zipBuilder.get();
             }
             if (TAR.equalsIgnoreCase(archiverName)) {
                 if (actualEncoding != null) {
@@ -452,10 +453,12 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
                 return (I) new TarArchiveInputStream(in);
             }
             if (JAR.equalsIgnoreCase(archiverName) || APK.equalsIgnoreCase(archiverName)) {
+                final JarArchiveInputStream.Builder jarBuilder =
+                        JarArchiveInputStream.jarInputStreamBuilder().setInputStream(in);
                 if (actualEncoding != null) {
-                    return (I) new JarArchiveInputStream(in, actualEncoding);
+                    jarBuilder.setCharset(actualEncoding);
                 }
-                return (I) new JarArchiveInputStream(in);
+                return (I) jarBuilder.get();
             }
             if (CPIO.equalsIgnoreCase(archiverName)) {
                 final CpioArchiveInputStream.Builder cpioBuilder = CpioArchiveInputStream.builder().setInputStream(in);

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.commons.compress.archivers;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -270,7 +269,8 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
         }
         // COMPRESS-117
         if (signatureLength >= TAR_HEADER_SIZE) {
-            try (TarArchiveInputStream inputStream = new TarArchiveInputStream(new ByteArrayInputStream(tarHeader))) {
+            try (TarArchiveInputStream inputStream =
+                    TarArchiveInputStream.builder().setByteArray(tarHeader).get()) {
                 // COMPRESS-191 - verify the header checksum
                 TarArchiveEntry entry = inputStream.getNextEntry();
                 // try to find the first non-directory entry within the first 10 entries.
@@ -447,10 +447,11 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
                 return (I) zipBuilder.get();
             }
             if (TAR.equalsIgnoreCase(archiverName)) {
+                final TarArchiveInputStream.Builder tarBuilder = TarArchiveInputStream.builder().setInputStream(in);
                 if (actualEncoding != null) {
-                    return (I) new TarArchiveInputStream(in, actualEncoding);
+                    tarBuilder.setCharset(actualEncoding);
                 }
-                return (I) new TarArchiveInputStream(in);
+                return (I) tarBuilder.get();
             }
             if (JAR.equalsIgnoreCase(archiverName) || APK.equalsIgnoreCase(archiverName)) {
                 final JarArchiveInputStream.Builder jarBuilder =

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -458,10 +458,11 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
                 return (I) new JarArchiveInputStream(in);
             }
             if (CPIO.equalsIgnoreCase(archiverName)) {
+                final CpioArchiveInputStream.Builder cpioBuilder = CpioArchiveInputStream.builder().setInputStream(in);
                 if (actualEncoding != null) {
-                    return (I) new CpioArchiveInputStream(in, actualEncoding);
+                    cpioBuilder.setCharset(actualEncoding);
                 }
-                return (I) new CpioArchiveInputStream(in);
+                return (I) cpioBuilder.get();
             }
             if (DUMP.equalsIgnoreCase(archiverName)) {
                 if (actualEncoding != null) {

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -433,10 +433,11 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
                 return (I) ArArchiveInputStream.builder().setInputStream(in).get();
             }
             if (ARJ.equalsIgnoreCase(archiverName)) {
+                final ArjArchiveInputStream.Builder arjBuilder = ArjArchiveInputStream.builder().setInputStream(in);
                 if (actualEncoding != null) {
-                    return (I) new ArjArchiveInputStream(in, actualEncoding);
+                    arjBuilder.setCharset(actualEncoding);
                 }
-                return (I) new ArjArchiveInputStream(in);
+                return (I) arjBuilder.get();
             }
             if (ZIP.equalsIgnoreCase(archiverName)) {
                 if (actualEncoding != null) {

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -465,10 +465,11 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
                 return (I) cpioBuilder.get();
             }
             if (DUMP.equalsIgnoreCase(archiverName)) {
+                final DumpArchiveInputStream.Builder dumpBuilder = DumpArchiveInputStream.builder().setInputStream(in);
                 if (actualEncoding != null) {
-                    return (I) new DumpArchiveInputStream(in, actualEncoding);
+                    dumpBuilder.setCharset(actualEncoding);
                 }
-                return (I) new DumpArchiveInputStream(in);
+                return (I) dumpBuilder.get();
             }
             if (SEVEN_Z.equalsIgnoreCase(archiverName)) {
                 throw new StreamingNotSupportedException(SEVEN_Z);

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -428,53 +428,58 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
         if (in == null) {
             throw new IllegalArgumentException("InputStream must not be null.");
         }
-        if (AR.equalsIgnoreCase(archiverName)) {
-            return (I) new ArArchiveInputStream(in);
-        }
-        if (ARJ.equalsIgnoreCase(archiverName)) {
-            if (actualEncoding != null) {
-                return (I) new ArjArchiveInputStream(in, actualEncoding);
+        try {
+            if (AR.equalsIgnoreCase(archiverName)) {
+                return (I) ArArchiveInputStream.builder().setInputStream(in).get();
             }
-            return (I) new ArjArchiveInputStream(in);
-        }
-        if (ZIP.equalsIgnoreCase(archiverName)) {
-            if (actualEncoding != null) {
-                return (I) new ZipArchiveInputStream(in, actualEncoding);
+            if (ARJ.equalsIgnoreCase(archiverName)) {
+                if (actualEncoding != null) {
+                    return (I) new ArjArchiveInputStream(in, actualEncoding);
+                }
+                return (I) new ArjArchiveInputStream(in);
             }
-            return (I) new ZipArchiveInputStream(in);
-        }
-        if (TAR.equalsIgnoreCase(archiverName)) {
-            if (actualEncoding != null) {
-                return (I) new TarArchiveInputStream(in, actualEncoding);
+            if (ZIP.equalsIgnoreCase(archiverName)) {
+                if (actualEncoding != null) {
+                    return (I) new ZipArchiveInputStream(in, actualEncoding);
+                }
+                return (I) new ZipArchiveInputStream(in);
             }
-            return (I) new TarArchiveInputStream(in);
-        }
-        if (JAR.equalsIgnoreCase(archiverName) || APK.equalsIgnoreCase(archiverName)) {
-            if (actualEncoding != null) {
-                return (I) new JarArchiveInputStream(in, actualEncoding);
+            if (TAR.equalsIgnoreCase(archiverName)) {
+                if (actualEncoding != null) {
+                    return (I) new TarArchiveInputStream(in, actualEncoding);
+                }
+                return (I) new TarArchiveInputStream(in);
             }
-            return (I) new JarArchiveInputStream(in);
-        }
-        if (CPIO.equalsIgnoreCase(archiverName)) {
-            if (actualEncoding != null) {
-                return (I) new CpioArchiveInputStream(in, actualEncoding);
+            if (JAR.equalsIgnoreCase(archiverName) || APK.equalsIgnoreCase(archiverName)) {
+                if (actualEncoding != null) {
+                    return (I) new JarArchiveInputStream(in, actualEncoding);
+                }
+                return (I) new JarArchiveInputStream(in);
             }
-            return (I) new CpioArchiveInputStream(in);
-        }
-        if (DUMP.equalsIgnoreCase(archiverName)) {
-            if (actualEncoding != null) {
-                return (I) new DumpArchiveInputStream(in, actualEncoding);
+            if (CPIO.equalsIgnoreCase(archiverName)) {
+                if (actualEncoding != null) {
+                    return (I) new CpioArchiveInputStream(in, actualEncoding);
+                }
+                return (I) new CpioArchiveInputStream(in);
             }
-            return (I) new DumpArchiveInputStream(in);
+            if (DUMP.equalsIgnoreCase(archiverName)) {
+                if (actualEncoding != null) {
+                    return (I) new DumpArchiveInputStream(in, actualEncoding);
+                }
+                return (I) new DumpArchiveInputStream(in);
+            }
+            if (SEVEN_Z.equalsIgnoreCase(archiverName)) {
+                throw new StreamingNotSupportedException(SEVEN_Z);
+            }
+            final ArchiveStreamProvider archiveStreamProvider = getArchiveInputStreamProviders().get(toKey(archiverName));
+            if (archiveStreamProvider != null) {
+                return archiveStreamProvider.createArchiveInputStream(archiverName, in, actualEncoding);
+            }
+            throw new ArchiveException("Archiver: %s not found.", archiverName);
+        } catch (final IOException e) {
+            throw new ArchiveException(
+                    "IOException while creating " + archiverName + " input stream: " + e.getMessage(), e);
         }
-        if (SEVEN_Z.equalsIgnoreCase(archiverName)) {
-            throw new StreamingNotSupportedException(SEVEN_Z);
-        }
-        final ArchiveStreamProvider archiveStreamProvider = getArchiveInputStreamProviders().get(toKey(archiverName));
-        if (archiveStreamProvider != null) {
-            return archiveStreamProvider.createArchiveInputStream(archiverName, in, actualEncoding);
-        }
-        throw new ArchiveException("Archiver: %s not found.", archiverName);
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -483,6 +483,8 @@ public class ArchiveStreamFactory implements ArchiveStreamProvider {
                 return archiveStreamProvider.createArchiveInputStream(archiverName, in, actualEncoding);
             }
             throw new ArchiveException("Archiver: %s not found.", archiverName);
+        } catch (final ArchiveException e) {
+            throw e;
         } catch (final IOException e) {
             throw new ArchiveException(
                     "IOException while creating " + archiverName + " input stream: " + e.getMessage(), e);

--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
@@ -39,6 +39,30 @@ import org.apache.commons.lang3.ArrayUtils;
  */
 public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
 
+    /**
+     * Builds a new {@link ArArchiveInputStream}.
+     * <p>
+     *     For example:
+     * </p>
+     * <pre>{@code
+     * ArArchiveInputStream in = ArArchiveInputStream.builder()
+     *     .setPath(inputPath)
+     *     .get();
+     * }</pre>
+     * @since 1.29.0
+     */
+    public static final class Builder extends ArchiveInputStream.Builder<ArArchiveInputStream, Builder> {
+
+        private Builder() {
+            setCharset(StandardCharsets.US_ASCII);
+        }
+
+        @Override
+        public ArArchiveInputStream get() throws IOException {
+            return new ArArchiveInputStream(this);
+        }
+    }
+
     // offsets and length of meta data parts
     private static final int NAME_OFFSET = 0;
     private static final int NAME_LEN = 16;
@@ -113,6 +137,16 @@ public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
         return ArrayUtils.startsWith(buffer, ArArchiveEntry.HEADER_BYTES);
     }
 
+    /**
+     * Creates a new builder.
+     *
+     * @return A new builder
+     * @since 1.29.0
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
     private boolean closed;
 
     /*
@@ -137,7 +171,15 @@ public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
      * @param inputStream the ar input stream
      */
     public ArArchiveInputStream(final InputStream inputStream) {
-        super(inputStream, StandardCharsets.US_ASCII.name());
+        this(inputStream, builder());
+    }
+
+    private ArArchiveInputStream(final Builder builder) throws IOException {
+        this(builder.getInputStream(), builder);
+    }
+
+    private ArArchiveInputStream(final InputStream inputStream, final Builder builder) {
+        super(inputStream, builder.getCharset());
     }
 
     private int asInt(final byte[] byteArray, final int offset, final int len, final boolean treatBlankAsZero) throws IOException {

--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
@@ -42,7 +42,7 @@ public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
     /**
      * Builds a new {@link ArArchiveInputStream}.
      * <p>
-     *     For example:
+     * For example:
      * </p>
      * <pre>{@code
      * ArArchiveInputStream in = ArArchiveInputStream.builder()

--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
@@ -51,7 +51,7 @@ public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
      * }</pre>
      * @since 1.29.0
      */
-    public static final class Builder extends ArchiveInputStream.Builder<ArArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractBuilder<ArArchiveInputStream, Builder> {
 
         private Builder() {
             setCharset(StandardCharsets.US_ASCII);

--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -59,7 +59,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream<ArjArchiveEntry> {
      * }</pre>
      * @since 1.29.0
      */
-    public static final class Builder extends ArchiveInputStream.Builder<ArjArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractBuilder<ArjArchiveInputStream, Builder> {
 
         private Builder() {
             setCharset(ENCODING_NAME);

--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -49,7 +49,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream<ArjArchiveEntry> {
     /**
      * Builds a new {@link ArjArchiveInputStream}.
      * <p>
-     *     For example:
+     * For example:
      * </p>
      * <pre>{@code
      * ArjArchiveInputStream in = ArjArchiveInputStream.builder()

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -89,11 +89,11 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         /**
          * Sets the block size of the archive.
          * <p>
-         *     Default value is {@link CpioConstants#BLOCK_SIZE}.
+         * Default value is {@link CpioConstants#BLOCK_SIZE}.
          * </p>
          *
          * @param blockSize The block size must be bigger than 0
-         * @return this
+         * @return {@code this} instance.
          */
         public Builder setBlockSize(final int blockSize) {
             this.blockSize = blockSize;

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -89,7 +89,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         /**
          * Sets the block size of the archive.
          * <p>
-         *     Default value is {@value CpioConstants#BLOCK_SIZE}.
+         *     Default value is {@link CpioConstants#BLOCK_SIZE}.
          * </p>
          *
          * @param blockSize The block size must be bigger than 0

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -78,7 +78,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
      * }</pre>
      * @since 1.29.0
      */
-    public static final class Builder extends ArchiveInputStream.Builder<CpioArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractBuilder<CpioArchiveInputStream, Builder> {
 
         private int blockSize = BLOCK_SIZE;
 

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStream.java
@@ -116,7 +116,7 @@ public class CpioArchiveOutputStream extends ArchiveOutputStream<CpioArchiveEntr
      * @param format The format of the stream
      */
     public CpioArchiveOutputStream(final OutputStream out, final short format) {
-        this(out, format, BLOCK_SIZE, CpioUtil.DEFAULT_CHARSET_NAME);
+        this(out, format, BLOCK_SIZE, CpioUtil.DEFAULT_CHARSET.name());
     }
 
     /**
@@ -128,7 +128,7 @@ public class CpioArchiveOutputStream extends ArchiveOutputStream<CpioArchiveEntr
      * @since 1.1
      */
     public CpioArchiveOutputStream(final OutputStream out, final short format, final int blockSize) {
-        this(out, format, blockSize, CpioUtil.DEFAULT_CHARSET_NAME);
+        this(out, format, blockSize, CpioUtil.DEFAULT_CHARSET.name());
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioUtil.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.commons.compress.archivers.cpio;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -28,7 +29,7 @@ import java.util.Arrays;
  */
 final class CpioUtil {
 
-    static final String DEFAULT_CHARSET_NAME = StandardCharsets.US_ASCII.name();
+    static final Charset DEFAULT_CHARSET = StandardCharsets.US_ASCII;
 
     /**
      * Converts a byte array to a long. Halfwords can be swapped by setting swapHalfWord=true.

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
@@ -59,7 +59,7 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
      * }</pre>
      * @since 1.29.0
      */
-    public static final class Builder extends ArchiveInputStream.Builder<DumpArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractBuilder<DumpArchiveInputStream, Builder> {
 
         private Builder() {
         }

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
@@ -47,6 +47,29 @@ import org.apache.commons.compress.utils.IOUtils;
  */
 public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry> {
 
+    /**
+     * Builds a new {@link DumpArchiveInputStream}.
+     * <p>
+     *     For example:
+     * </p>
+     * <pre>{@code
+     * DumpArchiveInputStream in = DumpArchiveInputStream.builder()
+     *     .setPath(inputPath)
+     *     .get();
+     * }</pre>
+     * @since 1.29.0
+     */
+    public static final class Builder extends ArchiveInputStream.Builder<DumpArchiveInputStream, Builder> {
+
+        private Builder() {
+        }
+
+        @Override
+        public DumpArchiveInputStream get() throws IOException {
+            return new DumpArchiveInputStream(this);
+        }
+    }
+
     private static final String CURRENT_PATH_SEGMENT = ".";
     private static final String PARENT_PATH_SEGMENT = "..";
 
@@ -71,6 +94,16 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
 
         // this will work in a pinch.
         return DumpArchiveConstants.NFS_MAGIC == DumpArchiveUtil.convert32(buffer, 24);
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return A new builder
+     * @since 1.29.0
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     private final DumpArchiveSummary summary;
@@ -111,7 +144,7 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
      * @throws ArchiveException on error
      */
     public DumpArchiveInputStream(final InputStream is) throws ArchiveException {
-        this(is, null);
+        this(is, builder());
     }
 
     /**
@@ -123,10 +156,18 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
      * @since 1.6
      */
     public DumpArchiveInputStream(final InputStream is, final String encoding) throws ArchiveException {
-        super(is, encoding);
+        this(is, builder().setCharset(encoding));
+    }
+
+    private DumpArchiveInputStream(final Builder builder) throws IOException {
+        this(builder.getInputStream(), builder);
+    }
+
+    private DumpArchiveInputStream(final InputStream is, final Builder builder) throws ArchiveException {
+        super(is, builder.getCharset());
         this.raw = new TapeInputStream(is);
         this.hasHitEOF = false;
-        this.zipEncoding = ZipEncodingHelper.getZipEncoding(encoding);
+        this.zipEncoding = ZipEncodingHelper.getZipEncoding(builder.getCharset());
 
         try {
             // read header, verify it's a dump archive.

--- a/src/main/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStream.java
@@ -32,6 +32,27 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 public class JarArchiveInputStream extends ZipArchiveInputStream {
 
     /**
+     * Builds a new {@link JarArchiveInputStream}.
+     * <p>
+     *     For example:
+     * </p>
+     * <pre>{@code
+     * JarArchiveInputStream in = JarArchiveInputStream.builder()
+     *     .setPath(inputPath)
+     *     .setCharset(StandardCharsets.UTF_8)
+     *     .setUseUnicodeExtraFields(false)
+     *     .get();
+     * }</pre>
+     * @since 1.29.0
+     */
+    public static class Builder extends ZipArchiveInputStream.AbstractBuilder<JarArchiveInputStream, Builder> {
+        @Override
+        public JarArchiveInputStream get() throws IOException {
+            return new JarArchiveInputStream(this);
+        }
+    }
+
+    /**
      * Checks if the signature matches what is expected for a jar file (in this case it is the same as for a ZIP file).
      *
      * @param signature the bytes to check
@@ -40,6 +61,16 @@ public class JarArchiveInputStream extends ZipArchiveInputStream {
      */
     public static boolean matches(final byte[] signature, final int length) {
         return ZipArchiveInputStream.matches(signature, length);
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return A new builder
+     * @since 1.29.0
+     */
+    public static Builder jarInputStreamBuilder() {
+        return new Builder();
     }
 
     /**
@@ -60,6 +91,10 @@ public class JarArchiveInputStream extends ZipArchiveInputStream {
      */
     public JarArchiveInputStream(final InputStream inputStream, final String encoding) {
         super(inputStream, encoding);
+    }
+
+    private JarArchiveInputStream(final Builder builder) throws IOException {
+        super(builder);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStream.java
@@ -34,7 +34,7 @@ public class JarArchiveInputStream extends ZipArchiveInputStream {
     /**
      * Builds a new {@link JarArchiveInputStream}.
      * <p>
-     *     For example:
+     * For example:
      * </p>
      * <pre>{@code
      * JarArchiveInputStream in = JarArchiveInputStream.builder()

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -71,7 +71,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @since 1.29.0
      */
     // @formatter:on
-    public static class Builder extends ArchiveInputStream.Builder<TarArchiveInputStream, Builder> {
+    public static class Builder extends AbstractBuilder<TarArchiveInputStream, Builder> {
 
         private int blockSize = TarConstants.DEFAULT_BLKSIZE;
         private int recordSize = TarConstants.DEFAULT_RCDSIZE;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -42,7 +42,6 @@ import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.utils.ArchiveUtils;
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.io.build.AbstractStreamBuilder;
 import org.apache.commons.io.input.BoundedInputStream;
 
 /**
@@ -72,7 +71,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @since 1.29.0
      */
     // @formatter:on
-    public static class Builder extends AbstractStreamBuilder<TarArchiveInputStream, Builder> {
+    public static class Builder extends ArchiveInputStream.Builder<TarArchiveInputStream, Builder> {
 
         private int blockSize = TarConstants.DEFAULT_BLKSIZE;
         private int recordSize = TarConstants.DEFAULT_RCDSIZE;
@@ -216,7 +215,11 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
 
     @SuppressWarnings("resource") // caller closes.
     private TarArchiveInputStream(final Builder builder) throws IOException {
-        super(builder.getInputStream(), builder.getCharset());
+        this(builder.getInputStream(), builder);
+    }
+
+    private TarArchiveInputStream(final InputStream inputStream, final Builder builder) {
+        super(inputStream, builder.getCharset());
         this.zipEncoding = ZipEncodingHelper.getZipEncoding(builder.getCharset());
         this.recordBuffer = new byte[builder.recordSize];
         this.blockSize = builder.blockSize;
@@ -229,7 +232,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param inputStream the input stream to use.
      */
     public TarArchiveInputStream(final InputStream inputStream) {
-        this(inputStream, TarConstants.DEFAULT_BLKSIZE, TarConstants.DEFAULT_RCDSIZE);
+        this(inputStream, builder());
     }
 
     /**
@@ -243,7 +246,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final boolean lenient) {
-        this(inputStream, TarConstants.DEFAULT_BLKSIZE, TarConstants.DEFAULT_RCDSIZE, null, lenient);
+        this(inputStream, builder().setLenient(lenient));
     }
 
     /**
@@ -255,7 +258,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final int blockSize) {
-        this(inputStream, blockSize, TarConstants.DEFAULT_RCDSIZE);
+        this(inputStream, builder().setBlockSize(blockSize));
     }
 
     /**
@@ -268,7 +271,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final int blockSize, final int recordSize) {
-        this(inputStream, blockSize, recordSize, null);
+        this(inputStream, builder().setBlockSize(blockSize).setRecordSize(recordSize));
     }
 
     /**
@@ -282,8 +285,11 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
      */
     @Deprecated
-    public TarArchiveInputStream(final InputStream inputStream, final int blockSize, final int recordSize, final String encoding) {
-        this(inputStream, blockSize, recordSize, encoding, false);
+    public TarArchiveInputStream(
+            final InputStream inputStream, final int blockSize, final int recordSize, final String encoding) {
+        this(
+                inputStream,
+                builder().setBlockSize(blockSize).setRecordSize(recordSize).setCharset(encoding));
     }
 
     /**
@@ -299,12 +305,19 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
      */
     @Deprecated
-    public TarArchiveInputStream(final InputStream inputStream, final int blockSize, final int recordSize, final String encoding, final boolean lenient) {
-        super(inputStream, encoding);
-        this.zipEncoding = ZipEncodingHelper.getZipEncoding(encoding);
-        this.recordBuffer = new byte[recordSize];
-        this.blockSize = blockSize;
-        this.lenient = lenient;
+    public TarArchiveInputStream(
+            final InputStream inputStream,
+            final int blockSize,
+            final int recordSize,
+            final String encoding,
+            final boolean lenient) {
+        this(
+                inputStream,
+                builder()
+                        .setBlockSize(blockSize)
+                        .setRecordSize(recordSize)
+                        .setCharset(encoding)
+                        .setLenient(lenient));
     }
 
     /**
@@ -318,7 +331,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final int blockSize, final String encoding) {
-        this(inputStream, blockSize, TarConstants.DEFAULT_RCDSIZE, encoding);
+        this(inputStream, builder().setBlockSize(blockSize).setCharset(encoding));
     }
 
     /**
@@ -331,7 +344,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final String encoding) {
-        this(inputStream, TarConstants.DEFAULT_BLKSIZE, TarConstants.DEFAULT_RCDSIZE, encoding);
+        this(inputStream, builder().setCharset(encoding));
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -101,7 +101,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
         }
 
         /**
-         * Set whether illegal values for group/userid, mode, device numbers and timestamp will be ignored and the fields set to
+         * Sets whether illegal values for group/userid, mode, device numbers and timestamp will be ignored and the fields set to
          * {@link TarArchiveEntry#UNKNOWN}. When set to false such illegal fields cause an exception instead.
          *
          * @param lenient whether illegal values throw exceptions.

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -478,6 +478,13 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
                         .setSkipSplitSignature(skipSplitSignature));
     }
 
+    /**
+     * Creates an instance from the given builder.
+     *
+     * @param builder The builder used to configure and create the stream.
+     * @throws IOException If the builder fails to create the underlying {@link InputStream}.
+     * @since 1.29.0
+     */
     protected ZipArchiveInputStream(final AbstractBuilder<?, ?> builder) throws IOException {
         this(builder.getInputStream(), builder);
     }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -85,7 +85,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * @since 1.29.0
      */
     public abstract static class AbstractBuilder<T extends ZipArchiveInputStream, B extends AbstractBuilder<T, B>>
-            extends ArchiveInputStream.Builder<T, B> {
+            extends ArchiveInputStream.AbstractBuilder<T, B> {
         private boolean useUnicodeExtraFields = true;
         private boolean allowStoredEntriesWithDataDescriptor;
         private boolean skipSplitSig;

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -90,29 +90,37 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
         private boolean allowStoredEntriesWithDataDescriptor;
         private boolean skipSplitSig;
 
+        /**
+         * Constructs a new instance.
+         */
         protected AbstractBuilder() {
             setCharset(StandardCharsets.UTF_8);
         }
 
         /**
-         * Controls whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
+         * Sets whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
          *
          * <p>This feature is enabled by default.</p>
          *
          * @param useUnicodeExtraFields If {@code true} Unicode Extra Fields should be used.
-         * @return this
+         * @return {@code this} instance.
          */
         public B setUseUnicodeExtraFields(final boolean useUnicodeExtraFields) {
             this.useUnicodeExtraFields = useUnicodeExtraFields;
             return asThis();
         }
 
+        /**
+         * Tests whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
+         *
+         * @return {@code true} if Unicode Extra Fields should be used.
+         */
         protected boolean isUseUnicodeExtraFields() {
             return useUnicodeExtraFields;
         }
 
         /**
-         * Controls whether the stream attempts to read STORED entries that use a data descriptor.
+         * Sets whether the stream attempts to read STORED entries that use a data descriptor.
          *
          * <p>If set to {@code true}, the stream will not stop reading an entry at the
          * declared compressed size. Instead, it will continue until a data descriptor
@@ -126,32 +134,42 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
          *
          * @param allowStoredEntriesWithDataDescriptor {@code true} to read STORED entries with data descriptors,
          *                                             {@code false} to stop at the compressed size.
-         * @return this
+         * @return {@code this} instance.
          */
-
         public B setAllowStoredEntriesWithDataDescriptor(final boolean allowStoredEntriesWithDataDescriptor) {
             this.allowStoredEntriesWithDataDescriptor = allowStoredEntriesWithDataDescriptor;
             return asThis();
         }
 
+        /**
+         * Tests whether the stream attempts to read STORED entries that use a data descriptor.
+         *
+         * @return {@code true} to read STORED entries with data descriptors,
+         *         {@code false} to stop at the compressed size.
+         */
         protected boolean isAllowStoredEntriesWithDataDescriptor() {
             return allowStoredEntriesWithDataDescriptor;
         }
 
         /**
-         * Configures whether the stream should skip the ZIP split signature
+         * Sets whether the stream should skip the ZIP split signature
          * ({@code 08074B50}) at the beginning of the input.
          *
          * <p>Disabled by default.</p>
          *
-         * @param skipSplitSig {@code true} to skip the ZIP split signature, {@code false} otherwise
-         * @return this
+         * @param skipSplitSig {@code true} to skip the ZIP split signature, {@code false} otherwise.
+         * @return {@code this} instance.
          */
         public B setSkipSplitSig(final boolean skipSplitSig) {
             this.skipSplitSig = skipSplitSig;
             return asThis();
         }
 
+        /**
+         * Tests whether the stream should skip the ZIP split signature.
+         *
+         * @return {@code true} to skip the ZIP split signature, {@code false} otherwise.
+         */
         protected boolean isSkipSplitSig() {
             return skipSplitSig;
         }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -87,7 +87,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
     public abstract static class AbstractBuilder<T extends ZipArchiveInputStream, B extends AbstractBuilder<T, B>>
             extends ArchiveInputStream.AbstractBuilder<T, B> {
         private boolean useUnicodeExtraFields = true;
-        private boolean allowStoredEntriesWithDataDescriptor;
+        private boolean supportStoredEntryDataDescriptor;
         private boolean skipSplitSignature;
 
         /**
@@ -120,7 +120,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
         }
 
         /**
-         * Sets whether the stream attempts to read STORED entries that use a data descriptor.
+         * Sets whether the stream supports reading STORED entries that use a data descriptor.
          *
          * <p>If set to {@code true}, the stream will not stop reading an entry at the
          * declared compressed size. Instead, it will continue until a data descriptor
@@ -132,12 +132,12 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
          *
          * <p>This feature is disabled by default.</p>
          *
-         * @param allowStoredEntriesWithDataDescriptor {@code true} to read STORED entries with data descriptors,
-         *                                             {@code false} to stop at the compressed size.
+         * @param supportStoredEntryDataDescriptor {@code true} to support STORED entries with a data descriptor,
+         *                                             {@code false} to stop at the declared compressed size.
          * @return {@code this} instance.
          */
-        public B setAllowStoredEntriesWithDataDescriptor(final boolean allowStoredEntriesWithDataDescriptor) {
-            this.allowStoredEntriesWithDataDescriptor = allowStoredEntriesWithDataDescriptor;
+        public B setSupportStoredEntryDataDescriptor(final boolean supportStoredEntryDataDescriptor) {
+            this.supportStoredEntryDataDescriptor = supportStoredEntryDataDescriptor;
             return asThis();
         }
 
@@ -147,8 +147,8 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
          * @return {@code true} to read STORED entries with data descriptors,
          *         {@code false} to stop at the compressed size.
          */
-        protected boolean isAllowStoredEntriesWithDataDescriptor() {
-            return allowStoredEntriesWithDataDescriptor;
+        protected boolean isSupportStoredEntryDataDescriptor() {
+            return supportStoredEntryDataDescriptor;
         }
 
         /**
@@ -381,7 +381,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * https://github.com/apache/commons-compress/pull/137#issuecomment-690835644
      * </p>
      */
-    private final boolean allowStoredEntriesWithDataDescriptor;
+    private final boolean supportStoredEntryDataDescriptor;
     /** Count decompressed bytes for current entry */
     private long uncompressedCount;
     /** Whether the stream will try to skip the ZIP split signature(08074B50) at the beginning. **/
@@ -433,48 +433,48 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
     /**
      * Constructs an instance using the specified encoding.
      *
-     * @param inputStream                          the stream to wrap.
-     * @param encoding                             the encoding to use for file names, use null for the platform's default encoding.
-     * @param useUnicodeExtraFields                whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
-     * @param allowStoredEntriesWithDataDescriptor whether the stream will try to read STORED entries that use a data descriptor.
+     * @param inputStream                      the stream to wrap.
+     * @param encoding                         the encoding to use for file names, use null for the platform's default encoding.
+     * @param useUnicodeExtraFields            whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
+     * @param supportStoredEntryDataDescriptor whether the stream will try to read STORED entries that use a data descriptor.
      * @since 1.1
      */
     public ZipArchiveInputStream(
             final InputStream inputStream,
             final String encoding,
             final boolean useUnicodeExtraFields,
-            final boolean allowStoredEntriesWithDataDescriptor) {
+            final boolean supportStoredEntryDataDescriptor) {
         this(
                 inputStream,
                 builder()
                         .setCharset(encoding)
                         .setUseUnicodeExtraFields(useUnicodeExtraFields)
-                        .setAllowStoredEntriesWithDataDescriptor(allowStoredEntriesWithDataDescriptor));
+                        .setSupportStoredEntryDataDescriptor(supportStoredEntryDataDescriptor));
     }
 
     /**
      * Constructs an instance using the specified encoding.
      *
-     * @param inputStream                          the stream to wrap.
-     * @param encoding                             the encoding to use for file names, use null for the platform's default encoding.
-     * @param useUnicodeExtraFields                whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
-     * @param allowStoredEntriesWithDataDescriptor whether the stream will try to read STORED entries that use a data descriptor.
-     * @param skipSplitSignature                   Whether the stream will try to skip the zip split signature(08074B50) at the beginning.
-     *                                             You will need to set this to true if you want to read a split archive.
+     * @param inputStream                      the stream to wrap.
+     * @param encoding                         the encoding to use for file names, use null for the platform's default encoding.
+     * @param useUnicodeExtraFields            whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
+     * @param supportStoredEntryDataDescriptor whether the stream will try to read STORED entries that use a data descriptor.
+     * @param skipSplitSignature               Whether the stream will try to skip the zip split signature(08074B50) at the beginning.
+     *                                         You will need to set this to true if you want to read a split archive.
      * @since 1.20
      */
     public ZipArchiveInputStream(
             final InputStream inputStream,
             final String encoding,
             final boolean useUnicodeExtraFields,
-            final boolean allowStoredEntriesWithDataDescriptor,
+            final boolean supportStoredEntryDataDescriptor,
             final boolean skipSplitSignature) {
         this(
                 inputStream,
                 builder()
                         .setCharset(encoding)
                         .setUseUnicodeExtraFields(useUnicodeExtraFields)
-                        .setAllowStoredEntriesWithDataDescriptor(allowStoredEntriesWithDataDescriptor)
+                        .setSupportStoredEntryDataDescriptor(supportStoredEntryDataDescriptor)
                         .setSkipSplitSignature(skipSplitSignature));
     }
 
@@ -487,7 +487,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
         this.in = new PushbackInputStream(inputStream, buf.capacity());
         this.zipEncoding = ZipEncodingHelper.getZipEncoding(builder.getCharset());
         this.useUnicodeExtraFields = builder.isUseUnicodeExtraFields();
-        this.allowStoredEntriesWithDataDescriptor = builder.isAllowStoredEntriesWithDataDescriptor();
+        this.supportStoredEntryDataDescriptor = builder.isSupportStoredEntryDataDescriptor();
         this.skipSplitSignature = builder.isSkipSplitSignature();
         // haven't read anything so far
         buf.limit(0);
@@ -1423,19 +1423,19 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
     private boolean supportsCompressedSizeFor(final ZipArchiveEntry entry) {
         final int method = entry.getMethod();
         return entry.getCompressedSize() != ArchiveEntry.SIZE_UNKNOWN || method == ZipEntry.DEFLATED || method == ZipMethod.ENHANCED_DEFLATED.getCode()
-                || entry.getGeneralPurposeBit().usesDataDescriptor() && allowStoredEntriesWithDataDescriptor && method == ZipEntry.STORED
+                || entry.getGeneralPurposeBit().usesDataDescriptor() && supportStoredEntryDataDescriptor && method == ZipEntry.STORED
                 || ZipMethod.isZstd(method) || method == ZipMethod.XZ.getCode();
     }
 
     /**
      * Tests whether this entry requires a data descriptor this library can work with.
      *
-     * @return true if allowStoredEntriesWithDataDescriptor is true, the entry doesn't require any data descriptor or the method is DEFLATED or
+     * @return true if supportStoredEntryDataDescriptor is true, the entry doesn't require any data descriptor or the method is DEFLATED or
      *         ENHANCED_DEFLATED.
      */
     private boolean supportsDataDescriptorFor(final ZipArchiveEntry entry) {
         final int method = entry.getMethod();
-        return !entry.getGeneralPurposeBit().usesDataDescriptor() || allowStoredEntriesWithDataDescriptor && method == ZipEntry.STORED
+        return !entry.getGeneralPurposeBit().usesDataDescriptor() || supportStoredEntryDataDescriptor && method == ZipEntry.STORED
                 || method == ZipEntry.DEFLATED || method == ZipMethod.ENHANCED_DEFLATED.getCode() || ZipMethod.isZstd(method)
                 || method == ZipMethod.XZ.getCode();
     }

--- a/src/site/xdoc/zip.xml
+++ b/src/site/xdoc/zip.xml
@@ -193,7 +193,7 @@
         <code>ZipArchiveInputStream</code> support reading streams of
         this type, in the case of <code>ZipArchiveInputStream</code>
         you need to use a constructor where you can set
-        <code>skipSplitSig</code> to true.</p>
+        <code>skipSplitSignature</code> to true.</p>
       </subsection>
 
       <subsection name="Extra Fields">

--- a/src/test/java/org/apache/commons/compress/AbstractTest.java
+++ b/src/test/java/org/apache/commons/compress/AbstractTest.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -81,19 +82,23 @@ public abstract class AbstractTest extends AbstractTempDirTest {
     }
 
     public static File getFile(final String path) throws IOException {
-        final URL url = AbstractTest.class.getClassLoader().getResource(path);
-        if (url == null) {
-            throw new FileNotFoundException("couldn't find " + path);
-        }
-        try {
-            return new File(url.toURI());
-        } catch (final URISyntaxException ex) {
-            throw new IOException(ex);
-        }
+        return new File(getURI(path));
     }
 
     public static Path getPath(final String path) throws IOException {
         return getFile(path).toPath();
+    }
+
+    public static URI getURI(final String resourceName) throws IOException {
+        final URL url = AbstractTest.class.getClassLoader().getResource(resourceName);
+        if (url == null) {
+            throw new FileNotFoundException("couldn't find " + resourceName);
+        }
+        try {
+            return url.toURI();
+        } catch (final URISyntaxException ex) {
+            throw new IOException(ex);
+        }
     }
 
     public static InputStream newInputStream(final String path) throws IOException {

--- a/src/test/java/org/apache/commons/compress/ChainingTest.java
+++ b/src/test/java/org/apache/commons/compress/ChainingTest.java
@@ -33,7 +33,9 @@ class ChainingTest extends AbstractTest {
 
     @Test
     void testTarBzip2() throws Exception {
-        try (TarArchiveInputStream is = new TarArchiveInputStream(new BZip2CompressorInputStream(newInputStream("bla.tar.bz2")))) {
+        try (TarArchiveInputStream is = TarArchiveInputStream.builder()
+                .setInputStream(new BZip2CompressorInputStream(newInputStream("bla.tar.bz2")))
+                .get()) {
             final TarArchiveEntry entry = is.getNextEntry();
             assertNotNull(entry);
             assertEquals("test1.xml", entry.getName());
@@ -43,7 +45,11 @@ class ChainingTest extends AbstractTest {
 
     @Test
     void testTarGzip() throws Exception {
-        try (TarArchiveInputStream is = new TarArchiveInputStream(new GzipCompressorInputStream(newInputStream("bla.tgz")))) {
+        try (TarArchiveInputStream is = TarArchiveInputStream.builder()
+                .setInputStream(GzipCompressorInputStream.builder()
+                        .setURI(getURI("bla.tgz"))
+                        .get())
+                .get()) {
             final TarArchiveEntry entry = is.getNextEntry();
             assertNotNull(entry);
             assertEquals("test1.xml", entry.getName());

--- a/src/test/java/org/apache/commons/compress/DetectArchiverTest.java
+++ b/src/test/java/org/apache/commons/compress/DetectArchiverTest.java
@@ -197,7 +197,9 @@ public final class DetectArchiverTest extends AbstractTest {
 
     @Test
     void testIcoFileFirstTarArchiveEntry() throws Exception {
-        try (TarArchiveInputStream inputStream = new TarArchiveInputStream(createBufferedInputStream("org/apache/commons/compress/COMPRESS-644/ARW05UP.ICO"))) {
+        try (TarArchiveInputStream inputStream = TarArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/COMPRESS-644/ARW05UP.ICO"))
+                .get()) {
             final TarArchiveEntry entry = inputStream.getNextEntry();
             // Find hints that the file is not a TAR file.
             assertNull(entry.getCreationTime());

--- a/src/test/java/org/apache/commons/compress/archivers/ArTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ArTest.java
@@ -180,7 +180,7 @@ public final class ArTest extends AbstractTest {
         }
         //
         final ArArchiveEntry out;
-        try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (ArArchiveInputStream ais = ArArchiveInputStream.builder().setFile(archive).get()) {
             out = ais.getNextEntry();
         }
         assertNotNull(out);
@@ -201,7 +201,7 @@ public final class ArTest extends AbstractTest {
             aos.closeArchiveEntry();
         }
         final ArArchiveEntry out;
-        try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (ArArchiveInputStream ais = ArArchiveInputStream.builder().setFile(archive).get()) {
             out = ais.getNextEntry();
         }
         assertNotNull(out);
@@ -223,7 +223,7 @@ public final class ArTest extends AbstractTest {
             aos.closeArchiveEntry();
         }
         final ArArchiveEntry out;
-        try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (ArArchiveInputStream ais = ArArchiveInputStream.builder().setFile(archive).get()) {
             out = ais.getNextEntry();
         }
         assertNotNull(out);
@@ -248,7 +248,7 @@ public final class ArTest extends AbstractTest {
             aos.closeArchiveEntry();
         }
         final ArArchiveEntry out;
-        try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (ArArchiveInputStream ais = ArArchiveInputStream.builder().setFile(archive).get()) {
             out = ais.getNextEntry();
         }
         assertNotNull(out);
@@ -273,7 +273,7 @@ public final class ArTest extends AbstractTest {
             aos.closeArchiveEntry();
         }
         final ArArchiveEntry out;
-        try (ArArchiveInputStream ais = new ArArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (ArArchiveInputStream ais = ArArchiveInputStream.builder().setFile(archive).get()) {
             out = ais.getNextEntry();
         }
         assertNotNull(out);

--- a/src/test/java/org/apache/commons/compress/archivers/ArchiveStreamFactoryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ArchiveStreamFactoryTest.java
@@ -111,7 +111,8 @@ class ArchiveStreamFactoryTest extends AbstractTest {
         }
         ARJ_DEFAULT = dflt;
         dflt = UNKNOWN;
-        try (DumpArchiveInputStream inputStream = new DumpArchiveInputStream(newInputStream("bla.dump"))) {
+        try (DumpArchiveInputStream inputStream =
+                DumpArchiveInputStream.builder().setURI(getURI("bla.dump")).get()) {
             dflt = getCharsetName(inputStream);
         } catch (final Exception e) {
             e.printStackTrace();

--- a/src/test/java/org/apache/commons/compress/archivers/ArchiveStreamFactoryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ArchiveStreamFactoryTest.java
@@ -104,7 +104,7 @@ class ArchiveStreamFactoryTest extends AbstractTest {
     static {
         String dflt;
         dflt = UNKNOWN;
-        try (ArjArchiveInputStream inputStream = new ArjArchiveInputStream(newInputStream("bla.arj"))) {
+        try (ArjArchiveInputStream inputStream = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             dflt = getCharsetName(inputStream);
         } catch (final Exception e) {
             e.printStackTrace();

--- a/src/test/java/org/apache/commons/compress/archivers/CpioTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/CpioTest.java
@@ -120,7 +120,7 @@ public final class CpioTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final CpioArchiveEntry entryOut;
-        try (CpioArchiveInputStream tis = new CpioArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (CpioArchiveInputStream tis = CpioArchiveInputStream.builder().setFile(archive).get()) {
             entryOut = tis.getNextCPIOEntry();
         }
         assertNotNull(entryOut);
@@ -144,7 +144,7 @@ public final class CpioTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final CpioArchiveEntry out;
-        try (CpioArchiveInputStream tis = new CpioArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (CpioArchiveInputStream tis = CpioArchiveInputStream.builder().setFile(archive).get()) {
             out = tis.getNextCPIOEntry();
         }
         assertNotNull(out);
@@ -168,7 +168,7 @@ public final class CpioTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final CpioArchiveEntry out;
-        try (CpioArchiveInputStream tis = new CpioArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (CpioArchiveInputStream tis = CpioArchiveInputStream.builder().setFile(archive).get()) {
             out = tis.getNextCPIOEntry();
         }
         assertNotNull(out);
@@ -189,7 +189,7 @@ public final class CpioTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final CpioArchiveEntry out;
-        try (CpioArchiveInputStream tis = new CpioArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (CpioArchiveInputStream tis = CpioArchiveInputStream.builder().setFile(archive).get()) {
             out = tis.getNextCPIOEntry();
         }
         assertNotNull(out);
@@ -220,7 +220,7 @@ public final class CpioTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final CpioArchiveEntry entry;
-        try (CpioArchiveInputStream tis = new CpioArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (CpioArchiveInputStream tis = CpioArchiveInputStream.builder().setFile(archive).get()) {
             entry = tis.getNextEntry();
             assertEquals(nameLink, IOUtils.toString(tis, charset));
         }

--- a/src/test/java/org/apache/commons/compress/archivers/DumpTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/DumpTest.java
@@ -46,8 +46,8 @@ public final class DumpTest extends AbstractTest {
         expected.add("lost+found/");
         expected.add("test1.xml");
         expected.add("test2.xml");
-        try (InputStream is = Files.newInputStream(f.toPath());
-                DumpArchiveInputStream inputStream = new DumpArchiveInputStream(is);) {
+        try (DumpArchiveInputStream inputStream =
+                DumpArchiveInputStream.builder().setFile(f).get()) {
             checkArchiveContent(inputStream, expected);
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/TarTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/TarTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -69,9 +68,10 @@ public final class TarTest extends AbstractTest {
 
     @Test
     void testCOMPRESS114() throws Exception {
-        final File input = getFile("COMPRESS-114.tar");
-        try (InputStream is = Files.newInputStream(input.toPath());
-                TarArchiveInputStream in = new TarArchiveInputStream(is, StandardCharsets.ISO_8859_1.name())) {
+        try (TarArchiveInputStream in = TarArchiveInputStream.builder()
+                .setURI(getURI("COMPRESS-114.tar"))
+                .setCharset(StandardCharsets.ISO_8859_1)
+                .get()) {
             TarArchiveEntry entry = in.getNextEntry();
             assertEquals("3\u00b1\u00b1\u00b1F06\u00b1W2345\u00b1ZB\u00b1la\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1BLA", entry.getName());
             assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
@@ -94,9 +94,10 @@ public final class TarTest extends AbstractTest {
 
     @Test
     void testCOMPRESS178Lenient() throws Exception {
-        final File input = getFile("COMPRESS-178-fail.tar");
-        try (InputStream is = Files.newInputStream(input.toPath());
-                ArchiveInputStream<?> in = new TarArchiveInputStream(is, true)) {
+        try (ArchiveInputStream<?> in = TarArchiveInputStream.builder()
+                .setURI(getURI("COMPRESS-178-fail.tar"))
+                .setLenient(true)
+                .get()) {
             in.getNextEntry();
         }
     }
@@ -113,7 +114,7 @@ public final class TarTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final TarArchiveEntry out;
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setFile(archive).get()) {
             out = tis.getNextTarEntry();
         }
         assertNotNull(out);
@@ -127,9 +128,8 @@ public final class TarTest extends AbstractTest {
 
     @Test
     void testDirectoryRead() throws IOException {
-        final File input = getFile("directory.tar");
-        try (InputStream is = Files.newInputStream(input.toPath());
-                TarArchiveInputStream in = new TarArchiveInputStream(is)) {
+        try (TarArchiveInputStream in =
+                TarArchiveInputStream.builder().setURI(getURI("directory.tar")).get()) {
             final TarArchiveEntry directoryEntry = in.getNextTarEntry();
             assertEquals("directory/", directoryEntry.getName());
             assertEquals(TarConstants.LF_DIR, directoryEntry.getLinkFlag());
@@ -151,7 +151,7 @@ public final class TarTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final TarArchiveEntry out;
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setFile(archive).get()) {
             out = tis.getNextTarEntry();
         }
         assertNotNull(out);
@@ -175,7 +175,7 @@ public final class TarTest extends AbstractTest {
             outputStream.closeArchiveEntry();
         }
         final TarArchiveEntry entryOut;
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setFile(archive).get()) {
             entryOut = tis.getNextTarEntry();
         }
         assertNotNull(entryOut);
@@ -197,7 +197,7 @@ public final class TarTest extends AbstractTest {
             outputStream.closeArchiveEntry();
         }
         final TarArchiveEntry out;
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(Files.newInputStream(archive.toPath()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setFile(archive).get()) {
             out = tis.getNextTarEntry();
         }
         assertNotNull(out);
@@ -216,8 +216,8 @@ public final class TarTest extends AbstractTest {
             final String fileName = createLongName(length);
             assertEquals(length.intValue(), fileName.length());
             final byte[] data = createTarWithOneLongNameEntry(fileName);
-            try (ByteArrayInputStream bis = new ByteArrayInputStream(data);
-                    TarArchiveInputStream tis = new TarArchiveInputStream(bis)) {
+            try (TarArchiveInputStream tis =
+                    TarArchiveInputStream.builder().setByteArray(data).get()) {
                 assertEquals(fileName, tis.getNextTarEntry().getName());
             }
         }

--- a/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.commons.compress.archivers;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -353,7 +352,10 @@ public final class ZipTest extends AbstractTest {
         final File lastFile = newTempFile("splitZip.zip");
         try (SeekableByteChannel channel = ZipSplitReadOnlySeekableByteChannel.buildFromLastSplitSegment(lastFile);
                 InputStream inputStream = Channels.newInputStream(channel);
-                ZipArchiveInputStream splitInputStream = new ZipArchiveInputStream(inputStream, UTF_8.toString(), true, false, true)) {
+                ZipArchiveInputStream splitInputStream = ZipArchiveInputStream.builder()
+                        .setInputStream(inputStream)
+                        .setSkipSplitSig(true)
+                        .get()) {
 
             ArchiveEntry entry;
             final int filesNum = countNonDirectories(directoryToZip);
@@ -653,7 +655,7 @@ public final class ZipTest extends AbstractTest {
      */
     @Test
     void testSkipEntryWithUnsupportedCompressionMethod() throws IOException {
-        try (ZipArchiveInputStream zip = new ZipArchiveInputStream(newInputStream("moby.zip"))) {
+        try (ZipArchiveInputStream zip = ZipArchiveInputStream.builder().setURI(getURI("moby.zip")).get()) {
             final ZipArchiveEntry entry = zip.getNextZipEntry();
             assertEquals(ZipMethod.TOKENIZATION.getCode(), entry.getMethod(), "method");
             assertEquals("README", entry.getName());
@@ -667,12 +669,12 @@ public final class ZipTest extends AbstractTest {
      */
     @Test
     void testSkipsPK00Prefix() throws Exception {
-        final File input = getFile("COMPRESS-208.zip");
         final ArrayList<String> al = new ArrayList<>();
         al.add("test1.xml");
         al.add("test2.xml");
-        try (InputStream fis = Files.newInputStream(input.toPath());
-                ZipArchiveInputStream inputStream = new ZipArchiveInputStream(fis)) {
+        try (ZipArchiveInputStream inputStream = ZipArchiveInputStream.builder()
+                .setURI(getURI("COMPRESS-208.zip"))
+                .get()) {
             checkArchiveContent(inputStream, al);
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ZipTest.java
@@ -354,7 +354,7 @@ public final class ZipTest extends AbstractTest {
                 InputStream inputStream = Channels.newInputStream(channel);
                 ZipArchiveInputStream splitInputStream = ZipArchiveInputStream.builder()
                         .setInputStream(inputStream)
-                        .setSkipSplitSig(true)
+                        .setSkipSplitSignature(true)
                         .get()) {
 
             ArchiveEntry entry;

--- a/src/test/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStreamTest.java
@@ -28,8 +28,6 @@ import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -43,7 +41,9 @@ class ArArchiveInputStreamTest extends AbstractTest {
 
     private void checkLongNameEntry(final String archive) throws Exception {
         try (InputStream fis = newInputStream(archive);
-                ArArchiveInputStream s = new ArArchiveInputStream(new BufferedInputStream(fis))) {
+                ArArchiveInputStream s = ArArchiveInputStream.builder()
+                        .setInputStream(new BufferedInputStream(fis))
+                        .get()) {
             ArchiveEntry e = s.getNextEntry();
             assertEquals("this_is_a_long_file_name.txt", e.getName());
             assertEquals(14, e.getSize());
@@ -62,8 +62,7 @@ class ArArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testCantReadAfterClose() throws Exception {
-        try (InputStream in = newInputStream("bla.ar");
-                ArArchiveInputStream archive = new ArArchiveInputStream(in)) {
+        try (ArArchiveInputStream archive = ArArchiveInputStream.builder().setURI(getURI("bla.ar")).get()) {
             archive.close();
             assertThrows(IllegalStateException.class, () -> archive.read());
         }
@@ -71,8 +70,7 @@ class ArArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testCantReadWithoutOpeningAnEntry() throws Exception {
-        try (InputStream in = newInputStream("bla.ar");
-                ArArchiveInputStream archive = new ArArchiveInputStream(in)) {
+        try (ArArchiveInputStream archive = ArArchiveInputStream.builder().setURI(getURI("bla.ar")).get()) {
             assertThrows(IllegalStateException.class, () -> archive.read());
         }
     }
@@ -85,7 +83,9 @@ class ArArchiveInputStreamTest extends AbstractTest {
 
     private void testCompress661(final boolean checkMarkReadReset) throws IOException {
         try (InputStream in = newInputStream("org/apache/commons/compress/COMPRESS-661/testARofText.ar");
-                ArArchiveInputStream archive = new ArArchiveInputStream(new BufferedInputStream(in))) {
+                ArArchiveInputStream archive = ArArchiveInputStream.builder()
+                        .setInputStream(new BufferedInputStream(in))
+                        .get()) {
             assertNotNull(archive.getNextEntry());
             if (checkMarkReadReset && archive.markSupported()) {
                 // mark() shouldn't be supported, but if it would be,
@@ -107,16 +107,18 @@ class ArArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testGetNextArEntry() throws IOException {
-        try (ArArchiveInputStream inputStream = new ArArchiveInputStream(
-                Files.newInputStream(Paths.get("src/test/resources/org/apache/commons/compress/ar/getNextArEntry.bin")))) {
+        try (ArArchiveInputStream inputStream = ArArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/ar/getNextArEntry.bin"))
+                .get()) {
             assertThrows(EOFException.class, inputStream::getNextEntry);
         }
     }
 
     @Test
     void testInvalidBadTableLength() throws Exception {
-        try (InputStream in = newInputStream("org/apache/commons/compress/ar/number_parsing/bad_table_length_gnu-fail.ar");
-                ArArchiveInputStream archive = new ArArchiveInputStream(in)) {
+        try (ArArchiveInputStream archive = ArArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/ar/number_parsing/bad_table_length_gnu-fail.ar"))
+                .get()) {
             assertThrows(IOException.class, archive::getNextEntry);
         }
     }
@@ -125,8 +127,9 @@ class ArArchiveInputStreamTest extends AbstractTest {
     @ValueSource(strings = { "bad_long_namelen_bsd-fail.ar", "bad_long_namelen_gnu1-fail.ar", "bad_long_namelen_gnu2-fail.ar", "bad_long_namelen_gnu3-fail.ar",
             "bad_table_length_gnu-fail.ar" })
     void testInvalidLongNameLength(final String testFileName) throws Exception {
-        try (InputStream in = newInputStream("org/apache/commons/compress/ar/number_parsing/" + testFileName);
-                ArArchiveInputStream archive = new ArArchiveInputStream(in)) {
+        try (ArArchiveInputStream archive = ArArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/ar/number_parsing/" + testFileName))
+                .get()) {
             assertThrows(IOException.class, archive::getNextEntry);
         }
     }
@@ -134,8 +137,9 @@ class ArArchiveInputStreamTest extends AbstractTest {
     @ParameterizedTest
     @ValueSource(strings = { "bad_group-fail.ar", "bad_length-fail.ar", "bad_modified-fail.ar", "bad_user-fail.ar" })
     void testInvalidNumericFields(final String testFileName) throws Exception {
-        try (InputStream in = newInputStream("org/apache/commons/compress/ar/number_parsing/" + testFileName);
-                ArArchiveInputStream archive = new ArArchiveInputStream(in)) {
+        try (ArArchiveInputStream archive = ArArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/ar/number_parsing/" + testFileName))
+                .get()) {
             assertThrows(IOException.class, archive::getNextEntry);
         }
     }
@@ -143,8 +147,7 @@ class ArArchiveInputStreamTest extends AbstractTest {
     @Test
     void testMultiByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
         final byte[] buf = new byte[2];
-        try (InputStream in = newInputStream("bla.ar");
-                ArArchiveInputStream archive = new ArArchiveInputStream(in)) {
+        try (ArArchiveInputStream archive = ArArchiveInputStream.builder().setURI(getURI("bla.ar")).get()) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read(buf));
@@ -173,7 +176,9 @@ class ArArchiveInputStreamTest extends AbstractTest {
                         return fileInputStream.read();
                     }
                 }) {
-            try (ArArchiveInputStream archiveInputStream = new ArArchiveInputStream(simpleInputStream)) {
+            try (ArArchiveInputStream archiveInputStream = ArArchiveInputStream.builder()
+                    .setInputStream(simpleInputStream)
+                    .get()) {
                 final ArArchiveEntry entry1 = archiveInputStream.getNextEntry();
                 assertNotNull(entry1);
                 assertEquals("test1.xml", entry1.getName());
@@ -197,7 +202,9 @@ class ArArchiveInputStreamTest extends AbstractTest {
                         return fileInputStream.read();
                     }
                 }) {
-            try (ArArchiveInputStream archiveInputStream = new ArArchiveInputStream(simpleInputStream)) {
+            try (ArArchiveInputStream archiveInputStream = ArArchiveInputStream.builder()
+                    .setInputStream(simpleInputStream)
+                    .get()) {
                 final ArArchiveEntry entry1 = archiveInputStream.getNextEntry();
                 assertNotNull(entry1);
                 assertEquals("test1.xml", entry1.getName());
@@ -212,8 +219,7 @@ class ArArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testSingleByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
-        try (InputStream in = newInputStream("bla.ar");
-                ArArchiveInputStream archive = new ArArchiveInputStream(in)) {
+        try (ArArchiveInputStream archive = ArArchiveInputStream.builder().setURI(getURI("bla.ar")).get()) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read());

--- a/src/test/java/org/apache/commons/compress/archivers/ar/Compress678Test.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ar/Compress678Test.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -69,7 +68,7 @@ class Compress678Test {
             arOut.write(data);
             arOut.closeArchiveEntry();
         }
-        try (ArArchiveInputStream arIn = new ArArchiveInputStream(new FileInputStream(file))) {
+        try (ArArchiveInputStream arIn = ArArchiveInputStream.builder().setFile(file).get()) {
             final ArArchiveEntry entry = arIn.getNextEntry();
             assertEquals(fileName, entry.getName());
             // Fix
@@ -120,7 +119,7 @@ class Compress678Test {
             arOut.write(data);
             arOut.closeArchiveEntry();
         }
-        try (ArArchiveInputStream arIn = new ArArchiveInputStream(new FileInputStream(file))) {
+        try (ArArchiveInputStream arIn = ArArchiveInputStream.builder().setFile(file).get()) {
             final ArArchiveEntry entry = arIn.getNextEntry();
             assertEquals(name1, entry.getName());
             assertNotNull(arIn.getNextEntry());

--- a/src/test/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStreamTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Calendar;
 import java.util.TimeZone;
@@ -81,16 +80,16 @@ class ArjArchiveInputStreamTest extends AbstractTest {
     }
 
     @Test
-    void testFirstHeaderSizeSetToZero() throws Exception {
-        try (InputStream in = newInputStream("org/apache/commons/compress/arj/zero_sized_headers-fail.arj")) {
-            final ArchiveException ex = assertThrows(ArchiveException.class, () -> {
-                try (ArjArchiveInputStream archive = new ArjArchiveInputStream(in)) {
-                    // Do nothing, ArchiveException already thrown
-                    fail("ArchiveException not thrown.");
-                }
-            });
-            assertTrue(ex.getCause() instanceof IOException);
-        }
+    void testFirstHeaderSizeSetToZero() {
+        final ArchiveException ex = assertThrows(ArchiveException.class, () -> {
+            try (ArjArchiveInputStream archive = ArjArchiveInputStream.builder()
+                    .setURI(getURI("org/apache/commons/compress/arj/zero_sized_headers-fail.arj"))
+                    .get()) {
+                // Do nothing, ArchiveException already thrown
+                fail("ArchiveException not thrown.");
+            }
+        });
+        assertTrue(ex.getCause() instanceof IOException);
     }
 
     @Test
@@ -100,7 +99,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
         expected.append("<empty/>test2.xml<?xml version=\"1.0\"?>\n");
         expected.append("<empty/>\n");
         final StringBuilder result = new StringBuilder();
-        try (ArjArchiveInputStream in = new ArjArchiveInputStream(newInputStream("bla.arj"))) {
+        try (ArjArchiveInputStream in = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             in.forEach(entry -> {
                 result.append(entry.getName());
                 int tmp;
@@ -122,7 +121,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
         expected.append("<empty/>test2.xml<?xml version=\"1.0\"?>\n");
         expected.append("<empty/>\n");
         final StringBuilder result = new StringBuilder();
-        try (ArjArchiveInputStream in = new ArjArchiveInputStream(newInputStream("bla.arj"))) {
+        try (ArjArchiveInputStream in = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             ArjArchiveEntry entry;
             while ((entry = in.getNextEntry()) != null) {
                 result.append(entry.getName());
@@ -141,8 +140,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
     @Test
     void testMultiByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
         final byte[] buf = new byte[2];
-        try (InputStream in = newInputStream("bla.arj");
-                ArjArchiveInputStream archive = new ArjArchiveInputStream(in)) {
+        try (ArjArchiveInputStream archive = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read(buf));
@@ -159,7 +157,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
         expected.append("<empty/>\n");
         final Charset charset = Charset.defaultCharset();
         try (ByteArrayOutputStream result = new ByteArrayOutputStream();
-                ArjArchiveInputStream in = new ArjArchiveInputStream(newInputStream("bla.arj"))) {
+                ArjArchiveInputStream in = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             ArjArchiveEntry entry;
             while ((entry = in.getNextEntry()) != null) {
                 result.write(entry.getName().getBytes(charset));
@@ -184,7 +182,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
         expected.append("<empty/>\n");
         final Charset charset = Charset.defaultCharset();
         try (ByteArrayOutputStream result = new ByteArrayOutputStream();
-                ArjArchiveInputStream in = new ArjArchiveInputStream(newInputStream("bla.arj"))) {
+                ArjArchiveInputStream in = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             in.forEach(entry -> {
                 result.write(entry.getName().getBytes(charset));
                 final byte[] tmp = new byte[2];
@@ -209,7 +207,9 @@ class ArjArchiveInputStreamTest extends AbstractTest {
         expected.append("<empty/>\n");
         final Charset charset = Charset.defaultCharset();
         try (ByteArrayOutputStream result = new ByteArrayOutputStream();
-                ArjArchiveInputStream in = new ArjArchiveInputStream(newInputStream("bla.arj"))) {
+                ArjArchiveInputStream in = ArjArchiveInputStream.builder()
+                        .setURI(getURI("bla.arj"))
+                        .get()) {
             in.forEach(entry -> {
                 result.write(entry.getName().getBytes(charset));
                 final byte[] tmp = new byte[10];
@@ -228,7 +228,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testReadingOfAttributesDosVersion() throws Exception {
-        try (ArjArchiveInputStream archive = new ArjArchiveInputStream(newInputStream("bla.arj"))) {
+        try (ArjArchiveInputStream archive = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             final ArjArchiveEntry entry = archive.getNextEntry();
             assertEquals("test1.xml", entry.getName());
             assertEquals(30, entry.getSize());
@@ -243,7 +243,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testReadingOfAttributesUnixVersion() throws Exception {
-        try (ArjArchiveInputStream in = new ArjArchiveInputStream(newInputStream("bla.unix.arj"))) {
+        try (ArjArchiveInputStream in = ArjArchiveInputStream.builder().setURI(getURI("bla.unix.arj")).get()) {
             final ArjArchiveEntry entry = in.getNextEntry();
             assertEquals("test1.xml", entry.getName());
             assertEquals(30, entry.getSize());
@@ -258,8 +258,7 @@ class ArjArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testSingleByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
-        try (InputStream in = newInputStream("bla.arj");
-                ArjArchiveInputStream archive = new ArjArchiveInputStream(in)) {
+        try (ArjArchiveInputStream archive = ArjArchiveInputStream.builder().setURI(getURI("bla.arj")).get()) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read());

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveOutputStreamTest.java
@@ -42,7 +42,7 @@ class CpioArchiveOutputStreamTest extends AbstractTest {
             outputStream.closeArchiveEntry();
         }
         assertTrue(ref.isClosed());
-        try (CpioArchiveInputStream in = new CpioArchiveInputStream(Files.newInputStream(output.toPath()))) {
+        try (CpioArchiveInputStream in = CpioArchiveInputStream.builder().setFile(output).get()) {
             final CpioArchiveEntry e = in.getNextCPIOEntry();
             assertEquals("test1.xml", e.getName());
             assertNull(in.getNextEntry());

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
@@ -50,8 +49,10 @@ class CpioArchiveTest {
                 os.closeArchiveEntry();
             }
             baos.close();
-            try (ByteArrayInputStream bin = new ByteArrayInputStream(baos.toByteArray());
-                    CpioArchiveInputStream in = new CpioArchiveInputStream(bin, StandardCharsets.UTF_8.name())) {
+            try (CpioArchiveInputStream in = CpioArchiveInputStream.builder()
+                    .setByteArray(baos.toByteArray())
+                    .setCharset(StandardCharsets.UTF_8)
+                    .get()) {
                 final CpioArchiveEntry entry = in.getNextEntry();
                 assertNotNull(entry);
                 assertEquals("Test.txt", entry.getName());
@@ -74,8 +75,9 @@ class CpioArchiveTest {
                 os.closeArchiveEntry();
             }
             baos.close();
-            try (ByteArrayInputStream bin = new ByteArrayInputStream(baos.toByteArray());
-                    CpioArchiveInputStream in = new CpioArchiveInputStream(bin)) {
+            try (CpioArchiveInputStream in = CpioArchiveInputStream.builder()
+                    .setByteArray(baos.toByteArray())
+                    .get()) {
                 final CpioArchiveEntry entry = in.getNextEntry();
                 assertNotNull(entry);
                 assertEquals("T%U00E4st.txt", entry.getName());
@@ -98,8 +100,10 @@ class CpioArchiveTest {
                 os.closeArchiveEntry();
             }
             baos.close();
-            try (ByteArrayInputStream bin = new ByteArrayInputStream(baos.toByteArray());
-                    CpioArchiveInputStream in = new CpioArchiveInputStream(bin, StandardCharsets.UTF_16LE.name())) {
+            try (CpioArchiveInputStream in = CpioArchiveInputStream.builder()
+                    .setByteArray(baos.toByteArray())
+                    .setCharset(StandardCharsets.UTF_16LE)
+                    .get()) {
                 final CpioArchiveEntry entry = in.getNextEntry();
                 assertNotNull(entry);
                 assertEquals("T\u00e4st.txt", entry.getName());

--- a/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java
@@ -29,11 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -51,8 +48,9 @@ class DumpArchiveInputStreamTest extends AbstractTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 10, 32, 1024})
     void checkSupportedRecordSizes(final int ntrec) throws Exception {
-        try (InputStream is = createArchive(ntrec);
-                DumpArchiveInputStream dump = new DumpArchiveInputStream(is)) {
+        try (DumpArchiveInputStream dump = DumpArchiveInputStream.builder()
+                .setByteArray(createArchive(ntrec))
+                .get()) {
             final DumpArchiveSummary summary = dump.getSummary();
             assertNotNull(summary);
             assertEquals(ntrec, summary.getNTRec());
@@ -62,16 +60,14 @@ class DumpArchiveInputStreamTest extends AbstractTest {
     @ParameterizedTest
     @ValueSource(ints = {Integer.MIN_VALUE, -1, 0, 1025, Integer.MAX_VALUE})
     void checkUnsupportedRecordSizes(final int ntrec) throws Exception {
-        try (InputStream is = createArchive(ntrec)) {
-            final ArchiveException ex = assertThrows(ArchiveException.class, () -> new DumpArchiveInputStream(is));
-            assertInstanceOf(ArchiveException.class, ex.getCause());
-            assertTrue(
-                    ex.getMessage().contains(Integer.toString(ntrec)),
-                    "message should contain the invalid ntrec value");
-        }
+        final ArchiveException ex = assertThrows(ArchiveException.class, () -> DumpArchiveInputStream.builder()
+                .setByteArray(createArchive(ntrec))
+                .get());
+        assertInstanceOf(ArchiveException.class, ex.getCause());
+        assertTrue(ex.getMessage().contains(Integer.toString(ntrec)), "message should contain the invalid ntrec value");
     }
 
-    private InputStream createArchive(final int ntrec) {
+    private byte[] createArchive(final int ntrec) {
         final byte[] dump = new byte[1024 * TP_SIZE];
         int offset = 0;
         // summary
@@ -82,14 +78,15 @@ class DumpArchiveInputStreamTest extends AbstractTest {
         offset += TP_SIZE;
         // BITS segment
         System.arraycopy(createSegment(DumpArchiveConstants.SEGMENT_TYPE.BITS), 0, dump, offset, TP_SIZE);
-        return new ByteArrayInputStream(dump);
+        return dump;
     }
 
     @SuppressWarnings("deprecation")
     @Test
     void testConsumesArchiveCompletely() throws Exception {
         try (InputStream is = DumpArchiveInputStreamTest.class.getResourceAsStream("/archive_with_trailer.dump");
-                DumpArchiveInputStream dump = new DumpArchiveInputStream(is)) {
+                DumpArchiveInputStream dump =
+                        DumpArchiveInputStream.builder().setInputStream(is).get()) {
             while (dump.getNextDumpEntry() != null) {
                 // just consume the archive
             }
@@ -102,33 +99,37 @@ class DumpArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testDirectoryNullBytes() throws Exception {
-        try (InputStream is = newInputStream("org/apache/commons/compress/dump/directory_null_bytes-fail.dump");
-                DumpArchiveInputStream archive = new DumpArchiveInputStream(is)) {
+        try (DumpArchiveInputStream archive = DumpArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/dump/directory_null_bytes-fail.dump"))
+                .get()) {
             assertThrows(InvalidFormatException.class, archive::getNextEntry);
         }
     }
 
     @Test
     void testGetNextEntry() throws IOException {
-        try (DumpArchiveInputStream inputStream = new DumpArchiveInputStream(
-                Files.newInputStream(Paths.get("src/test/resources/org/apache/commons/compress/dump/getNextEntry.bin")))) {
+        try (DumpArchiveInputStream inputStream = DumpArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/dump/getNextEntry.bin"))
+                .get()) {
             assertThrows(ArchiveException.class, inputStream::getNextEntry);
         }
     }
 
     @Test
-    void testInvalidCompressType() throws Exception {
-        try (InputStream is = newInputStream("org/apache/commons/compress/dump/invalid_compression_type-fail.dump")) {
-            final ArchiveException ex = assertThrows(ArchiveException.class, () -> new DumpArchiveInputStream(is).close());
-            assertInstanceOf(UnsupportedCompressionAlgorithmException.class, ex.getCause());
-        }
+    void testInvalidCompressType() {
+        final ArchiveException ex = assertThrows(ArchiveException.class, () -> DumpArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/dump/invalid_compression_type-fail.dump"))
+                .get()
+                .close());
+        assertInstanceOf(UnsupportedCompressionAlgorithmException.class, ex.getCause());
     }
 
     @Test
     @Timeout(value = 15, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
     void testLoopingInodes() throws Exception {
-        try (InputStream is = newInputStream("org/apache/commons/compress/dump/looping_inodes-fail.dump");
-                DumpArchiveInputStream archive = new DumpArchiveInputStream(is)) {
+        try (DumpArchiveInputStream archive = DumpArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/dump/looping_inodes-fail.dump"))
+                .get()) {
             archive.getNextEntry();
             assertThrows(DumpArchiveException.class, archive::getNextEntry);
         }
@@ -137,8 +138,8 @@ class DumpArchiveInputStreamTest extends AbstractTest {
     @Test
     void testMultiByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
         final byte[] buf = new byte[2];
-        try (InputStream in = newInputStream("bla.dump");
-                DumpArchiveInputStream archive = new DumpArchiveInputStream(in)) {
+        try (DumpArchiveInputStream archive =
+                DumpArchiveInputStream.builder().setURI(getURI("bla.dump")).get()) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read(buf));
@@ -147,25 +148,34 @@ class DumpArchiveInputStreamTest extends AbstractTest {
     }
 
     @Test
-    void testNotADumpArchive() throws Exception {
-        try (InputStream is = newInputStream("bla.zip")) {
-            final ArchiveException ex = assertThrows(ArchiveException.class, () -> new DumpArchiveInputStream(is).close(), "expected an exception");
-            assertTrue(ex.getCause() instanceof ShortFileException);
-        }
+    void testNotADumpArchive() {
+        final ArchiveException ex = assertThrows(
+                ArchiveException.class,
+                () -> DumpArchiveInputStream.builder()
+                        .setURI(getURI("bla.zip"))
+                        .get()
+                        .close(),
+                "expected an exception");
+        assertTrue(ex.getCause() instanceof ShortFileException);
     }
 
     @Test
     void testNotADumpArchiveButBigEnough() throws Exception {
-        try (InputStream is = newInputStream("zip64support.tar.bz2")) {
-            final ArchiveException ex = assertThrows(ArchiveException.class, () -> new DumpArchiveInputStream(is).close(), "expected an exception");
-            assertInstanceOf(UnrecognizedFormatException.class, ex.getCause());
-        }
+        final ArchiveException ex = assertThrows(
+                ArchiveException.class,
+                () -> DumpArchiveInputStream.builder()
+                        .setURI(getURI("zip64support.tar.bz2"))
+                        .get()
+                        .close(),
+                "expected an exception");
+        assertInstanceOf(UnrecognizedFormatException.class, ex.getCause());
     }
 
     @Test
     void testRecLenZeroLongExecution() throws Exception {
-        try (InputStream is = newInputStream("org/apache/commons/compress/dump/reclen_zero-fail.dump");
-                DumpArchiveInputStream archive = new DumpArchiveInputStream(is)) {
+        try (DumpArchiveInputStream archive = DumpArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/dump/reclen_zero-fail.dump"))
+                .get()) {
             assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
                 assertThrows(DumpArchiveException.class, archive::getNextEntry);
             });
@@ -174,8 +184,8 @@ class DumpArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testSingleByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
-        try (InputStream in = newInputStream("bla.dump");
-                DumpArchiveInputStream archive = new DumpArchiveInputStream(in)) {
+        try (DumpArchiveInputStream archive =
+                DumpArchiveInputStream.builder().setURI(getURI("bla.dump")).get()) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read());

--- a/src/test/java/org/apache/commons/compress/archivers/dump/TapeInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/dump/TapeInputStreamTest.java
@@ -22,9 +22,6 @@ package org.apache.commons.compress.archivers.dump;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.CompressException;
@@ -44,13 +41,14 @@ class TapeInputStreamTest extends AbstractTest {
     }
 
     @Test
-    void testResetBlockSizeBadSignature() throws IOException {
-        assertThrows(ArchiveException.class,
-                () -> new DumpArchiveInputStream(Files.newInputStream(Paths.get("src/test/resources/org/apache/commons/compress/dump/resetBlockSize.bin"))));
+    void testResetBlockSizeBadSignature() {
+        assertThrows(ArchiveException.class, () -> DumpArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/dump/resetBlockSize.bin"))
+                .get());
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { Integer.MAX_VALUE / 1000, Integer.MAX_VALUE })
+    @ValueSource(ints = {Integer.MAX_VALUE / 1000, Integer.MAX_VALUE})
     void testResetBlockSizeMemoryLimit(final int recsPerBlock) throws Exception {
         try (TapeInputStream tapeInputStream = new TapeInputStream(new ByteArrayInputStream(new byte[1]))) {
             // CompressException works from both the Maven command line and within Eclipse

--- a/src/test/java/org/apache/commons/compress/archivers/tar/BigFilesIT.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/BigFilesIT.java
@@ -40,7 +40,8 @@ public class BigFilesIT extends AbstractTest {
     private void readFileBiggerThan8GByte(final String name) throws Exception {
         try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(name)));
                 GzipCompressorInputStream gzin = new GzipCompressorInputStream(in);
-                TarArchiveInputStream tin = new TarArchiveInputStream(gzin)) {
+                TarArchiveInputStream tin =
+                        TarArchiveInputStream.builder().setInputStream(gzin).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertEquals(8200L * 1024 * 1024, e.getSize());
@@ -77,7 +78,8 @@ public class BigFilesIT extends AbstractTest {
     void testReadFileHeadersOfArchiveBiggerThan8GByte() throws Exception {
         try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath("8.posix.tar.gz")));
                 GzipCompressorInputStream gzin = new GzipCompressorInputStream(in);
-                TarArchiveInputStream tin = new TarArchiveInputStream(gzin)) {
+                TarArchiveInputStream tin =
+                        TarArchiveInputStream.builder().setInputStream(gzin).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertNull(tin.getNextTarEntry());

--- a/src/test/java/org/apache/commons/compress/archivers/tar/Compress700Test.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/Compress700Test.java
@@ -27,9 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.Arrays;
@@ -38,19 +35,20 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests https://issues.apache.org/jira/browse/COMPRESS-699
  */
-class Compress700Test {
+class Compress700Test extends AbstractTest {
 
-    private static final Path PATH = Paths.get("src/test/resources/org/apache/commons/compress/COMPRESS-700/flutter_awesome_buttons-0.1.0.tar");
+    private static final String RESOURCE_NAME = "org/apache/commons/compress/COMPRESS-700/flutter_awesome_buttons-0.1.0.tar";
 
     @Test
     void testFirstTarArchiveEntry() throws Exception {
-        try (TarArchiveInputStream inputStream = new TarArchiveInputStream(new BufferedInputStream(Files.newInputStream(PATH)))) {
+        try (TarArchiveInputStream inputStream = TarArchiveInputStream.builder().setURI(getURI(RESOURCE_NAME)).get()) {
             final TarArchiveEntry entry = inputStream.getNextEntry();
             assertNull(entry.getCreationTime());
             assertEquals(-1, entry.getDataOffset());
@@ -175,7 +173,7 @@ class Compress700Test {
                 new Object[] {9879,  "README.md"},
                 new Object[] {433,   "test/flutter_buttons_test.dart"});
         // @formatter:on
-        try (TarArchiveInputStream inputStream = new TarArchiveInputStream(new BufferedInputStream(Files.newInputStream(PATH)))) {
+        try (TarArchiveInputStream inputStream = TarArchiveInputStream.builder().setURI(getURI(RESOURCE_NAME)).get()) {
             final AtomicInteger i = new AtomicInteger();
             for (final Object[] pair : list) {
                 final TarArchiveEntry entry = inputStream.getNextEntry();
@@ -195,7 +193,7 @@ class Compress700Test {
     //@Ignore
     @Test
     void testTarArchive() throws Exception {
-        try (BufferedInputStream fileInputStream = new BufferedInputStream(Files.newInputStream(PATH))) {
+        try (BufferedInputStream fileInputStream = new BufferedInputStream(newInputStream(RESOURCE_NAME))) {
             assertEquals(ArchiveStreamFactory.TAR, ArchiveStreamFactory.detect(fileInputStream));
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/FileTimesIT.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/FileTimesIT.java
@@ -24,9 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.BufferedInputStream;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 
@@ -49,8 +46,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarEpax() throws Exception {
         final String file = "COMPRESS-612/test-times-epax-folder.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -79,8 +75,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarExustar() throws Exception {
         final String file = "COMPRESS-612/test-times-exustar-folder.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertEquals("test/", e.getName());
@@ -109,8 +104,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarGnu() throws Exception {
         final String file = "COMPRESS-612/test-times-gnu.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -127,8 +121,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarGnuIncremental() throws Exception {
         final String file = "COMPRESS-612/test-times-gnu-incremental.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -154,8 +147,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarGnuTar() throws Exception {
         final String file = "COMPRESS-612/test-times-gnutar.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -171,8 +163,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarOldBsdTar() throws Exception {
         final String file = "COMPRESS-612/test-times-oldbsdtar.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -189,8 +180,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarOldGnu() throws Exception {
         final String file = "COMPRESS-612/test-times-oldgnu.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -207,8 +197,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarOldGnuIncremental() throws Exception {
         final String file = "COMPRESS-612/test-times-oldgnu-incremental.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -234,8 +223,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarPax() throws Exception {
         final String file = "COMPRESS-612/test-times-pax-folder.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -265,8 +253,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarPosix() throws Exception {
         final String file = "COMPRESS-612/test-times-posix.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -283,8 +270,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarPosixLibArchive() throws Exception {
         final String file = "COMPRESS-612/test-times-bsd-folder.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -314,8 +300,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarPosixLinux() throws Exception {
         final String file = "COMPRESS-612/test-times-posix-linux.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -331,8 +316,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarStarFolder() throws Exception {
         final String file = "COMPRESS-612/test-times-star-folder.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -360,8 +344,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarUstar() throws Exception {
         final String file = "COMPRESS-612/test-times-ustar.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -377,8 +360,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarV7() throws Exception {
         final String file = "COMPRESS-612/test-times-v7.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -394,8 +376,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarXstar() throws Exception {
         final String file = "COMPRESS-612/test-times-xstar.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -411,8 +392,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarXstarFolder() throws Exception {
         final String file = "COMPRESS-612/test-times-xstar-folder.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -440,8 +420,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarXstarIncremental() throws Exception {
         final String file = "COMPRESS-612/test-times-xstar-incremental.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -466,8 +445,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarXustar() throws Exception {
         final String file = "COMPRESS-612/test-times-xustar.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -483,8 +461,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarXustarFolder() throws Exception {
         final String file = "COMPRESS-612/test-times-xustar-folder.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());
@@ -512,8 +489,7 @@ public class FileTimesIT extends AbstractTest {
     @Test
     void testReadTimeFromTarXustarIncremental() throws Exception {
         final String file = "COMPRESS-612/test-times-xustar-incremental.tar";
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(getPath(file)));
-                TarArchiveInputStream tin = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setURI(getURI(file)).get()) {
             TarArchiveEntry e = tin.getNextTarEntry();
             assertNotNull(e);
             assertTrue(e.getExtraPaxHeaders().isEmpty());

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -116,7 +115,8 @@ class SparseFilesTest extends AbstractTest {
     @Test
     void testCompareTarArchiveInputStreamWithTarFile() throws IOException {
         final Path file = getPath("oldgnu_sparse.tar");
-        try (TarArchiveInputStream tarIn = new TarArchiveInputStream(new BufferedInputStream(Files.newInputStream(file)));
+        try (TarArchiveInputStream tarIn =
+                        TarArchiveInputStream.builder().setPath(file).get();
                 TarFile tarFile = new TarFile(file)) {
             assertNotNull(tarIn.getNextTarEntry());
             try (InputStream inputStream = tarFile.getInputStream(tarFile.getEntries().get(0))) {
@@ -130,7 +130,7 @@ class SparseFilesTest extends AbstractTest {
     void testExtractExtendedOldGNU() throws IOException, InterruptedException {
         final File file = getFile("oldgnu_extended_sparse.tar");
         try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparse6");
-                TarArchiveInputStream tin = new TarArchiveInputStream(Files.newInputStream(file.toPath()))) {
+                TarArchiveInputStream tin = TarArchiveInputStream.builder().setFile(file).get()) {
             final TarArchiveEntry ae = tin.getNextTarEntry();
             assertTrue(tin.canReadEntryData(ae));
 
@@ -168,7 +168,7 @@ class SparseFilesTest extends AbstractTest {
         try {
             final File file = getFile("oldgnu_sparse.tar");
             try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile");
-                    TarArchiveInputStream tin = new TarArchiveInputStream(Files.newInputStream(file.toPath()))) {
+                    TarArchiveInputStream tin = TarArchiveInputStream.builder().setFile(file).get()) {
                 final TarArchiveEntry entry = tin.getNextTarEntry();
                 assertTrue(tin.canReadEntryData(entry));
                 assertArrayEquals(IOUtils.toByteArray(tin), IOUtils.toByteArray(sparseFileInputStream));
@@ -188,7 +188,7 @@ class SparseFilesTest extends AbstractTest {
         assumeFalse(getTarBinaryHelp().startsWith("tar (GNU tar) 1.28"), "This test should be ignored if GNU tar is version 1.28");
 
         final File file = getFile("pax_gnu_sparse.tar");
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(Files.newInputStream(file.toPath()))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setFile(file).get()) {
 
             TarArchiveEntry paxGNUEntry = tin.getNextTarEntry();
             assertTrue(tin.canReadEntryData(paxGNUEntry));
@@ -215,12 +215,12 @@ class SparseFilesTest extends AbstractTest {
     void testExtractSparseTarsOnWindows() throws IOException {
         final File oldGNUSparseTar = getFile("oldgnu_sparse.tar");
         final File paxGNUSparseTar = getFile("pax_gnu_sparse.tar");
-        try (TarArchiveInputStream paxGNUSparseInputStream = new TarArchiveInputStream(Files.newInputStream(paxGNUSparseTar.toPath()))) {
+        try (TarArchiveInputStream paxGNUSparseInputStream = TarArchiveInputStream.builder().setFile(paxGNUSparseTar).get()) {
 
             // compare between old GNU and PAX 0.0
             TarArchiveEntry paxGNUEntry = paxGNUSparseInputStream.getNextTarEntry();
             assertTrue(paxGNUSparseInputStream.canReadEntryData(paxGNUEntry));
-            try (TarArchiveInputStream oldGNUSparseInputStream = new TarArchiveInputStream(Files.newInputStream(oldGNUSparseTar.toPath()))) {
+            try (TarArchiveInputStream oldGNUSparseInputStream = TarArchiveInputStream.builder().setFile(oldGNUSparseTar).get()) {
                 final TarArchiveEntry oldGNUEntry = oldGNUSparseInputStream.getNextTarEntry();
                 assertTrue(oldGNUSparseInputStream.canReadEntryData(oldGNUEntry));
                 assertArrayEquals(IOUtils.toByteArray(oldGNUSparseInputStream), IOUtils.toByteArray(paxGNUSparseInputStream));
@@ -229,7 +229,7 @@ class SparseFilesTest extends AbstractTest {
             // compare between old GNU and PAX 0.1
             paxGNUEntry = paxGNUSparseInputStream.getNextTarEntry();
             assertTrue(paxGNUSparseInputStream.canReadEntryData(paxGNUEntry));
-            try (TarArchiveInputStream oldGNUSparseInputStream = new TarArchiveInputStream(Files.newInputStream(oldGNUSparseTar.toPath()))) {
+            try (TarArchiveInputStream oldGNUSparseInputStream = TarArchiveInputStream.builder().setFile(oldGNUSparseTar).get()) {
                 final TarArchiveEntry oldGNUEntry = oldGNUSparseInputStream.getNextTarEntry();
                 assertTrue(oldGNUSparseInputStream.canReadEntryData(oldGNUEntry));
                 assertArrayEquals(IOUtils.toByteArray(oldGNUSparseInputStream), IOUtils.toByteArray(paxGNUSparseInputStream));
@@ -238,7 +238,7 @@ class SparseFilesTest extends AbstractTest {
             // compare between old GNU and PAX 1.0
             paxGNUEntry = paxGNUSparseInputStream.getNextTarEntry();
             assertTrue(paxGNUSparseInputStream.canReadEntryData(paxGNUEntry));
-            try (TarArchiveInputStream oldGNUSparseInputStream = new TarArchiveInputStream(Files.newInputStream(oldGNUSparseTar.toPath()))) {
+            try (TarArchiveInputStream oldGNUSparseInputStream = TarArchiveInputStream.builder().setFile(oldGNUSparseTar).get()) {
                 final TarArchiveEntry oldGNUEntry = oldGNUSparseInputStream.getNextTarEntry();
                 assertTrue(oldGNUSparseInputStream.canReadEntryData(oldGNUEntry));
                 assertArrayEquals(IOUtils.toByteArray(oldGNUSparseInputStream), IOUtils.toByteArray(paxGNUSparseInputStream));
@@ -248,8 +248,9 @@ class SparseFilesTest extends AbstractTest {
 
     @Test
     void testOldGNU() throws Throwable {
-        final File file = getFile("oldgnu_sparse.tar");
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(Files.newInputStream(file.toPath()))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder()
+                .setURI(getURI("oldgnu_sparse.tar"))
+                .get()) {
             final TarArchiveEntry ae = tin.getNextTarEntry();
             assertEquals("sparsefile", ae.getName());
             assertEquals(TarConstants.LF_GNUTYPE_SPARSE, ae.getLinkFlag());
@@ -289,8 +290,9 @@ class SparseFilesTest extends AbstractTest {
 
     @Test
     void testPaxGNU() throws Throwable {
-        final File file = getFile("pax_gnu_sparse.tar");
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(Files.newInputStream(file.toPath()))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder()
+                .setURI(getURI("pax_gnu_sparse.tar"))
+                .get()) {
             assertPaxGNUEntry(tin, "0.0");
             assertPaxGNUEntry(tin, "0.1");
             assertPaxGNUEntry(tin, "1.0");

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveEntryTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -100,7 +99,7 @@ class TarArchiveEntryTest implements TarConstants {
         assertNotEquals(0, entry.getExtraPaxHeaders().size(), "should have extra headers before clear");
         entry.clearExtraPaxHeaders();
         assertEquals(0, entry.getExtraPaxHeaders().size(), "extra headers should be empty after clear");
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setByteArray(bos.toByteArray()).get()) {
             entry = tis.getNextTarEntry();
             assertNotNull(entry, "couldn't get entry");
 
@@ -304,7 +303,7 @@ class TarArchiveEntryTest implements TarConstants {
             tos.write('W');
             tos.closeArchiveEntry();
         }
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setByteArray(bos.toByteArray()).get()) {
             final TarArchiveEntry entry = tis.getNextTarEntry();
             assertNotNull(entry, "couldn't get entry");
 
@@ -351,7 +350,7 @@ class TarArchiveEntryTest implements TarConstants {
             tos.write('W');
             tos.closeArchiveEntry();
         }
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setByteArray(bos.toByteArray()).get()) {
             final TarArchiveEntry entry = tis.getNextTarEntry();
             assertNotNull(entry, "couldn't get entry");
 
@@ -383,7 +382,7 @@ class TarArchiveEntryTest implements TarConstants {
             tos.write('W');
             tos.closeArchiveEntry();
         }
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setByteArray(bos.toByteArray()).get()) {
             final TarArchiveEntry entry = tis.getNextTarEntry();
             assertNotNull(entry, "couldn't get entry");
 
@@ -414,7 +413,7 @@ class TarArchiveEntryTest implements TarConstants {
             tos.write('W');
             tos.closeArchiveEntry();
         }
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder().setByteArray(bos.toByteArray()).get()) {
             final TarArchiveEntry entry = tis.getNextTarEntry();
             assertNotNull(entry, "couldn't get entry");
 
@@ -460,7 +459,7 @@ class TarArchiveEntryTest implements TarConstants {
                 tout.write(new byte[] { '!' });
                 tout.closeArchiveEntry();
             }
-            try (TarArchiveInputStream tin = new TarArchiveInputStream(Files.newInputStream(f.toPath()))) {
+            try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setFile(f).get()) {
                 // tin.setDebug(true);
                 entry = tin.getNextTarEntry();
                 assertNotNull(entry);

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
@@ -40,7 +40,6 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,7 +69,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class TarArchiveInputStreamTest extends AbstractTest {
 
     private void datePriorToEpoch(final String archive) throws Exception {
-        try (TarArchiveInputStream in = new TarArchiveInputStream(Files.newInputStream(getFile(archive).toPath()))) {
+        try (TarArchiveInputStream in = getTestStream(archive)) {
             final TarArchiveEntry tae = in.getNextTarEntry();
             assertEquals("foo", tae.getName());
             assertEquals(TarConstants.LF_NORMAL, tae.getLinkFlag());
@@ -88,14 +87,18 @@ class TarArchiveInputStreamTest extends AbstractTest {
     }
 
     @SuppressWarnings("resource") // Caller closes
-    private TarArchiveInputStream getTestStream(final String name) {
-        return new TarArchiveInputStream(TarArchiveInputStreamTest.class.getResourceAsStream(name));
+    private static TarArchiveInputStream getTestStream(final String name) throws IOException {
+        return TarArchiveInputStream.builder()
+                .setURI(getURI(name))
+                .get();
     }
 
     @Test
     void testChecksumOnly4Byte() throws IOException {
-        try (InputStream in = newInputStream("org/apache/commons/compress/COMPRESS-707/COMPRESS-707-lenient.tar");
-                TarArchiveInputStream archive = TarArchiveInputStream.builder().setInputStream(in).setLenient(true).get()) {
+        try (TarArchiveInputStream archive = TarArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/COMPRESS-707/COMPRESS-707-lenient.tar"))
+                .setLenient(true)
+                .get()) {
             final TarArchiveEntry nextEntry = archive.getNextEntry();
             assertNotNull(nextEntry);
             assertEquals("hi-gary.txt", nextEntry.getName());
@@ -105,7 +108,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testCompress197() throws IOException {
-        try (TarArchiveInputStream tar = getTestStream("/COMPRESS-197.tar")) {
+        try (TarArchiveInputStream tar = getTestStream("COMPRESS-197.tar")) {
             TarArchiveEntry entry = tar.getNextTarEntry();
             assertNotNull(entry);
             while (entry != null) {
@@ -117,7 +120,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testCompress197ForEach() throws IOException {
-        try (TarArchiveInputStream tar = getTestStream("/COMPRESS-197.tar")) {
+        try (TarArchiveInputStream tar = getTestStream("COMPRESS-197.tar")) {
             tar.forEach(IOConsumer.noop());
         }
     }
@@ -144,8 +147,8 @@ class TarArchiveInputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (ByteArrayInputStream bis = new ByteArrayInputStream(data);
-                TarArchiveInputStream tis = new TarArchiveInputStream(bis)) {
+        try (TarArchiveInputStream tis =
+                TarArchiveInputStream.builder().setByteArray(data).get()) {
             assertEquals(folderName, tis.getNextTarEntry().getName());
             assertEquals(TarConstants.LF_DIR, tis.getCurrentEntry().getLinkFlag());
             assertEquals(consumerJavaName, tis.getNextTarEntry().getName());
@@ -268,7 +271,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testGetAndSetOfPaxEntry() throws Exception {
-        try (TarArchiveInputStream is = getTestStream("/COMPRESS-356.tar")) {
+        try (TarArchiveInputStream is = getTestStream("COMPRESS-356.tar")) {
             final TarArchiveEntry entry = is.getNextTarEntry();
             assertEquals("package/package.json", entry.getName());
             assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
@@ -293,8 +296,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testGetNextEntry() throws IOException {
-        try (TarArchiveInputStream inputStream = new TarArchiveInputStream(
-                Files.newInputStream(Paths.get("src/test/resources/org/apache/commons/compress/tar/getNextTarEntry.bin")))) {
+        try (TarArchiveInputStream inputStream = getTestStream("org/apache/commons/compress/tar/getNextTarEntry.bin")) {
             final AtomicLong count = new AtomicLong();
             final TarArchiveEntry entry = inputStream.getNextEntry();
             assertNull(entry.getCreationTime());
@@ -331,8 +333,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testGetNextTarEntryDeprecated() throws IOException {
-        try (TarArchiveInputStream inputStream = new TarArchiveInputStream(
-                Files.newInputStream(Paths.get("src/test/resources/org/apache/commons/compress/tar/getNextTarEntry.bin")))) {
+        try (TarArchiveInputStream inputStream = getTestStream("org/apache/commons/compress/tar/getNextTarEntry.bin")) {
             final AtomicLong count = new AtomicLong();
             final TarArchiveEntry entry = inputStream.getNextTarEntry();
             assertNull(entry.getCreationTime());
@@ -367,8 +368,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
     @Test
     void testMultiByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
         final byte[] buf = new byte[2];
-        try (InputStream in = newInputStream("bla.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("bla.tar")) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read(buf));
@@ -378,32 +378,28 @@ class TarArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testParseTarTruncatedInContent() throws IOException {
-        try (InputStream in = newInputStream("COMPRESS-544_truncated_in_content-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("COMPRESS-544_truncated_in_content-fail.tar")) {
             getNextEntryUntilIOException(archive);
         }
     }
 
     @Test
     void testParseTarTruncatedInPadding() throws IOException {
-        try (InputStream in = newInputStream("COMPRESS-544_truncated_in_padding-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("COMPRESS-544_truncated_in_padding-fail.tar")) {
             getNextEntryUntilIOException(archive);
         }
     }
 
     @Test
     void testParseTarWithNonNumberPaxHeaders() throws IOException {
-        try (InputStream in = newInputStream("COMPRESS-529-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("COMPRESS-529-fail.tar")) {
             assertThrows(ArchiveException.class, () -> archive.getNextEntry());
         }
     }
 
     @Test
     void testParseTarWithSpecialPaxHeaders() throws IOException {
-        try (InputStream in = newInputStream("COMPRESS-530-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("COMPRESS-530-fail.tar")) {
             assertThrows(ArchiveException.class, () -> archive.getNextEntry());
             assertThrows(ArchiveException.class, () -> IOUtils.toByteArray(archive));
         }
@@ -414,8 +410,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testPaxHeaders() throws IOException {
-        try (TarArchiveInputStream inputStream = new TarArchiveInputStream(
-                Files.newInputStream(Paths.get("src/test/resources/org/apache/commons/compress/tar/paxHeaders.bin")))) {
+        try (TarArchiveInputStream inputStream = getTestStream("org/apache/commons/compress/tar/paxHeaders.bin")) {
             assertThrows(ArchiveException.class, inputStream::getNextEntry);
         }
     }
@@ -424,7 +419,8 @@ class TarArchiveInputStreamTest extends AbstractTest {
     void testReadsArchiveCompletely_COMPRESS245() {
         try (InputStream is = TarArchiveInputStreamTest.class.getResourceAsStream("/COMPRESS-245.tar.gz")) {
             final InputStream gin = new GZIPInputStream(is);
-            try (TarArchiveInputStream tar = new TarArchiveInputStream(gin)) {
+            try (TarArchiveInputStream tar =
+                    TarArchiveInputStream.builder().setInputStream(gin).get()) {
                 int count = 0;
                 TarArchiveEntry entry = tar.getNextTarEntry();
                 while (entry != null) {
@@ -440,8 +436,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testRejectsArchivesWithNegativeSizes() throws Exception {
-        try (InputStream in = newInputStream("COMPRESS-569-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("COMPRESS-569-fail.tar")) {
             getNextEntryUntilIOException(archive);
         }
     }
@@ -452,7 +447,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
     @Test
     void testShouldConsumeArchiveCompletely() throws Exception {
         try (InputStream is = TarArchiveInputStreamTest.class.getResourceAsStream("/archive_with_trailer.tar");
-                TarArchiveInputStream tar = new TarArchiveInputStream(is)) {
+                TarArchiveInputStream tar = TarArchiveInputStream.builder().setInputStream(is).get()) {
             while (tar.getNextTarEntry() != null) {
                 // just consume the archive
             }
@@ -476,8 +471,8 @@ class TarArchiveInputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        final ByteArrayInputStream bis = new ByteArrayInputStream(data);
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(bis)) {
+        try (TarArchiveInputStream tis =
+                TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry t = tis.getNextTarEntry();
             assertEquals(4294967294L, t.getLongGroupId());
         }
@@ -488,7 +483,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testShouldReadGNULongNameEntryWithWrongName() throws Exception {
-        try (TarArchiveInputStream is = getTestStream("/COMPRESS-324.tar")) {
+        try (TarArchiveInputStream is = getTestStream("COMPRESS-324.tar")) {
             final TarArchiveEntry entry = is.getNextTarEntry();
             assertEquals(
                     "1234567890123456789012345678901234567890123456789012345678901234567890"
@@ -501,7 +496,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
     @Test
     void testShouldThrowAnExceptionOnTruncatedEntries() throws Exception {
         final Path dir = createTempDirectory("COMPRESS-279");
-        try (TarArchiveInputStream is = getTestStream("/COMPRESS-279-fail.tar")) {
+        try (TarArchiveInputStream is = getTestStream("COMPRESS-279-fail.tar")) {
             assertThrows(ArchiveException.class, () -> {
                 TarArchiveEntry entry = is.getNextTarEntry();
                 int count = 0;
@@ -517,7 +512,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
     @Test
     void testShouldThrowAnExceptionOnTruncatedStream() throws Exception {
         final Path dir = createTempDirectory("COMPRESS-279");
-        try (TarArchiveInputStream is = getTestStream("/COMPRESS-279-fail.tar")) {
+        try (TarArchiveInputStream is = getTestStream("COMPRESS-279-fail.tar")) {
             final AtomicInteger count = new AtomicInteger();
             assertThrows(ArchiveException.class, () -> is.forEach(entry -> Files.copy(is, dir.resolve(String.valueOf(count.getAndIncrement())))));
         }
@@ -538,7 +533,10 @@ class TarArchiveInputStreamTest extends AbstractTest {
         }
         final byte[] data = bos.toByteArray();
         final ByteArrayInputStream bis = new ByteArrayInputStream(data);
-        try (TarArchiveInputStream tis = new TarArchiveInputStream(bis, encoding)) {
+        try (TarArchiveInputStream tis = TarArchiveInputStream.builder()
+                .setByteArray(data)
+                .setCharset(encoding)
+                .get()) {
             final TarArchiveEntry t = tis.getNextTarEntry();
             assertEquals(name, t.getName());
         }
@@ -546,8 +544,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testSingleByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
-        try (InputStream in = newInputStream("bla.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("bla.tar")) {
             assertNotNull(archive.getNextEntry());
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read());
@@ -560,7 +557,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testSkipsDevNumbersWhenEntryIsNoDevice() throws Exception {
-        try (TarArchiveInputStream is = getTestStream("/COMPRESS-417.tar")) {
+        try (TarArchiveInputStream is = getTestStream("COMPRESS-417.tar")) {
             assertEquals("test1.xml", is.getNextTarEntry().getName());
             assertEquals(TarConstants.LF_NORMAL, is.getCurrentEntry().getLinkFlag());
             assertEquals("test2.xml", is.getNextTarEntry().getName());
@@ -574,7 +571,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testSurvivesBlankLinesInPaxHeader() throws Exception {
-        try (TarArchiveInputStream is = getTestStream("/COMPRESS-355.tar")) {
+        try (TarArchiveInputStream is = getTestStream("COMPRESS-355.tar")) {
             final TarArchiveEntry entry = is.getNextTarEntry();
             assertEquals("package/package.json", entry.getName());
             assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
@@ -587,7 +584,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
      */
     @Test
     void testSurvivesPaxHeaderWithNameEndingInSlash() throws Exception {
-        try (TarArchiveInputStream is = getTestStream("/COMPRESS-356.tar")) {
+        try (TarArchiveInputStream is = getTestStream("COMPRESS-356.tar")) {
             final TarArchiveEntry entry = is.getNextTarEntry();
             assertEquals("package/package.json", entry.getName());
             assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
@@ -597,23 +594,21 @@ class TarArchiveInputStreamTest extends AbstractTest {
 
     @Test
     void testThrowException() throws IOException {
-        try (InputStream in = newInputStream("COMPRESS-553-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("COMPRESS-553-fail.tar")) {
             getNextEntryUntilIOException(archive);
         }
     }
 
     @Test
     void testThrowExceptionWithNullEntry() throws IOException {
-        try (InputStream in = newInputStream("COMPRESS-554-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = getTestStream("COMPRESS-554-fail.tar")) {
             getNextEntryUntilIOException(archive);
         }
     }
 
     @Test
     void testWorkaroundForBrokenTimeHeader() throws Exception {
-        try (TarArchiveInputStream in = new TarArchiveInputStream(newInputStream("simple-aix-native-tar.tar"))) {
+        try (TarArchiveInputStream in = getTestStream("simple-aix-native-tar.tar")) {
             TarArchiveEntry tae = in.getNextTarEntry();
             tae = in.getNextTarEntry();
             assertEquals("sample/link-to-txt-file.lnk", tae.getName());

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveOutputStreamTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -109,7 +108,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         final byte[] data = bos.toByteArray();
         assertEquals("00000000000 ",
                 new String(data, 1024 + TarConstants.NAMELEN + TarConstants.MODELEN + TarConstants.UIDLEN + TarConstants.GIDLEN, 12, UTF_8));
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(0100000000000L, e.getSize());
         }
@@ -130,7 +129,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         tos.write(new byte[10 * 1024]);
         final byte[] data = bos.toByteArray();
         assertEquals(0x80, data[TarConstants.NAMELEN + TarConstants.MODELEN + TarConstants.UIDLEN + TarConstants.GIDLEN] & 0x80);
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(0100000000000L, e.getSize());
         }
@@ -209,7 +208,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         // do I still have the correct modification date?
         // let a second elapse, so we don't get the current time
         Thread.sleep(1000);
-        try (TarArchiveInputStream tarIn = new TarArchiveInputStream(new ByteArrayInputStream(archive2))) {
+        try (TarArchiveInputStream tarIn = TarArchiveInputStream.builder().setByteArray(archive2).get()) {
             final ArchiveEntry nextEntry = tarIn.getNextEntry();
             assertEquals(longFileName, nextEntry.getName());
             // tar archive stores modification time to second granularity only (floored)
@@ -252,7 +251,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         final byte[] data = bos.toByteArray();
         assertEquals("00000000000 ", new String(data,
                 1024 + TarConstants.NAMELEN + TarConstants.MODELEN + TarConstants.UIDLEN + TarConstants.GIDLEN + TarConstants.SIZELEN, 12, UTF_8));
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             final Calendar cal = Calendar.getInstance(TimeZones.GMT);
             cal.set(1969, 11, 31, 23, 59, 59);
@@ -277,7 +276,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         tos.write(new byte[10 * 1024]);
         final byte[] data = bos.toByteArray();
         assertEquals((byte) 0xff, data[TarConstants.NAMELEN + TarConstants.MODELEN + TarConstants.UIDLEN + TarConstants.GIDLEN + TarConstants.SIZELEN]);
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             final Calendar cal = Calendar.getInstance(TimeZones.GMT);
             cal.set(1969, 11, 31, 23, 59, 59);
@@ -359,7 +358,8 @@ class TarArchiveOutputStreamTest extends AbstractTest {
             tos.write(y.getBytes());
             tos.closeArchiveEntry();
         }
-        final TarArchiveInputStream in = new TarArchiveInputStream(new ByteArrayInputStream(bos.toByteArray()));
+        final TarArchiveInputStream in =
+                TarArchiveInputStream.builder().setByteArray(bos.toByteArray()).get();
         TarArchiveEntry entryIn = in.getNextTarEntry();
         assertNotNull(entryIn);
         assertEquals("message", entryIn.getName());
@@ -403,7 +403,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             assertEquals(n, tin.getNextTarEntry().getName());
         }
     }
@@ -435,7 +435,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getName());
             assertTrue(e.isDirectory());
@@ -491,7 +491,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n.substring(0, TarConstants.NAMELEN) + "/", e.getName(), "Entry name");
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
@@ -516,7 +516,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
             final byte[] data = bos.toByteArray();
             assertEquals("160 path=" + n + "\n", new String(data, 512, 160, UTF_8));
-            try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+            try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
                 assertEquals(n, tin.getNextTarEntry().getName());
                 assertEquals(TarConstants.LF_NORMAL, tin.getCurrentEntry().getLinkFlag());
             }
@@ -549,7 +549,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         }
 
         final byte[] data = bos.toByteArray();
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals("test", e.getName(), "Entry name");
             assertEquals(linkName, e.getLinkName(), "Link name");
@@ -609,7 +609,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         }
 
         final byte[] data = bos.toByteArray();
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(linkName.substring(0, TarConstants.NAMELEN), e.getLinkName(), "Link name");
             assertEquals(TarConstants.LF_SYMLINK, e.getLinkFlag(), "Link flag");
@@ -630,7 +630,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getName());
             assertEquals(TarConstants.LF_DIR, e.getLinkFlag());
@@ -653,7 +653,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         }
         final byte[] data = bos.toByteArray();
         assertEquals("15 linkpath=" + n + "\n", new String(data, 512, 15, UTF_8));
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getLinkName());
             assertEquals(TarConstants.LF_LINK, e.getLinkFlag(), "Link flag");
@@ -674,7 +674,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());
@@ -696,7 +696,7 @@ class TarArchiveOutputStreamTest extends AbstractTest {
         }
         final byte[] data = bos.toByteArray();
         assertEquals("11 path=" + n + "\n", new String(data, 512, 11, UTF_8));
-        try (TarArchiveInputStream tin = new TarArchiveInputStream(new ByteArrayInputStream(data))) {
+        try (TarArchiveInputStream tin = TarArchiveInputStream.builder().setByteArray(data).get()) {
             final TarArchiveEntry e = tin.getNextTarEntry();
             assertEquals(n, e.getName());
             assertEquals(TarConstants.LF_NORMAL, e.getLinkFlag());

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarLister.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarLister.java
@@ -19,10 +19,7 @@
 
 package org.apache.commons.compress.archivers.tar;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.InputStream;
-import java.nio.file.Files;
 
 /**
  * Simple command line application that lists the contents of a tar archive.
@@ -87,8 +84,12 @@ public final class TarLister {
         if (!f.isFile()) {
             System.err.println(f + " doesn't exist or is a directory");
         }
-        try (InputStream fis = new BufferedInputStream(Files.newInputStream(f.toPath()));
-                TarArchiveInputStream ais = args.length > 1 ? new TarArchiveInputStream(fis, args[1]) : new TarArchiveInputStream(fis)) {
+        TarArchiveInputStream.Builder tarBuilder =
+                TarArchiveInputStream.builder().setFile(f);
+        if (args.length > 1) {
+            tarBuilder = tarBuilder.setCharset(args[1]);
+        }
+        try (TarArchiveInputStream ais = tarBuilder.get()) {
             System.out.println("Created " + ais);
             TarArchiveEntry ae;
             while ((ae = ais.getNextTarEntry()) != null) {

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarMemoryFileSystemTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarMemoryFileSystemTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -63,8 +62,8 @@ class TarMemoryFileSystemTest {
                 tarOut.closeArchiveEntry();
             }
 
-            try (InputStream input = Files.newInputStream(target);
-                    TarArchiveInputStream tarIn = new TarArchiveInputStream(input)) {
+            try (TarArchiveInputStream tarIn =
+                    TarArchiveInputStream.builder().setPath(target).get()) {
                 final TarArchiveEntry nextTarEntry = tarIn.getNextTarEntry();
 
                 assertEquals(user, nextTarEntry.getUserName());

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -389,8 +389,9 @@ class TarUtilsTest extends AbstractTest {
 
     @Test
     void testParseTarWithSpecialPaxHeaders() throws IOException {
-        try (InputStream in = newInputStream("COMPRESS-530-fail.tar");
-                TarArchiveInputStream archive = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream archive = TarArchiveInputStream.builder()
+                .setURI(getURI("COMPRESS-530-fail.tar"))
+                .get()) {
             assertThrows(ArchiveException.class, () -> archive.getNextEntry());
             // IOUtils.toByteArray(archive);
         }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/Crash_f2efd9eaeb86cda597d07b5e3c3d81363633c2da_Test.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/Crash_f2efd9eaeb86cda597d07b5e3c3d81363633c2da_Test.java
@@ -20,25 +20,23 @@ package org.apache.commons.compress.archivers.zip;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.archivers.ArchiveEntry;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests https://issues.apache.org/jira/browse/COMPRESS-598
  */
-class Crash_f2efd9eaeb86cda597d07b5e3c3d81363633c2da_Test {
+class Crash_f2efd9eaeb86cda597d07b5e3c3d81363633c2da_Test extends AbstractTest {
 
     @Test
     void test() throws IOException {
-        final byte[] input = FileUtils
-                .readFileToByteArray(new File("src/test/resources/org/apache/commons/compress/fuzz/crash-f2efd9eaeb86cda597d07b5e3c3d81363633c2da"));
-        try (ZipArchiveInputStream zis = new ZipArchiveInputStream(new ByteArrayInputStream(input))) {
+        try (ZipArchiveInputStream zis = ZipArchiveInputStream.builder()
+                .setURI(getURI("org/apache/commons/compress/fuzz/crash-f2efd9eaeb86cda597d07b5e3c3d81363633c2da"))
+                .get()) {
             assertThrows(IOException.class, () -> {
                 for (;;) {
                     final ArchiveEntry zipEntry = zis.getNextEntry();

--- a/src/test/java/org/apache/commons/compress/archivers/zip/EncryptedArchiveTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/EncryptedArchiveTest.java
@@ -19,16 +19,14 @@
 
 package org.apache.commons.compress.archivers.zip;
 
-import static org.apache.commons.compress.AbstractTest.getFile;
+import static org.apache.commons.compress.AbstractTest.getURI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,8 +34,9 @@ class EncryptedArchiveTest {
 
     @Test
     void testReadPasswordEncryptedEntryViaStream() throws IOException {
-        final File file = getFile("password-encrypted.zip");
-        try (ZipArchiveInputStream zin = new ZipArchiveInputStream(Files.newInputStream(file.toPath()))) {
+        try (ZipArchiveInputStream zin = ZipArchiveInputStream.builder()
+                .setURI(getURI("password-encrypted.zip"))
+                .get()) {
             final ZipArchiveEntry zae = zin.getNextZipEntry();
             assertEquals("LICENSE.txt", zae.getName());
             assertTrue(zae.getGeneralPurposeBit().usesEncryption());
@@ -53,7 +52,7 @@ class EncryptedArchiveTest {
 
     @Test
     void testReadPasswordEncryptedEntryViaZipFile() throws IOException {
-        try (ZipFile zf = ZipFile.builder().setFile(getFile("password-encrypted.zip")).get()) {
+        try (ZipFile zf = ZipFile.builder().setURI(getURI("password-encrypted.zip")).get()) {
             final ZipArchiveEntry zae = zf.getEntry("LICENSE.txt");
             assertTrue(zae.getGeneralPurposeBit().usesEncryption());
             assertFalse(zae.getGeneralPurposeBit().usesStrongEncryption());

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ExplodeSupportTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ExplodeSupportTest.java
@@ -25,10 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedOutputStream;
 
@@ -85,7 +83,7 @@ class ExplodeSupportTest {
     }
 
     private void testZipStreamWithImplodeCompression(final String fileName, final String entryName) throws IOException {
-        try (ZipArchiveInputStream zin = new ZipArchiveInputStream(Files.newInputStream(new File(fileName).toPath()))) {
+        try (ZipArchiveInputStream zin = ZipArchiveInputStream.builder().setFile(fileName).get()) {
             final ZipArchiveEntry entry = zin.getNextZipEntry();
             assertEquals(entryName, entry.getName(), "entry name");
             assertTrue(zin.canReadEntryData(entry), "entry can't be read");

--- a/src/test/java/org/apache/commons/compress/archivers/zip/Lister.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/Lister.java
@@ -19,7 +19,6 @@
 
 package org.apache.commons.compress.archivers.zip;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,14 +69,16 @@ public final class Lister {
             usage();
         }
         if (cl.useStream) {
-            try (BufferedInputStream fs = new BufferedInputStream(Files.newInputStream(f.toPath()))) {
-                final ZipArchiveInputStream zs = new ZipArchiveInputStream(fs, cl.encoding, true, cl.allowStoredEntriesWithDataDescriptor);
-                for (ArchiveEntry entry = zs.getNextEntry(); entry != null; entry = zs.getNextEntry()) {
-                    final ZipArchiveEntry ze = (ZipArchiveEntry) entry;
-                    list(ze);
-                    if (cl.dir != null) {
-                        extract(cl.dir, ze, zs);
-                    }
+            final ZipArchiveInputStream zs = ZipArchiveInputStream.builder()
+                    .setFile(f)
+                    .setCharset(cl.encoding)
+                    .setAllowStoredEntriesWithDataDescriptor(cl.allowStoredEntriesWithDataDescriptor)
+                    .get();
+            for (ArchiveEntry entry = zs.getNextEntry(); entry != null; entry = zs.getNextEntry()) {
+                final ZipArchiveEntry ze = (ZipArchiveEntry) entry;
+                list(ze);
+                if (cl.dir != null) {
+                    extract(cl.dir, ze, zs);
                 }
             }
         } else {

--- a/src/test/java/org/apache/commons/compress/archivers/zip/Lister.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/Lister.java
@@ -44,7 +44,7 @@ public final class Lister {
         String archive;
         boolean useStream;
         String encoding;
-        boolean allowStoredEntriesWithDataDescriptor;
+        boolean supportStoredEntryDataDescriptor;
         Path dir;
     }
 
@@ -72,7 +72,7 @@ public final class Lister {
             final ZipArchiveInputStream zs = ZipArchiveInputStream.builder()
                     .setFile(f)
                     .setCharset(cl.encoding)
-                    .setAllowStoredEntriesWithDataDescriptor(cl.allowStoredEntriesWithDataDescriptor)
+                    .setSupportStoredEntryDataDescriptor(cl.supportStoredEntryDataDescriptor)
                     .get();
             for (ArchiveEntry entry = zs.getNextEntry(); entry != null; entry = zs.getNextEntry()) {
                 final ZipArchiveEntry ze = (ZipArchiveEntry) entry;
@@ -117,7 +117,7 @@ public final class Lister {
             } else if (args[i].equals("-stream")) {
                 cl.useStream = true;
             } else if (args[i].equals("+storeddd")) {
-                cl.allowStoredEntriesWithDataDescriptor = true;
+                cl.supportStoredEntryDataDescriptor = true;
             } else if (args[i].equals("-file")) {
                 cl.useStream = false;
             } else if (cl.archive != null) {

--- a/src/test/java/org/apache/commons/compress/archivers/zip/Maven221MultiVolumeTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/Maven221MultiVolumeTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -71,8 +70,10 @@ class Maven221MultiVolumeTest extends AbstractTest {
     @Test
     void testRead7ZipMultiVolumeArchiveForStream() throws IOException {
 
-        try (InputStream archive = newInputStream("apache-maven-2.2.1.zip.001");
-                ZipArchiveInputStream zi = new ZipArchiveInputStream(archive, null, false)) {
+        try (ZipArchiveInputStream zi = ZipArchiveInputStream.builder()
+                .setURI(getURI("apache-maven-2.2.1.zip.001"))
+                .setUseUnicodeExtraFields(false)
+                .get()) {
 
             // these are the entries that are supposed to be processed correctly without any problems.
             for (final String element : ENTRIES) {

--- a/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
@@ -31,7 +31,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.zip.CRC32;
 
 import org.apache.commons.compress.AbstractTest;
@@ -178,7 +177,11 @@ class UTF8ZipFilesTest extends AbstractTest {
 
     @Test
     void testRawNameReadFromStream() throws IOException {
-        try (ZipArchiveInputStream zi = new ZipArchiveInputStream(newInputStream("utf8-7zip-test.zip"), CP437, false)) {
+        try (ZipArchiveInputStream zi = ZipArchiveInputStream.builder()
+                .setURI(getURI("utf8-7zip-test.zip"))
+                .setCharset(CP437)
+                .setUseUnicodeExtraFields(false)
+                .get()) {
             assertRawNameOfAcsiiTxt(zi.getNextEntry());
         }
     }
@@ -208,7 +211,11 @@ class UTF8ZipFilesTest extends AbstractTest {
 
     @Test
     void testRead7ZipArchiveForStream() throws IOException {
-        try (ZipArchiveInputStream zi = new ZipArchiveInputStream(newInputStream("utf8-7zip-test.zip"), CP437, false)) {
+        try (ZipArchiveInputStream zi = ZipArchiveInputStream.builder()
+                .setURI(getURI("utf8-7zip-test.zip"))
+                .setCharset(CP437)
+                .setUseUnicodeExtraFields(false)
+                .get()) {
             assertEquals(ASCII_TXT, zi.getNextEntry().getName());
             assertEquals(OIL_BARREL_TXT, zi.getNextEntry().getName());
             assertEquals(EURO_FOR_DOLLAR_TXT, zi.getNextEntry().getName());
@@ -235,13 +242,10 @@ class UTF8ZipFilesTest extends AbstractTest {
 
     @Test
     void testReadWinZipArchiveForStream() throws IOException {
-        // fix for test fails on Windows with default charset that is not UTF-8
-        String encoding = null;
-        if (Charset.defaultCharset() != UTF_8) {
-            encoding = UTF_8.name();
-        }
-        try (InputStream archive = newInputStream("utf8-winzip-test.zip");
-                ZipArchiveInputStream zi = new ZipArchiveInputStream(archive, encoding, true)) {
+        try (ZipArchiveInputStream zi = ZipArchiveInputStream.builder()
+                .setURI(getURI("utf8-winzip-test.zip"))
+                .setCharset(UTF_8)
+                .get()) {
             assertEquals(EURO_FOR_DOLLAR_TXT, zi.getNextEntry().getName());
             assertEquals(OIL_BARREL_TXT, zi.getNextEntry().getName());
             assertEquals(ASCII_TXT, zi.getNextEntry().getName());
@@ -253,8 +257,9 @@ class UTF8ZipFilesTest extends AbstractTest {
      */
     @Test
     void testStreamSkipsOverUnicodeExtraFieldWithUnsupportedVersion() throws IOException {
-        try (InputStream archive = newInputStream("COMPRESS-479.zip");
-                ZipArchiveInputStream zi = new ZipArchiveInputStream(archive)) {
+        try (ZipArchiveInputStream zi = ZipArchiveInputStream.builder()
+                .setURI(getURI("COMPRESS-479.zip"))
+                .get()) {
             assertEquals(OIL_BARREL_TXT, zi.getNextEntry().getName());
             assertEquals("%U20AC_for_Dollar.txt", zi.getNextEntry().getName());
             assertEquals(ASCII_TXT, zi.getNextEntry().getName());
@@ -304,7 +309,10 @@ class UTF8ZipFilesTest extends AbstractTest {
     void testZipFileReadsUnicodeFields() throws IOException {
         final File file = createTempFile("unicode-test", ".zip");
         createTestFile(file, StandardCharsets.US_ASCII.name(), false, true);
-        try (ZipArchiveInputStream zi = new ZipArchiveInputStream(Files.newInputStream(file.toPath()), StandardCharsets.US_ASCII.name(), true)) {
+        try (ZipArchiveInputStream zi = ZipArchiveInputStream.builder()
+                .setFile(file)
+                .setCharset(StandardCharsets.US_ASCII)
+                .get()) {
             assertEquals(OIL_BARREL_TXT, zi.getNextEntry().getName());
             assertEquals(EURO_FOR_DOLLAR_TXT, zi.getNextEntry().getName());
             assertEquals(ASCII_TXT, zi.getNextEntry().getName());

--- a/src/test/java/org/apache/commons/compress/archivers/zip/Zip64SupportIT.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/Zip64SupportIT.java
@@ -152,8 +152,8 @@ public class Zip64SupportIT {
     }
 
     private static void read100KFilesImpl(final File f) throws IOException {
-        try (InputStream fin = Files.newInputStream(f.toPath());
-                ZipArchiveInputStream zin = new ZipArchiveInputStream(fin)) {
+        try (ZipArchiveInputStream zin =
+                ZipArchiveInputStream.builder().setFile(f).get()) {
             int files = 0;
             ZipArchiveEntry zae;
             while ((zae = zin.getNextZipEntry()) != null) {
@@ -182,8 +182,8 @@ public class Zip64SupportIT {
     }
 
     private static void read5GBOfZerosImpl(final File f, final String expectedName) throws IOException {
-        try (InputStream fin = Files.newInputStream(f.toPath());
-                ZipArchiveInputStream zin = new ZipArchiveInputStream(fin)) {
+        try (ZipArchiveInputStream zin =
+                ZipArchiveInputStream.builder().setFile(f).get()) {
             ZipArchiveEntry zae = zin.getNextZipEntry();
             while (zae.isDirectory()) {
                 zae = zin.getNextZipEntry();

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamMalformedTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamMalformedTest.java
@@ -21,12 +21,10 @@ package org.apache.commons.compress.archivers.zip;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.commons.compress.CompressException;
@@ -69,7 +67,10 @@ public class ZipArchiveInputStreamMalformedTest {
                 fos.write(chunk);
             }
         }
-        try (ZipArchiveInputStream zis = new ZipArchiveInputStream(new FileInputStream(fixture), StandardCharsets.UTF_8.name(), true, true)) {
+        try (ZipArchiveInputStream zis = ZipArchiveInputStream.builder()
+                .setFile(fixture)
+                .setAllowStoredEntriesWithDataDescriptor(true)
+                .get()) {
             zis.getNextEntry();
             assertThrows(CompressException.class, () -> IOUtils.toByteArray(zis));
         }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamMalformedTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamMalformedTest.java
@@ -69,7 +69,7 @@ public class ZipArchiveInputStreamMalformedTest {
         }
         try (ZipArchiveInputStream zis = ZipArchiveInputStream.builder()
                 .setFile(fixture)
-                .setAllowStoredEntriesWithDataDescriptor(true)
+                .setSupportStoredEntryDataDescriptor(true)
                 .get()) {
             zis.getNextEntry();
             assertThrows(CompressException.class, () -> IOUtils.toByteArray(zis));

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -379,7 +379,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
     void testProperlyReadsStoredEntryWithDataDescriptorWithoutSignature() throws IOException {
         try (ZipArchiveInputStream archive = ZipArchiveInputStream.builder()
                 .setURI(getURI("bla-stored-dd-nosig.zip"))
-                .setAllowStoredEntriesWithDataDescriptor(true)
+                .setSupportStoredEntryDataDescriptor(true)
                 .get()) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
@@ -397,7 +397,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
     void testProperlyReadsStoredEntryWithDataDescriptorWithSignature() throws IOException {
         try (ZipArchiveInputStream archive = ZipArchiveInputStream.builder()
                 .setURI(getURI("bla-stored-dd.zip"))
-                .setAllowStoredEntriesWithDataDescriptor(true)
+                .setSupportStoredEntryDataDescriptor(true)
                 .get()) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
@@ -672,7 +672,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
     void testThrowsIfStoredDDIsDifferentFromLengthRead() throws IOException {
         try (ZipArchiveInputStream archive = ZipArchiveInputStream.builder()
                 .setURI(getURI("bla-stored-dd-contradicts-actualsize.zip"))
-                .setAllowStoredEntriesWithDataDescriptor(true)
+                .setSupportStoredEntryDataDescriptor(true)
                 .get()) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
@@ -687,7 +687,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
     void testThrowsIfStoredDDIsInconsistent() throws IOException {
         try (ZipArchiveInputStream archive = ZipArchiveInputStream.builder()
                 .setURI(getURI("bla-stored-dd-sizes-differ.zip"))
-                .setAllowStoredEntriesWithDataDescriptor(true)
+                .setSupportStoredEntryDataDescriptor(true)
                 .get()) {
             final ZipArchiveEntry e = archive.getNextZipEntry();
             assertNotNull(e);
@@ -868,7 +868,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
         try (ZipArchiveInputStream zIn = ZipArchiveInputStream.builder()
                 .setURI(getURI("COMPRESS-647/test.zip"))
                 .setUseUnicodeExtraFields(false)
-                .setAllowStoredEntriesWithDataDescriptor(allowStoredEntriesWithDataDescriptor)
+                .setSupportStoredEntryDataDescriptor(allowStoredEntriesWithDataDescriptor)
                 .get()) {
             ZipArchiveEntry zae = zIn.getNextEntry();
             while (zae != null) {
@@ -884,7 +884,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
         try (InputStream inputStream = forgeZipInputStream();
                 ZipArchiveInputStream zipInputStream = ZipArchiveInputStream.builder()
                         .setInputStream(inputStream)
-                        .setAllowStoredEntriesWithDataDescriptor(true)
+                        .setSupportStoredEntryDataDescriptor(true)
                         .get()) {
             getAllZipEntries(zipInputStream);
         }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -568,13 +568,13 @@ class ZipArchiveInputStreamTest extends AbstractTest {
                 InputStream inputStream = Channels.newInputStream(channel);
                 ZipArchiveInputStream splitInputStream = ZipArchiveInputStream.builder()
                         .setInputStream(inputStream)
-                        .setSkipSplitSig(true)
+                        .setSkipSplitSignature(true)
                         .get()) {
 
             final File fileToCompare = getFile("COMPRESS-477/split_zip_created_by_winrar/zip_to_compare_created_by_winrar.zip");
             try (ZipArchiveInputStream inputStreamToCompare = ZipArchiveInputStream.builder()
                     .setFile(fileToCompare)
-                    .setSkipSplitSig(true)
+                    .setSkipSplitSignature(true)
                     .get()) {
                 ArchiveEntry entry;
                 while ((entry = splitInputStream.getNextEntry()) != null && inputStreamToCompare.getNextEntry() != null) {
@@ -594,7 +594,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
                 InputStream inputStream = Channels.newInputStream(channel);
                 ZipArchiveInputStream splitInputStream = ZipArchiveInputStream.builder()
                         .setInputStream(inputStream)
-                        .setSkipSplitSig(true)
+                        .setSkipSplitSignature(true)
                         .get()) {
 
             final Path fileToCompare = getPath("COMPRESS-477/split_zip_created_by_zip/zip_to_compare_created_by_zip.zip");
@@ -619,13 +619,13 @@ class ZipArchiveInputStreamTest extends AbstractTest {
                 InputStream inputStream = Channels.newInputStream(channel);
                 ZipArchiveInputStream splitInputStream = ZipArchiveInputStream.builder()
                         .setInputStream(inputStream)
-                        .setSkipSplitSig(true)
+                        .setSkipSplitSignature(true)
                         .get()) {
 
             final Path fileToCompare = getPath("COMPRESS-477/split_zip_created_by_zip/zip_to_compare_created_by_zip_zip64.zip");
             try (ZipArchiveInputStream inputStreamToCompare = ZipArchiveInputStream.builder()
                     .setPath(fileToCompare)
-                    .setSkipSplitSig(true)
+                    .setSkipSplitSignature(true)
                     .get()) {
 
                 ArchiveEntry entry;
@@ -643,7 +643,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
     void testSplitZipCreatedByZipThrowsException() throws IOException {
         try (ZipArchiveInputStream inputStream = ZipArchiveInputStream.builder()
                 .setURI(getURI("COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z01"))
-                .setSkipSplitSig(true)
+                .setSkipSplitSignature(true)
                 .get()) {
 
             assertThrows(EOFException.class, () -> {

--- a/src/test/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStreamTest.java
@@ -101,7 +101,7 @@ class GzipCompressorInputStreamTest {
             assertEquals("Helm", gis.getMetaData().getComment());
             assertEquals(41, gis.getMetaData().getExtraFieldXlen());
             final List<String> fileNames = new ArrayList<>();
-            try (TarArchiveInputStream tar = new TarArchiveInputStream(gis)) {
+            try (TarArchiveInputStream tar = TarArchiveInputStream.builder().setInputStream(gis).get()) {
                 TarArchiveEntry entry;
                 while ((entry = tar.getNextEntry()) != null) {
                     fileNames.add(entry.getName());

--- a/src/test/java/org/apache/commons/compress/compressors/pack200/Pack200UtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/pack200/Pack200UtilsTest.java
@@ -90,9 +90,8 @@ public final class Pack200UtilsTest extends AbstractTest {
         //
         // If you use a zip archive instead of a tar archive you
         // get a different number of bytes read, but still not the expected
-        try (InputStream is = new FileInputStream(archiveFile);
-                // Files.newInputStream(archiveFile.toPath());
-                TarArchiveInputStream in = new TarArchiveInputStream(is)) {
+        try (TarArchiveInputStream in =
+                TarArchiveInputStream.builder().setFile(archiveFile).get()) {
             ArchiveEntry entry = in.getNextEntry();
             int entries = 0;
             long count = 0;


### PR DESCRIPTION
This PR introduces builders for all `ArchiveInputStream` implementations, starting from a new generic builder that captures options shared across implementations. Existing code has been refactored to use the new builders instead of direct constructor calls, improving consistency, readability, and maintainability.

## Changes

* **Generic builder** for `ArchiveInputStream` to handle shared options.
* **New builders** for specific implementations:

  * `ArArchiveInputStream`
  * `ArjArchiveInputStream`
  * `CpioArchiveInputStream`
  * `DumpArchiveInputStream`
  * `JarArchiveInputStream`
  * `ZipArchiveInputStream`

## Motivation

* Simplifies client code by replacing complex or repetitive constructor calls.
* Provides a unified and extensible API for configuring archive input streams.
* Improves readability and makes future changes to constructors less disruptive.
