### PR TITLE
remove: make `TarUtils` final and clean up internal methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,12 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
                 <exclude>org.apache.commons.compress.harmony.pack200.SegmentMethodVisitor</exclude>
                 <exclude>org.apache.commons.compress.harmony.pack200.SegmentAnnotationVisitor</exclude>
                 <exclude>org.apache.commons.compress.harmony.pack200.SegmentFieldVisitor</exclude>
+                <!-- Compress 1.28.0 -> 1.29.0: make TarUtils final -->
+                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parseFromPAX01SparseHeaders(java.lang.String)</exclude>
+                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePAX01SparseHeaders(java.lang.String)</exclude>
+                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePAX1XSparseHeaders(java.io.InputStream,int)</exclude>
+                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePaxHeaders(java.io.InputStream,java.util.List,java.util.Map)</exclude>
+                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePaxHeaders(java.io.InputStream,java.util.List,java.util.Map,long)</exclude>
               </excludes>
             </parameter>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,6 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
     <slf4j.version>2.0.16</slf4j.version>
     <!-- project.build.outputTimestamp is managed by Maven plugins, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
     <project.build.outputTimestamp>2025-07-29T22:23:16Z</project.build.outputTimestamp>
-    <!-- spdx 0.6.0 can require Java 11 depending on undocumented behavior which kicks in for us here. -->
-    <commons.spdx.version>0.5.5</commons.spdx.version>
     <!-- JaCoCo: Don't make code coverage worse than: -->
     <commons.jacoco.haltOnFailure>true</commons.jacoco.haltOnFailure>
     <commons.jacoco.classRatio>0.96</commons.jacoco.classRatio>
@@ -89,6 +87,12 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
     <checkstyle.config.file>${basedir}/src/conf/checkstyle/checkstyle.xml</checkstyle.config.file>
     <checkstyle.suppress.file>${basedir}/src/conf/checkstyle/checkstyle-suppressions.xml</checkstyle.suppress.file>
     <checkstyle.resourceExcludes>LICENSE.txt, NOTICE.txt, **/maven-archiver/pom.properties</checkstyle.resourceExcludes>
+    <!--
+      ~ Temporary overrides of versions defined by parent pom.
+      -->
+    <!-- spdx 0.6.0 can require Java 11 depending on undocumented behavior which kicks in for us here. -->
+    <commons.spdx.version>0.5.5</commons.spdx.version>
+    <commons.japicmp.version>0.24.0</commons.japicmp.version>
   </properties>
   <issueManagement>
     <system>jira</system>
@@ -288,40 +292,6 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>${commons.felix.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>com.github.siom79.japicmp</groupId>
-          <artifactId>japicmp-maven-plugin</artifactId>
-          <configuration>
-            <parameter>
-              <excludes>
-                <!-- Compress 1.21 -> 1.22 updates ASM from 3.2 to 9.2 for pack200 implementation. -->
-                <exclude>org.apache.commons.compress.harmony.pack200.Segment</exclude>
-                <exclude>org.apache.commons.compress.harmony.pack200.SegmentMethodVisitor</exclude>
-                <exclude>org.apache.commons.compress.harmony.pack200.SegmentAnnotationVisitor</exclude>
-                <exclude>org.apache.commons.compress.harmony.pack200.SegmentFieldVisitor</exclude>
-                <!-- Compress 1.28.0 -> 1.29.0: make TarUtils final -->
-                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parseFromPAX01SparseHeaders(java.lang.String)</exclude>
-                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePAX01SparseHeaders(java.lang.String)</exclude>
-                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePAX1XSparseHeaders(java.io.InputStream,int)</exclude>
-                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePaxHeaders(java.io.InputStream,java.util.List,java.util.Map)</exclude>
-                <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePaxHeaders(java.io.InputStream,java.util.List,java.util.Map,long)</exclude>
-              </excludes>
-              <!--
-                ~ JapiCmp does not support ignoring a specific compatibility change for a single class.
-                ~ As a workaround, we override the change globally.
-                ~
-                ~ TODO: Remove after release 1.29.0.
-                -->
-              <overrideCompatibilityChangeParameters>
-                <overrideCompatibilityChangeParameter>
-                  <compatibilityChange>CLASS_NOW_FINAL</compatibilityChange>
-                  <binaryCompatible>true</binaryCompatible>
-                  <sourceCompatible>true</sourceCompatible>
-                </overrideCompatibilityChangeParameter>
-              </overrideCompatibilityChangeParameters>
-            </parameter>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,8 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
     <slf4j.version>2.0.16</slf4j.version>
     <!-- project.build.outputTimestamp is managed by Maven plugins, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
     <project.build.outputTimestamp>2025-07-29T22:23:16Z</project.build.outputTimestamp>
+    <!-- spdx 0.6.0 can require Java 11 depending on undocumented behavior which kicks in for us here. -->
+    <commons.spdx.version>0.5.5</commons.spdx.version>
     <!-- JaCoCo: Don't make code coverage worse than: -->
     <commons.jacoco.haltOnFailure>true</commons.jacoco.haltOnFailure>
     <commons.jacoco.classRatio>0.96</commons.jacoco.classRatio>
@@ -87,11 +89,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
     <checkstyle.config.file>${basedir}/src/conf/checkstyle/checkstyle.xml</checkstyle.config.file>
     <checkstyle.suppress.file>${basedir}/src/conf/checkstyle/checkstyle-suppressions.xml</checkstyle.suppress.file>
     <checkstyle.resourceExcludes>LICENSE.txt, NOTICE.txt, **/maven-archiver/pom.properties</checkstyle.resourceExcludes>
-    <!--
-      ~ Temporary overrides of versions defined by parent pom.
-      -->
-    <!-- spdx 0.6.0 can require Java 11 depending on undocumented behavior which kicks in for us here. -->
-    <commons.spdx.version>0.5.5</commons.spdx.version>
+    <!-- Temporary overrides of versions defined by parent pom. -->
     <commons.japicmp.version>0.24.1</commons.japicmp.version>
   </properties>
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -408,6 +408,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <id>cleanup-parent-upgrade</id>
@@ -418,7 +419,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
               <rules>
                 <requireProperty>
                   <property>project.parent.version</property>
-                  <regex>\s*88\s*</regex>
+                  <regex>88</regex>
                   <regexMessage>Please remove `commons.japicmp.version` override.</regexMessage>
                 </requireProperty>
               </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -418,8 +418,6 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
               <rules>
                 <requireProperty>
                   <property>project.parent.version</property>
-                  <regex>88</regex>
-                  <regexMessage>Please remove the override of the `commons.japicmp.version` property in the pom.xml.</regexMessage>
                 </requireProperty>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       -->
     <!-- spdx 0.6.0 can require Java 11 depending on undocumented behavior which kicks in for us here. -->
     <commons.spdx.version>0.5.5</commons.spdx.version>
-    <commons.japicmp.version>0.24.0</commons.japicmp.version>
+    <commons.japicmp.version>0.24.1</commons.japicmp.version>
   </properties>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -404,29 +404,6 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
-      <!-- Rule to remember to clean up various overrides after parent upgrade -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.6.2</version>
-        <executions>
-          <execution>
-            <id>cleanup-parent-upgrade</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireProperty>
-                  <property>project.parent.version</property>
-                  <regex>88</regex>
-                  <regexMessage>Please remove `commons.japicmp.version` override.</regexMessage>
-                </requireProperty>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,28 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
+      <!-- Rule to remember to clean up various overrides after parent upgrade -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>cleanup-parent-upgrade</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>project.parent.version</property>
+                  <regex>88</regex>
+                  <regexMessage>Please remove the override of the `commons.japicmp.version` property in the pom.xml.</regexMessage>
+                </requireProperty>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,19 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
                 <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePaxHeaders(java.io.InputStream,java.util.List,java.util.Map)</exclude>
                 <exclude>org.apache.commons.compress.archivers.tar.TarUtils#parsePaxHeaders(java.io.InputStream,java.util.List,java.util.Map,long)</exclude>
               </excludes>
+              <!--
+                ~ JapiCmp does not support ignoring a specific compatibility change for a single class.
+                ~ As a workaround, we override the change globally.
+                ~
+                ~ TODO: Remove after release 1.29.0.
+                -->
+              <overrideCompatibilityChangeParameters>
+                <overrideCompatibilityChangeParameter>
+                  <compatibilityChange>CLASS_NOW_FINAL</compatibilityChange>
+                  <binaryCompatible>true</binaryCompatible>
+                  <sourceCompatible>true</sourceCompatible>
+                </overrideCompatibilityChangeParameter>
+              </overrideCompatibilityChangeParameters>
             </parameter>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,8 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
               <rules>
                 <requireProperty>
                   <property>project.parent.version</property>
+                  <regex>\s*88\s*</regex>
+                  <regexMessage>Please remove `commons.japicmp.version` override.</regexMessage>
                 </requireProperty>
               </rules>
             </configuration>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -127,6 +127,8 @@ The <action> type attribute can be add,update,fix,remove.
       <!-- UPDATE -->
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-parent from 85 to 88 #707.</action>
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-lang3 from 3.18.0 to 3.19.0.</action>
+      <!-- REMOVE -->
+      <action type="remove" dev="pkarwasz" due-to="Piotr P. Karwasz">Makes TarUtils final and cleans up protected methods.</action>
     </release>
     <release version="1.28.0" date="2025-07-26" description="This is a feature and maintenance release. Java 8 or later is required.">
       <!-- FIX -->

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -128,7 +128,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-parent from 85 to 88 #707.</action>
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-lang3 from 3.18.0 to 3.19.0.</action>
       <!-- REMOVE -->
-      <action type="remove" dev="pkarwasz" due-to="Piotr P. Karwasz">Makes TarUtils final and cleans up protected methods.</action>
+      <action type="remove" dev="pkarwasz" due-to="Piotr P. Karwasz">Makes TarUtils final and cleans up protected methods #712.</action>
     </release>
     <release version="1.28.0" date="2025-07-26" description="This is a feature and maintenance release. Java 8 or later is required.">
       <!-- FIX -->

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -48,8 +48,7 @@ import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
  *
  * @Immutable
  */
-// CheckStyle:HideUtilityClassConstructorCheck OFF (bc)
-public class TarUtils {
+public final class TarUtils {
 
     private static final Pattern HEADER_STRINGS_PATTERN = Pattern.compile(",");
 

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -461,7 +461,7 @@ public class TarUtils {
      * @throws IOException Corrupted TAR archive.
      * @since 1.21
      */
-    protected static List<TarArchiveStructSparse> parseFromPAX01SparseHeaders(final String sparseMap) throws IOException {
+    static List<TarArchiveStructSparse> parseFromPAX01SparseHeaders(final String sparseMap) throws IOException {
         final List<TarArchiveStructSparse> sparseHeaders = new ArrayList<>();
         final String[] sparseHeaderStrings = HEADER_STRINGS_PATTERN.split(sparseMap);
         if (sparseHeaderStrings.length % 2 == 1) {
@@ -615,30 +615,6 @@ public class TarUtils {
     }
 
     /**
-     * For PAX Format 0.1, the sparse headers are stored in a single variable : GNU.sparse.map
-     *
-     * <p>
-     * <em>GNU.sparse.map</em>: Map of non-null data chunks. It is a string consisting of comma-separated values "offset,size[,offset-1,size-1...]"
-     * </p>
-     * <p>
-     * Will internally invoke {@link #parseFromPAX01SparseHeaders} and map IOExceptions to a RzuntimeException, You should use
-     * {@link #parseFromPAX01SparseHeaders} directly instead.
-     * </p>
-     *
-     * @param sparseMap the sparse map string consisting of comma-separated values "offset,size[,offset-1,size-1...]".
-     * @return sparse headers parsed from sparse map.
-     * @deprecated use #parseFromPAX01SparseHeaders instead.
-     */
-    @Deprecated
-    protected static List<TarArchiveStructSparse> parsePAX01SparseHeaders(final String sparseMap) {
-        try {
-            return parseFromPAX01SparseHeaders(sparseMap);
-        } catch (final IOException ex) {
-            throw new UncheckedIOException(ex.getMessage(), ex);
-        }
-    }
-
-    /**
      * For PAX Format 1.X: The sparse map itself is stored in the file data block, preceding the actual file data. It consists of a series of decimal numbers
      * delimited by newlines. The map is padded with nulls to the nearest block boundary. The first number gives the number of entries in the map. Following are
      * map entries, each one consisting of two numbers giving the offset and size of the data block it describes.
@@ -648,7 +624,7 @@ public class TarUtils {
      * @return sparse headers.
      * @throws IOException if an I/O error occurs.
      */
-    protected static List<TarArchiveStructSparse> parsePAX1XSparseHeaders(final InputStream inputStream, final int recordSize) throws IOException {
+    static List<TarArchiveStructSparse> parsePAX1XSparseHeaders(final InputStream inputStream, final int recordSize) throws IOException {
         // for 1.X PAX Headers
         final List<TarArchiveStructSparse> sparseHeaders = new ArrayList<>();
         long bytesRead = 0;
@@ -693,37 +669,6 @@ public class TarUtils {
      * end repeat
      * </pre>
      * <p>
-     * For PAX Format 0.1, the sparse headers are stored in a single variable: GNU.sparse.map
-     * </p>
-     * <p>
-     * <em>GNU.sparse.map</em>: Map of non-null data chunks. It is a string consisting of comma-separated values "offset,size[,offset-1,size-1...]"
-     * </p>
-     *
-     * @param inputStream      input stream to read keys and values.
-     * @param sparseHeaders    used in PAX Format 0.0 &amp; 0.1, as it may appear multiple times, the sparse headers need to be stored in an array, not a map.
-     * @param globalPaxHeaders global PAX headers of the tar archive.
-     * @return map of PAX headers values found inside the current (local or global) PAX headers tar entry.
-     * @throws IOException if an I/O error occurs.
-     * @deprecated use the four-arg version instead.
-     */
-    @Deprecated
-    protected static Map<String, String> parsePaxHeaders(final InputStream inputStream, final List<TarArchiveStructSparse> sparseHeaders,
-            final Map<String, String> globalPaxHeaders) throws IOException {
-        return parsePaxHeaders(inputStream, sparseHeaders, globalPaxHeaders, -1);
-    }
-
-    /**
-     * For PAX Format 0.0, the sparse headers(GNU.sparse.offset and GNU.sparse.numbytes) may appear multi times, and they look like:
-     *
-     * <pre>
-     * GNU.sparse.size=size
-     * GNU.sparse.numblocks=numblocks
-     * repeat numblocks times
-     *   GNU.sparse.offset=offset
-     *   GNU.sparse.numbytes=numbytes
-     * end repeat
-     * </pre>
-     * <p>
      * For PAX Format 0.1, the sparse headers are stored in a single variable : GNU.sparse.map
      * </p>
      * <p>
@@ -733,13 +678,17 @@ public class TarUtils {
      * @param inputStream      input stream to read keys and values
      * @param sparseHeaders    used in PAX Format 0.0 &amp; 0.1, as it may appear multiple times, the sparse headers need to be stored in an array, not a map
      * @param globalPaxHeaders global PAX headers of the tar archive
-     * @param headerSize       total size of the PAX header, will be ignored if negative
+     * @param headerSize       total size of the PAX header
      * @return map of PAX headers values found inside the current (local or global) PAX headers tar entry.
      * @throws IOException if an I/O error occurs.
      * @since 1.21
      */
-    protected static Map<String, String> parsePaxHeaders(final InputStream inputStream, final List<TarArchiveStructSparse> sparseHeaders,
-            final Map<String, String> globalPaxHeaders, final long headerSize) throws IOException {
+    static Map<String, String> parsePaxHeaders(
+            final InputStream inputStream,
+            final List<TarArchiveStructSparse> sparseHeaders,
+            final Map<String, String> globalPaxHeaders,
+            final long headerSize)
+            throws IOException {
         final Map<String, String> headers = new HashMap<>(globalPaxHeaders);
         Long offset = null;
         // Format is "length keyword=value\n";
@@ -760,7 +709,7 @@ public class TarUtils {
                     while ((ch = inputStream.read()) != -1) {
                         read++;
                         totalRead++;
-                        if (totalRead < 0 || headerSize >= 0 && totalRead >= headerSize) {
+                        if (totalRead < 0 || totalRead >= headerSize) {
                             break;
                         }
                         if (ch == '=') { // end of keyword
@@ -769,7 +718,7 @@ public class TarUtils {
                             final int restLen = len - read;
                             if (restLen <= 1) { // only NL
                                 headers.remove(keyword);
-                            } else if (headerSize >= 0 && restLen > headerSize - totalRead) {
+                            } else if (restLen > headerSize - totalRead) {
                                 throw new ArchiveException("PAX header value size %,d exceeds size of header record.", restLen);
                             } else {
                                 final byte[] rest = IOUtils.readRange(inputStream, restLen);
@@ -791,9 +740,10 @@ public class TarUtils {
                                         sparseHeaders.add(new TarArchiveStructSparse(offset, 0));
                                     }
                                     try {
-                                        offset = Long.valueOf(value);
-                                    } catch (final NumberFormatException ex) {
-                                        throw new ArchiveException("Failed to read PAX header: Offset %s contains a non-numeric value.",
+                                        offset = ParsingUtils.parseLongValue(value);
+                                    } catch (final IOException ex) {
+                                        throw new ArchiveException(
+                                                "Failed to read PAX header: Offset %s contains a non-numeric value.",
                                                 TarGnuSparseKeys.OFFSET);
                                     }
                                     if (offset < 0) {
@@ -806,7 +756,14 @@ public class TarUtils {
                                         throw new ArchiveException("Failed to read PAX header: %s is expected before GNU.sparse.numbytes shows up.",
                                                 TarGnuSparseKeys.OFFSET);
                                     }
-                                    final long numbytes = ParsingUtils.parseLongValue(value);
+                                    final long numbytes;
+                                    try {
+                                        numbytes = ParsingUtils.parseLongValue(value);
+                                    } catch (final IOException ex) {
+                                        throw new ArchiveException(
+                                                "Failed to read PAX header: Numbytes %s contains a non-numeric value.",
+                                                TarGnuSparseKeys.NUMBYTES);
+                                    }
                                     if (numbytes < 0) {
                                         throw new ArchiveException("Failed to read PAX header: %s contains negative value.", TarGnuSparseKeys.NUMBYTES);
                                     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -504,6 +504,10 @@ class TarUtilsTest extends AbstractTest {
                 Arguments.of(
                         "Non-numeric offset in PAX 00 sparse header",
                         "23 GNU.sparse.offset=a\n26 GNU.sparse.numbytes=10\n"),
+                Arguments.of(
+                        "Numbytes in PAX 00 sparse header without offset",
+                        "26 GNU.sparse.numbytes=10\n"
+                ),
                 Arguments.of("Missing trailing newline in PAX header", "30 atime=1321711775.9720594634"));
     }
 
@@ -644,11 +648,9 @@ class TarUtilsTest extends AbstractTest {
 
     @Test
     void testSecondEntryWinsWhenPaxHeaderContainsDuplicateKey() throws Exception {
-        final Map<String, String> headers = TarUtils.parsePaxHeaders(
-                new ByteArrayInputStream("11 foo=bar\n11 foo=baz\n".getBytes(UTF_8)),
-                emptyList(),
-                emptyMap(),
-                Integer.MAX_VALUE);
+        final byte[] header = "11 foo=bar\n11 foo=baz\n".getBytes(UTF_8);
+        final Map<String, String> headers =
+                TarUtils.parsePaxHeaders(new ByteArrayInputStream(header), emptyList(), emptyMap(), header.length);
         assertEquals(1, headers.size());
         assertEquals("baz", headers.get("foo"));
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -20,6 +20,8 @@
 package org.apache.commons.compress.archivers.tar;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -29,12 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -291,7 +290,7 @@ class TarUtilsTest extends AbstractTest {
     @Test
     void testParsePAX01SparseHeadersRejectsOddNumberOfEntries() {
         final String map = "0,10,20,0,20";
-        assertThrows(UncheckedIOException.class, () -> TarUtils.parsePAX01SparseHeaders(map));
+        assertThrows(ArchiveException.class, () -> TarUtils.parseFromPAX01SparseHeaders(map));
     }
 
     @Test
@@ -399,7 +398,9 @@ class TarUtilsTest extends AbstractTest {
 
     @Test
     void testPaxHeaderEntryWithEmptyValueRemovesKey() throws Exception {
-        final Map<String, String> headers = TarUtils.parsePaxHeaders(new ByteArrayInputStream("11 foo=bar\n7 foo=\n".getBytes(UTF_8)), null, new HashMap<>());
+        final byte[] bytes = "11 foo=bar\n7 foo=\n".getBytes(UTF_8);
+        final Map<String, String> headers =
+                TarUtils.parsePaxHeaders(new ByteArrayInputStream(bytes), emptyList(), emptyMap(), bytes.length);
         assertEquals(0, headers.size());
     }
 
@@ -459,17 +460,19 @@ class TarUtilsTest extends AbstractTest {
     void testReadNonAsciiPaxHeader() throws Exception {
         final String ae = "\u00e4";
         final String line = "11 path=" + ae + "\n";
-        assertEquals(11, line.getBytes(UTF_8).length);
-        final Map<String, String> headers = TarUtils.parsePaxHeaders(new ByteArrayInputStream(line.getBytes(UTF_8)), null, new HashMap<>());
+        final byte[] bytes = line.getBytes(UTF_8);
+        assertEquals(11, bytes.length);
+        final Map<String, String> headers =
+                TarUtils.parsePaxHeaders(new ByteArrayInputStream(bytes), emptyList(), emptyMap(), 11);
         assertEquals(1, headers.size());
         assertEquals(ae, headers.get("path"));
     }
 
     @Test
     void testReadPax00SparseHeader() throws Exception {
-        final String header = "23 GNU.sparse.offset=0\n26 GNU.sparse.numbytes=10\n";
+        final byte[] header = "23 GNU.sparse.offset=0\n26 GNU.sparse.numbytes=10\n".getBytes(UTF_8);
         final List<TarArchiveStructSparse> sparseHeaders = new ArrayList<>();
-        TarUtils.parsePaxHeaders(new ByteArrayInputStream(header.getBytes(UTF_8)), sparseHeaders, Collections.emptyMap());
+        TarUtils.parsePaxHeaders(new ByteArrayInputStream(header), sparseHeaders, emptyMap(), header.length);
         assertEquals(1, sparseHeaders.size());
         assertEquals(0, sparseHeaders.get(0).getOffset());
         assertEquals(10, sparseHeaders.get(0).getNumbytes());
@@ -477,9 +480,9 @@ class TarUtilsTest extends AbstractTest {
 
     @Test
     void testReadPax00SparseHeaderMakesNumbytesOptional() throws Exception {
-        final String header = "23 GNU.sparse.offset=0\n24 GNU.sparse.offset=10\n";
+        final byte[] header = "23 GNU.sparse.offset=0\n24 GNU.sparse.offset=10\n".getBytes(UTF_8);
         final List<TarArchiveStructSparse> sparseHeaders = new ArrayList<>();
-        TarUtils.parsePaxHeaders(new ByteArrayInputStream(header.getBytes(UTF_8)), sparseHeaders, Collections.emptyMap());
+        TarUtils.parsePaxHeaders(new ByteArrayInputStream(header), sparseHeaders, emptyMap(), header.length);
         assertEquals(2, sparseHeaders.size());
         assertEquals(0, sparseHeaders.get(0).getOffset());
         assertEquals(0, sparseHeaders.get(0).getNumbytes());
@@ -487,48 +490,46 @@ class TarUtilsTest extends AbstractTest {
         assertEquals(0, sparseHeaders.get(1).getNumbytes());
     }
 
-    @Test
-    void testReadPax00SparseHeaderRejectsNegativeNumbytes() throws Exception {
-        final String header = "23 GNU.sparse.offset=0\n26 GNU.sparse.numbytes=-1\n";
-        assertThrows(ArchiveException.class, () -> TarUtils.parsePaxHeaders(new ByteArrayInputStream(header.getBytes(UTF_8)), null, Collections.emptyMap()));
+    static Stream<Arguments> testReadPaxHeaderInvalidCases() {
+        return Stream.of(
+                Arguments.of(
+                        "Negative numbytes in PAX 00 sparse header",
+                        "23 GNU.sparse.offset=0\n26 GNU.sparse.numbytes=-1\n"),
+                Arguments.of(
+                        "Negative offset in PAX 00 sparse header",
+                        "24 GNU.sparse.offset=-1\n26 GNU.sparse.numbytes=10\n"),
+                Arguments.of(
+                        "Non-numeric numbytes in PAX 00 sparse header",
+                        "23 GNU.sparse.offset=0\n26 GNU.sparse.numbytes=1a\n"),
+                Arguments.of(
+                        "Non-numeric offset in PAX 00 sparse header",
+                        "23 GNU.sparse.offset=a\n26 GNU.sparse.numbytes=10\n"),
+                Arguments.of("Missing trailing newline in PAX header", "30 atime=1321711775.9720594634"));
     }
 
-    @Test
-    void testReadPax00SparseHeaderRejectsNegativeOffset() throws Exception {
-        final String header = "24 GNU.sparse.offset=-1\n26 GNU.sparse.numbytes=10\n";
-        assertThrows(ArchiveException.class, () -> TarUtils.parsePaxHeaders(new ByteArrayInputStream(header.getBytes(UTF_8)), null, Collections.emptyMap()));
-    }
-
-    @Test
-    void testReadPax00SparseHeaderRejectsNonNumericNumbytes() throws Exception {
-        final String header = "23 GNU.sparse.offset=0\n26 GNU.sparse.numbytes=1a\n";
-        assertThrows(IOException.class, () -> TarUtils.parsePaxHeaders(new ByteArrayInputStream(header.getBytes(UTF_8)), null, Collections.emptyMap()));
-    }
-
-    @Test
-    void testReadPax00SparseHeaderRejectsNonNumericOffset() throws Exception {
-        final String header = "23 GNU.sparse.offset=a\n26 GNU.sparse.numbytes=10\n";
-        assertThrows(ArchiveException.class, () -> TarUtils.parsePaxHeaders(new ByteArrayInputStream(header.getBytes(UTF_8)), null, Collections.emptyMap()));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void testReadPaxHeaderInvalidCases(final String description, final String header) {
+        final byte[] bytes = header.getBytes(UTF_8);
+        assertThrows(
+                ArchiveException.class,
+                () -> TarUtils.parsePaxHeaders(new ByteArrayInputStream(bytes), emptyList(), emptyMap(), bytes.length));
     }
 
     @Test
     void testReadPaxHeaderWithEmbeddedNewline() throws Exception {
-        final Map<String, String> headers = TarUtils.parsePaxHeaders(new ByteArrayInputStream("28 comment=line1\nline2\nand3\n".getBytes(UTF_8)), null,
-                new HashMap<>());
+        final byte[] header = "28 comment=line1\nline2\nand3\n".getBytes(UTF_8);
+        final Map<String, String> headers =
+                TarUtils.parsePaxHeaders(new ByteArrayInputStream(header), emptyList(), emptyMap(), header.length);
         assertEquals(1, headers.size());
         assertEquals("line1\nline2\nand3", headers.get("comment"));
     }
 
     @Test
-    void testReadPaxHeaderWithoutTrailingNewline() throws Exception {
-        assertThrows(ArchiveException.class,
-                () -> TarUtils.parsePaxHeaders(new ByteArrayInputStream("30 atime=1321711775.9720594634".getBytes(UTF_8)), null, Collections.emptyMap()));
-    }
-
-    @Test
     void testReadSimplePaxHeader() throws Exception {
-        final Map<String, String> headers = TarUtils.parsePaxHeaders(new ByteArrayInputStream("30 atime=1321711775.972059463\n".getBytes(UTF_8)), null,
-                new HashMap<>());
+        final byte[] header = "30 atime=1321711775.972059463\n".getBytes(UTF_8);
+        final Map<String, String> headers =
+                TarUtils.parsePaxHeaders(new ByteArrayInputStream(header), emptyList(), emptyMap(), header.length);
         assertEquals(1, headers.size());
         assertEquals("1321711775.972059463", headers.get("atime"));
     }
@@ -643,8 +644,11 @@ class TarUtilsTest extends AbstractTest {
 
     @Test
     void testSecondEntryWinsWhenPaxHeaderContainsDuplicateKey() throws Exception {
-        final Map<String, String> headers = TarUtils.parsePaxHeaders(new ByteArrayInputStream("11 foo=bar\n11 foo=baz\n".getBytes(UTF_8)), null,
-                new HashMap<>());
+        final Map<String, String> headers = TarUtils.parsePaxHeaders(
+                new ByteArrayInputStream("11 foo=bar\n11 foo=baz\n".getBytes(UTF_8)),
+                emptyList(),
+                emptyMap(),
+                Integer.MAX_VALUE);
         assertEquals(1, headers.size());
         assertEquals("baz", headers.get("foo"));
     }


### PR DESCRIPTION
`TarUtils` already had a private constructor and was only used within the `o.a.c.compress.archivers.tar` package. This PR makes the class explicitly final and simplifies its internal API:

* Mark `TarUtils` as `final`.
* Change `protected` methods to package-private (they were never usable outside the package due to the private constructor).
* Remove deprecated non-`public` methods.
* Simplify `parsePaxHeaders`:

  * Require a non-negative `headerSize`. The special value `-1` (“unlimited”) was only used in tests.
  * Update tests to supply a valid `headerSize`.
  * Standardize error handling for invalid PAX 0.0 sparse records: all parsing errors now throw `ArchiveException` (previously one case threw `IOException`).

A changelog entry is included even though these are internal changes, to give users a reference point in case any unintended side effects arise.

This change is linked with #710, which needs to add a parameter to the currently protected `parsePaxHeaders` method.