### PR TITLE
tests: Add coverage for deprecated and single-argument constructors

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -138,7 +138,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream<ArjArchiveEntry> {
      * @param inputStream the underlying stream, whose ownership is taken
      * @param charsetName the charset used for file names and comments in the archive. May be {@code null} to use the platform default.
      * @throws ArchiveException if an exception occurs while reading
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0 use {@link #builder()}.
      */
     @Deprecated
     public ArjArchiveInputStream(final InputStream inputStream, final String charsetName) throws ArchiveException {

--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -138,7 +138,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream<ArjArchiveEntry> {
      * @param inputStream the underlying stream, whose ownership is taken
      * @param charsetName the charset used for file names and comments in the archive. May be {@code null} to use the platform default.
      * @throws ArchiveException if an exception occurs while reading
-     * @deprecated Since 1.29.0 use {@link #builder()}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public ArjArchiveInputStream(final InputStream inputStream, final String charsetName) throws ArchiveException {

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -225,7 +225,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
      * @param in        The cpio stream
      * @param blockSize The block size of the archive.
      * @since 1.5
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public CpioArchiveInputStream(final InputStream in, final int blockSize) {
@@ -240,7 +240,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
      * @param encoding  The encoding of file names to expect - use null for the platform's default.
      * @throws IllegalArgumentException if {@code blockSize} is not bigger than 0
      * @since 1.6
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public CpioArchiveInputStream(final InputStream in, final int blockSize, final String encoding) {
@@ -253,7 +253,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
      * @param in       The cpio stream
      * @param encoding The encoding of file names to expect - use null for the platform's default.
      * @since 1.6
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public CpioArchiveInputStream(final InputStream in, final String encoding) {

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
@@ -204,7 +204,7 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
      * @param encoding the encoding to use for file names, use null for the platform's default encoding
      * @throws ArchiveException on error
      * @since 1.6
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public DumpArchiveInputStream(final InputStream is, final String encoding) throws ArchiveException {

--- a/src/main/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStream.java
@@ -93,7 +93,7 @@ public class JarArchiveInputStream extends ZipArchiveInputStream {
      * @param inputStream the input stream to wrap
      * @param encoding    the encoding to use
      * @since 1.10
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #jarInputStreamBuilder()}.
      */
     @Deprecated
     public JarArchiveInputStream(final InputStream inputStream, final String encoding) {

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -71,7 +71,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @since 1.29.0
      */
     // @formatter:on
-    public static class Builder extends AbstractBuilder<TarArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractBuilder<TarArchiveInputStream, Builder> {
 
         private int blockSize = TarConstants.DEFAULT_BLKSIZE;
         private int recordSize = TarConstants.DEFAULT_RCDSIZE;
@@ -80,7 +80,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
         /**
          * Constructs a new instance.
          */
-        public Builder() {
+        private Builder() {
             // empty
         }
 
@@ -234,7 +234,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param lenient     when set to true illegal values for group/userid, mode, device numbers and timestamp will be ignored and the fields set to
      *                    {@link TarArchiveEntry#UNKNOWN}. When set to false such illegal fields cause an exception instead.
      * @since 1.19
-     * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final boolean lenient) {
@@ -254,7 +254,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      *
      * @param inputStream the input stream to use.
      * @param blockSize   the block size to use.
-     * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final int blockSize) {
@@ -267,7 +267,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param inputStream the input stream to use.
      * @param blockSize   the block size to use.
      * @param recordSize  the record size to use.
-     * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final int blockSize, final int recordSize) {
@@ -282,7 +282,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param recordSize  the record size to use.
      * @param encoding    name of the encoding to use for file names.
      * @since 1.4
-     * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public TarArchiveInputStream(
@@ -302,7 +302,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param lenient     when set to true illegal values for group/userid, mode, device numbers and timestamp will be ignored and the fields set to
      *                    {@link TarArchiveEntry#UNKNOWN}. When set to false such illegal fields cause an exception instead.
      * @since 1.19
-     * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final int blockSize, final int recordSize, final String encoding, final boolean lenient) {
@@ -322,7 +322,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param blockSize   the block size to use.
      * @param encoding    name of the encoding to use for file names.
      * @since 1.4
-     * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final int blockSize, final String encoding) {
@@ -335,7 +335,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param inputStream the input stream to use.
      * @param encoding    name of the encoding to use for file names.
      * @since 1.4
-     * @deprecated Use {@link #builder()} to configure and {@link Builder#get() get()} a {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public TarArchiveInputStream(final InputStream inputStream, final String encoding) {

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -437,7 +437,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * @param inputStream the stream to wrap.
      * @param encoding    the encoding to use for file names, use null for the platform's default encoding.
      * @since 1.5
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public ZipArchiveInputStream(final InputStream inputStream, final String encoding) {
@@ -450,7 +450,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * @param inputStream           the stream to wrap.
      * @param encoding              the encoding to use for file names, use null for the platform's default encoding.
      * @param useUnicodeExtraFields whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public ZipArchiveInputStream(final InputStream inputStream, final String encoding, final boolean useUnicodeExtraFields) {
@@ -465,7 +465,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * @param useUnicodeExtraFields            whether to use InfoZIP Unicode Extra Fields (if present) to set the file names.
      * @param supportStoredEntryDataDescriptor whether the stream will try to read STORED entries that use a data descriptor.
      * @since 1.1
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public ZipArchiveInputStream(
@@ -491,7 +491,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * @param skipSplitSignature               Whether the stream will try to skip the zip split signature(08074B50) at the beginning.
      *                                         You will need to set this to true if you want to read a split archive.
      * @since 1.20
-     * @deprecated Use {@link #builder()} and {@link Builder}.
+     * @deprecated Since 1.29.0, use {@link #builder()}.
      */
     @Deprecated
     public ZipArchiveInputStream(

--- a/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
+++ b/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
+import static org.apache.commons.lang3.reflect.FieldUtils.readField;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.stream.Stream;
+
+import org.apache.commons.compress.archivers.arj.ArjArchiveInputStream;
+import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
+import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
+import org.apache.commons.compress.archivers.jar.JarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies that deprecated constructors are equivalent to the new builder pattern.
+ */
+@Tag("deprecated")
+@SuppressWarnings("deprecation") // testing deprecated code
+class LegacyConstructorsTest extends AbstractTest {
+
+    @Test
+    void testArjConstructor() throws Exception {
+        try (InputStream inputStream = Files.newInputStream(getPath("bla.arj"));
+                ArjArchiveInputStream archiveInputStream = new ArjArchiveInputStream(inputStream, "US-ASCII")) {
+            // Arj wraps the input stream in a DataInputStream
+            assertEquals(inputStream, getNestedInputStream(getNestedInputStream(archiveInputStream)));
+            assertEquals(US_ASCII, archiveInputStream.getCharset());
+        }
+    }
+
+    static Stream<Arguments> testCpioConstructors() {
+        final InputStream inputStream = mock(InputStream.class);
+        return Stream.of(
+                Arguments.of(new CpioArchiveInputStream(inputStream, 1024), inputStream, "US-ASCII", 1024),
+                Arguments.of(new CpioArchiveInputStream(inputStream, 1024, "UTF-8"), inputStream, "UTF-8", 1024),
+                Arguments.of(new CpioArchiveInputStream(inputStream, "UTF-8"), inputStream, "UTF-8", 512));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testCpioConstructors(
+            CpioArchiveInputStream archiveStream,
+            InputStream expectedInput,
+            String expectedEncoding,
+            int expectedBlockSize)
+            throws Exception {
+        assertEquals(expectedInput, getNestedInputStream(archiveStream));
+        assertEquals(Charset.forName(expectedEncoding), archiveStream.getCharset());
+        assertEquals(expectedBlockSize, readDeclaredField(archiveStream, "blockSize", true));
+    }
+
+    @Test
+    void testDumpConstructor() throws Exception {
+        final String otherEncoding = "UTF-8".equals(Charset.defaultCharset().name()) ? "US-ASCII" : "UTF-8";
+        try (InputStream inputStream = Files.newInputStream(getPath("bla.dump"));
+                DumpArchiveInputStream archiveStream = new DumpArchiveInputStream(inputStream, otherEncoding)) {
+            assertEquals(inputStream, getNestedInputStream(archiveStream));
+            assertEquals(Charset.forName(otherEncoding), archiveStream.getCharset());
+        }
+    }
+
+    @Test
+    void testJarConstructor() throws Exception {
+        final InputStream inputStream = mock(InputStream.class);
+        try (JarArchiveInputStream archiveInputStream = new JarArchiveInputStream(inputStream, "US-ASCII")) {
+            assertEquals(US_ASCII, archiveInputStream.getCharset());
+        }
+    }
+
+    static Stream<Arguments> testTarContructors() {
+        final InputStream inputStream = mock(InputStream.class);
+        final String defaultEncoding = Charset.defaultCharset().name();
+        final String otherEncoding = "UTF-8".equals(defaultEncoding) ? "US-ASCII" : "UTF-8";
+        return Stream.of(
+                Arguments.of(
+                        new TarArchiveInputStream(inputStream, true), inputStream, 10240, 512, defaultEncoding, true),
+                Arguments.of(
+                        new TarArchiveInputStream(inputStream, 20480), inputStream, 20480, 512, defaultEncoding, false),
+                Arguments.of(
+                        new TarArchiveInputStream(inputStream, 20480, 1024),
+                        inputStream,
+                        20480,
+                        1024,
+                        defaultEncoding,
+                        false),
+                Arguments.of(
+                        new TarArchiveInputStream(inputStream, 20480, 1024, otherEncoding),
+                        inputStream,
+                        20480,
+                        1024,
+                        otherEncoding,
+                        false),
+                Arguments.of(
+                        new TarArchiveInputStream(inputStream, 20480, 1024, otherEncoding, true),
+                        inputStream,
+                        20480,
+                        1024,
+                        otherEncoding,
+                        true),
+                Arguments.of(
+                        new TarArchiveInputStream(inputStream, 20480, otherEncoding),
+                        inputStream,
+                        20480,
+                        512,
+                        otherEncoding,
+                        false),
+                Arguments.of(
+                        new TarArchiveInputStream(inputStream, otherEncoding),
+                        inputStream,
+                        10240,
+                        512,
+                        otherEncoding,
+                        false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testTarContructors(
+            TarArchiveInputStream archiveStream,
+            InputStream expectedInput,
+            int expectedBlockSize,
+            int expectedRecordSize,
+            String expectedEncoding,
+            boolean expectedLenient)
+            throws Exception {
+        assertEquals(expectedInput, getNestedInputStream(archiveStream));
+        assertEquals(expectedBlockSize, readDeclaredField(archiveStream, "blockSize", true));
+        final byte[] recordBuffer = (byte[]) readField(archiveStream, "recordBuffer", true);
+        assertEquals(expectedRecordSize, recordBuffer.length);
+        assertEquals(Charset.forName(expectedEncoding), archiveStream.getCharset());
+        assertEquals(expectedLenient, readField(archiveStream, "lenient", true));
+    }
+
+    static Stream<Arguments> testZipConstructors() {
+        final InputStream inputStream = mock(InputStream.class);
+        return Stream.of(
+                Arguments.of(
+                        new ZipArchiveInputStream(inputStream, "US-ASCII"),
+                        inputStream,
+                        "US-ASCII",
+                        true,
+                        false,
+                        false),
+                Arguments.of(
+                        new ZipArchiveInputStream(inputStream, "US-ASCII", false),
+                        inputStream,
+                        "US-ASCII",
+                        false,
+                        false,
+                        false),
+                Arguments.of(
+                        new ZipArchiveInputStream(inputStream, "US-ASCII", false, true),
+                        inputStream,
+                        "US-ASCII",
+                        false,
+                        true,
+                        false),
+                Arguments.of(
+                        new ZipArchiveInputStream(inputStream, "US-ASCII", false, true, true),
+                        inputStream,
+                        "US-ASCII",
+                        false,
+                        true,
+                        true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testZipConstructors(
+            ZipArchiveInputStream archiveStream,
+            InputStream expectedInput,
+            String expectedEncoding,
+            boolean expectedUseUnicodeExtraFields,
+            boolean expectedSupportStoredEntryDataDescriptor,
+            boolean expectedSkipSplitSignature)
+            throws Exception {
+        // Zip wraps the input stream in a PushbackInputStream
+        assertEquals(expectedInput, getNestedInputStream(getNestedInputStream(archiveStream)));
+        assertEquals(Charset.forName(expectedEncoding), archiveStream.getCharset());
+        assertEquals(expectedUseUnicodeExtraFields, readDeclaredField(archiveStream, "useUnicodeExtraFields", true));
+        assertEquals(
+                expectedSupportStoredEntryDataDescriptor,
+                readDeclaredField(archiveStream, "supportStoredEntryDataDescriptor", true));
+        assertEquals(expectedSkipSplitSignature, readDeclaredField(archiveStream, "skipSplitSignature", true));
+    }
+
+    private static InputStream getNestedInputStream(InputStream is) throws ReflectiveOperationException {
+        return (InputStream) readField(is, "in", true);
+    }
+}

--- a/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
+++ b/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
@@ -97,7 +97,7 @@ class LegacyConstructorsTest extends AbstractTest {
         }
     }
 
-    static Stream<Arguments> testTarContructors() {
+    static Stream<Arguments> testTarConstructors() {
         final InputStream inputStream = mock(InputStream.class);
         final String defaultEncoding = Charset.defaultCharset().name();
         final String otherEncoding = "UTF-8".equals(defaultEncoding) ? "US-ASCII" : "UTF-8";
@@ -145,7 +145,7 @@ class LegacyConstructorsTest extends AbstractTest {
 
     @ParameterizedTest
     @MethodSource
-    void testTarContructors(
+    void testTarConstructors(
             TarArchiveInputStream archiveStream,
             InputStream expectedInput,
             int expectedBlockSize,

--- a/src/test/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStreamTest.java
@@ -19,10 +19,12 @@
 
 package org.apache.commons.compress.archivers.ar;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import java.io.BufferedInputStream;
 import java.io.EOFException;
@@ -227,4 +229,11 @@ class ArArchiveInputStreamTest extends AbstractTest {
         }
     }
 
+    @Test
+    void testSingleArgumentConstructor() throws Exception {
+        final InputStream inputStream = mock(InputStream.class);
+        try (ArArchiveInputStream archiveStream = new ArArchiveInputStream(inputStream)) {
+            assertEquals(US_ASCII, archiveStream.getCharset());
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStreamTest.java
@@ -28,7 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -267,4 +269,11 @@ class ArjArchiveInputStreamTest extends AbstractTest {
         }
     }
 
+    @Test
+    void testSingleArgumentConstructor() throws Exception {
+        try (InputStream inputStream = Files.newInputStream(getPath("bla.arj"));
+                ArjArchiveInputStream archiveStream = new ArjArchiveInputStream(inputStream)) {
+            assertEquals(Charset.forName("CP437"), archiveStream.getCharset());
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
@@ -18,11 +18,14 @@
  */
 package org.apache.commons.compress.archivers.cpio;
 
+import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.compress.AbstractTest;
@@ -173,4 +176,12 @@ class CpioArchiveInputStreamTest extends AbstractTest {
         }
     }
 
+    @Test
+    void testSingleArgumentConstructor() throws Exception {
+        final InputStream inputStream = mock(InputStream.class);
+        try (CpioArchiveInputStream archiveStream = new CpioArchiveInputStream(inputStream)) {
+            assertEquals(StandardCharsets.US_ASCII, archiveStream.getCharset());
+            assertEquals(512, readDeclaredField(archiveStream, "blockSize", true));
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java
@@ -31,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -190,6 +192,14 @@ class DumpArchiveInputStreamTest extends AbstractTest {
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read());
             assertEquals(-1, archive.read());
+        }
+    }
+
+    @Test
+    void testSingleArgumentConstructor() throws Exception {
+        try (InputStream inputStream = Files.newInputStream(getPath("bla.dump"));
+                DumpArchiveInputStream archiveStream = new DumpArchiveInputStream(inputStream)) {
+            assertEquals(Charset.defaultCharset(), archiveStream.getCharset());
         }
     }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/jar/JarArchiveInputStreamTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers.jar;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+class JarArchiveInputStreamTest {
+
+    @Test
+    void testSingleArgumentConstructor() throws IOException {
+        final InputStream inputStream = mock(InputStream.class);
+        try (JarArchiveInputStream archiveInputStream = new JarArchiveInputStream(inputStream)) {
+            assertEquals(UTF_8, archiveInputStream.getCharset());
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.commons.compress.archivers.tar;
 
+import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
+import static org.apache.commons.lang3.reflect.FieldUtils.readField;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -37,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -616,6 +620,18 @@ class TarArchiveInputStreamTest extends AbstractTest {
             assertEquals(new Date(0), tae.getLastModifiedDate());
             assertTrue(tae.isSymbolicLink());
             assertTrue(tae.isCheckSumOK());
+        }
+    }
+
+    @Test
+    void testSingleArgumentConstructor() throws Exception {
+        final InputStream inputStream = mock(InputStream.class);
+        try (TarArchiveInputStream archiveStream = new TarArchiveInputStream(inputStream)) {
+            assertEquals(10240, readDeclaredField(archiveStream, "blockSize", true));
+            final byte[] recordBuffer = (byte[]) readField(archiveStream, "recordBuffer", true);
+            assertEquals(512, recordBuffer.length);
+            assertEquals(Charset.defaultCharset(), archiveStream.getCharset());
+            assertEquals(false, readField(archiveStream, "lenient", true));
         }
     }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.commons.compress.archivers.zip;
 
+import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -929,6 +931,17 @@ class ZipArchiveInputStreamTest extends AbstractTest {
             assertEquals("file-1.txt", entry.getName());
             final byte[] content = IOUtils.toByteArray(zis);
             assertArrayEquals("entry-content\n".getBytes(StandardCharsets.UTF_8), content);
+        }
+    }
+
+    @Test
+    void testSingleArgumentConstructor() throws Exception {
+        final InputStream inputStream = mock(InputStream.class);
+        try (ZipArchiveInputStream archiveStream = new ZipArchiveInputStream(inputStream)) {
+            assertEquals(StandardCharsets.UTF_8, archiveStream.getCharset());
+            assertEquals(true, readDeclaredField(archiveStream, "useUnicodeExtraFields", true));
+            assertEquals(false, readDeclaredField(archiveStream, "supportStoredEntryDataDescriptor", true));
+            assertEquals(false, readDeclaredField(archiveStream, "skipSplitSignature", true));
         }
     }
 }


### PR DESCRIPTION
This change ensures that behavior of legacy constructors remains consistent with version `1.28.0` while paving the way for their eventual removal.

**Key changes:**

* Introduces a new `LegacyConstructorsTest` class that verifies the parameter values of *deprecated* constructors. *Rationale:* this provides explicit coverage and will allow us to remove both the constructors and their tests in one step when deprecations are finalized.
* Adds equivalent test cases for non-deprecated single-argument constructors in their corresponding test classes.
* Makes the constructor of `TarArchiveInputStream.Builder` private, aligning it with the visibility of other builder constructors.
* Fixes Javadoc on deprecated constructors, which previously (incorrectly) suggested using private `Builder()` constructors.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create the PR description.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
