### PR TITLE
Improve sparse file handling performance

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/tar/ComposedTarInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/ComposedTarInputStream.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers.tar;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+import org.apache.commons.compress.utils.ArchiveUtils;
+
+final class ComposedTarInputStream extends InputStream {
+
+    final Iterator<? extends InputStream> streams;
+    private final long size;
+    private InputStream current;
+    private long position;
+
+    ComposedTarInputStream(final Iterable<? extends InputStream> streams, final long size) {
+        this.streams = streams.iterator();
+        this.size = size;
+        this.current = this.streams.hasNext() ? this.streams.next() : null;
+        this.position = 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+        while (current != null) {
+            current.close();
+            current = streams.hasNext() ? streams.next() : null;
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (position >= size) {
+            return -1;
+        }
+        while (current != null) {
+            final int ret = current.read();
+            if (ret != -1) {
+                position++;
+                return ret;
+            }
+            nextStream();
+        }
+        throw new EOFException(String.format("Truncated TAR archive: expected %d bytes, but got only %d bytes", size, position));
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        ArchiveUtils.checkFromIndexSize(b, off, len);
+        if (len == 0) {
+            return 0;
+        }
+        if (position >= size) {
+            return -1;
+        }
+
+        final int toRead = (int) Math.min(size - position, len);
+        int remaining = toRead;
+        int dst = off;
+
+        while (current != null && remaining > 0) {
+            final int n = current.read(b, dst, remaining);
+            if (n == -1) {
+                nextStream();
+                continue;
+            }
+            position += n;
+            dst += n;
+            remaining -= n;
+        }
+
+        if (remaining == 0) {
+            return toRead;
+        }
+        throw new EOFException(String.format("Truncated TAR archive: expected %d bytes, but got only %d bytes", size, position));
+    }
+
+    private void nextStream() throws IOException {
+        if (current != null) {
+            current.close();
+        }
+        current = streams.hasNext() ? streams.next() : null;
+    }
+}

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -25,6 +25,7 @@
 package org.apache.commons.compress.archivers.tar;
 
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -149,20 +150,14 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
     /** True if stream is at EOF. */
     private boolean atEof;
 
-    /** Size of the current. */
-    private long entrySize;
-
     /** How far into the entry the stream is at. */
     private long entryOffset;
 
-    /** Input streams for reading sparse entries. **/
-    private List<InputStream> sparseInputStreams;
-
-    /** The index of current input stream being read when reading sparse entries. */
-    private int currentSparseInputStreamIndex;
-
     /** The meta-data about the current entry. */
     private TarArchiveEntry currEntry;
+
+    /** The current input stream. */
+    private InputStream currentInputStream;
 
     /** The encoding of the file. */
     private final ZipEncoding zipEncoding;
@@ -332,8 +327,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * </p>
      */
     private void buildSparseInputStreams() throws IOException {
-        currentSparseInputStreamIndex = -1;
-        sparseInputStreams = new ArrayList<>();
+        final List<InputStream> sparseInputStreams = new ArrayList<>();
         final List<TarArchiveStructSparse> sparseHeaders = currEntry.getOrderedSparseHeaders();
         // Stream doesn't need to be closed at all as it doesn't use any resources
         final InputStream zeroInputStream = new TarArchiveSparseZeroInputStream(); // NOSONAR
@@ -359,15 +353,15 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
                 // @formatter:off
                 sparseInputStreams.add(BoundedInputStream.builder()
                         .setInputStream(in)
+                        .setAfterRead(this::afterRead)
                         .setMaxCount(sparseHeader.getNumbytes())
+                        .setPropagateClose(false)
                         .get());
                 // @formatter:on
             }
             offset = sparseHeader.getOffset() + sparseHeader.getNumbytes();
         }
-        if (!sparseInputStreams.isEmpty()) {
-            currentSparseInputStreamIndex = 0;
-        }
+        currentInputStream = new ComposedTarInputStream(sparseInputStreams, currEntry.getRealSize());
     }
 
     /**
@@ -388,10 +382,9 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
     @Override
     public void close() throws IOException {
         // Close all the input streams in sparseInputStreams
-        if (sparseInputStreams != null) {
-            for (final InputStream inputStream : sparseInputStreams) {
-                inputStream.close();
-            }
+        if (currentInputStream != null) {
+            currentInputStream.close();
+            currentInputStream = null;
         }
         in.close();
     }
@@ -411,7 +404,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * For FileInputStream, the skip always return the number you input, so we need the available bytes to determine how many bytes are actually skipped
      *
      * @param available available bytes returned by {@link InputStream#available()}.
-     * @param skipped   skipped bytes returned by {@link InputStream#skip()}.
+     * @param skipped   skipped bytes returned by {@link InputStream#skip(long)}.
      * @param expected  bytes expected to skip.
      * @return number of bytes actually skipped.
      * @throws IOException if a truncated tar archive is detected.
@@ -491,8 +484,8 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
         boolean lastWasSpecial = false;
         do {
             // If there is a current entry, skip any unread data and padding
-            if (currEntry != null) {
-                IOUtils.skip(this, Long.MAX_VALUE); // Skip to end of current entry
+            if (currentInputStream != null) {
+                IOUtils.skip(currentInputStream, Long.MAX_VALUE); // Skip to end of current entry
                 skipRecordPadding(); // Skip padding to align to the next record
             }
             // Read the next header record
@@ -507,12 +500,18 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
             }
             // Parse the header into a new entry
             currEntry = new TarArchiveEntry(globalPaxHeaders, headerBuf, zipEncoding, lenient);
+            // Set up the input stream for the new entry
+            currentInputStream = BoundedInputStream.builder()
+                    .setInputStream(in)
+                    .setAfterRead(this::afterRead)
+                    .setMaxCount(currEntry.getSize())
+                    .setPropagateClose(false)
+                    .get();
             entryOffset = 0;
-            entrySize = currEntry.getSize();
             lastWasSpecial = TarUtils.isSpecialTarRecord(currEntry);
             if (lastWasSpecial) {
                 // Handle PAX, GNU long name, or other special records
-                TarUtils.handleSpecialTarRecord(this, zipEncoding, currEntry, paxHeaders, sparseHeaders, globalPaxHeaders, globalSparseHeaders);
+                TarUtils.handleSpecialTarRecord(currentInputStream, zipEncoding, currEntry, paxHeaders, sparseHeaders, globalPaxHeaders, globalSparseHeaders);
             }
         } while (lastWasSpecial);
         // Apply global and local PAX headers
@@ -520,9 +519,12 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
         // Handle sparse files
         if (currEntry.isSparse()) {
             if (currEntry.isOldGNUSparse()) {
+                // Old GNU sparse format uses extra header blocks for metadata.
+                // These blocks are not included in the entry’s size, so we cannot
+                // rely on BoundedInputStream here.
                 readOldGNUSparse();
             } else if (currEntry.isPaxGNU1XSparse()) {
-                currEntry.setSparseHeaders(TarUtils.parsePAX1XSparseHeaders(in, getRecordSize()));
+                currEntry.setSparseHeaders(TarUtils.parsePAX1XSparseHeaders(currentInputStream, getRecordSize()));
             }
             // sparse headers are all done reading, we need to build
             // sparse input streams using these sparse headers
@@ -532,9 +534,18 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
         if (currEntry.isDirectory() && !currEntry.getName().endsWith("/")) {
             currEntry.setName(currEntry.getName() + "/");
         }
-        // Update entry size in case it changed due to PAX headers
-        entrySize = currEntry.getSize();
         return currEntry;
+    }
+
+    private void afterRead(final int read) throws IOException {
+        // Count the bytes read
+        count(read);
+        // Check for truncated entries
+        if (read == -1 && entryOffset < currEntry.getSize()) {
+            throw new EOFException(String.format("Truncated TAR archive: entry '%s' expected %d bytes, but got %d", currEntry.getName(), currEntry.getSize(),
+                    entryOffset));
+        }
+        entryOffset += Math.max(0, read);
     }
 
     /**
@@ -634,40 +645,23 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @param offset    The offset at which to place bytes read.
      * @param numToRead The number of bytes to read.
      * @return The number of bytes read, or -1 at EOF.
+     * @throws NullPointerException if {@code buf} is null
+     * @throws IndexOutOfBoundsException if {@code [offset, offset + numToRead)} is not a valid range within {@code buf}
      * @throws IOException on error
      */
     @Override
     public int read(final byte[] buf, final int offset, int numToRead) throws IOException {
+        ArchiveUtils.checkFromIndexSize(buf, offset, numToRead);
         if (numToRead == 0) {
             return 0;
         }
-        int totalRead = 0;
         if (isAtEOF() || isDirectory()) {
             return -1;
         }
-        if (currEntry == null) {
+        if (currEntry == null || currentInputStream == null) {
             throw new IllegalStateException("No current tar entry");
         }
-        if (entryOffset >= currEntry.getRealSize()) {
-            return -1;
-        }
-        numToRead = Math.min(numToRead, available());
-        if (currEntry.isSparse()) {
-            // for sparse entries, we need to read them in another way
-            totalRead = readSparse(buf, offset, numToRead);
-        } else {
-            totalRead = in.read(buf, offset, numToRead);
-        }
-        if (totalRead == -1) {
-            if (numToRead > 0) {
-                throw new ArchiveException("Truncated TAR archive");
-            }
-            setAtEOF(true);
-        } else {
-            count(totalRead);
-            entryOffset += totalRead;
-        }
-        return totalRead;
+        return currentInputStream.read(buf, offset, numToRead);
     }
 
     /**
@@ -687,9 +681,6 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
                 currEntry.getSparseHeaders().addAll(entry.getSparseHeaders());
             } while (entry.isExtended());
         }
-        // sparse headers are all done reading, we need to build
-        // sparse input streams using these sparse headers
-        buildSparseInputStreams();
     }
 
     /**
@@ -705,52 +696,6 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
             return null;
         }
         return recordBuffer;
-    }
-
-    /**
-     * For sparse tar entries, there are many "holes"(consisting of all 0) in the file. Only the non-zero data is stored in tar files, and they are stored
-     * separately. The structure of non-zero data is introduced by the sparse headers using the offset, where a block of non-zero data starts, and numbytes, the
-     * length of the non-zero data block. When reading sparse entries, the actual data is read out with "holes" and non-zero data combined according to
-     * the sparse headers.
-     *
-     * @param buf       The buffer into which to place bytes read.
-     * @param offset    The offset at which to place bytes read.
-     * @param numToRead The number of bytes to read.
-     * @return The number of bytes read, or -1 at EOF.
-     * @throws IOException on error.
-     */
-    private int readSparse(final byte[] buf, final int offset, final int numToRead) throws IOException {
-        // if there are no actual input streams, just read from the original input stream
-        if (sparseInputStreams == null || sparseInputStreams.isEmpty()) {
-            return in.read(buf, offset, numToRead);
-        }
-        if (currentSparseInputStreamIndex >= sparseInputStreams.size()) {
-            return -1;
-        }
-        final InputStream currentInputStream = sparseInputStreams.get(currentSparseInputStreamIndex);
-        final int readLen = currentInputStream.read(buf, offset, numToRead);
-        // if the current input stream is the last input stream,
-        // just return the number of bytes read from current input stream
-        if (currentSparseInputStreamIndex == sparseInputStreams.size() - 1) {
-            return readLen;
-        }
-        // if EOF of current input stream is meet, open a new input stream and recursively call read
-        if (readLen == -1) {
-            currentSparseInputStreamIndex++;
-            return readSparse(buf, offset, numToRead);
-        }
-        // if the rest data of current input stream is not long enough, open a new input stream
-        // and recursively call read
-        if (readLen < numToRead) {
-            currentSparseInputStreamIndex++;
-            final int readLenOfNext = readSparse(buf, offset + readLen, numToRead - readLen);
-            if (readLenOfNext == -1) {
-                return readLen;
-            }
-            return readLen + readLenOfNext;
-        }
-        // if the rest data of current input stream is enough(which means readLen == len), just return readLen
-        return readLen;
     }
 
     /**
@@ -793,21 +738,11 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
         if (n <= 0 || isDirectory()) {
             return 0;
         }
-        final long availableOfInputStream = in.available();
-        final long available = currEntry.getRealSize() - entryOffset;
-        final long numToSkip = Math.min(n, available);
-        long skipped;
-        if (!currEntry.isSparse()) {
-            skipped = IOUtils.skip(in, numToSkip);
-            // for non-sparse entry, we should get the bytes actually skipped bytes along with
-            // inputStream.available() if inputStream is instance of FileInputStream
-            skipped = getActuallySkipped(availableOfInputStream, skipped, numToSkip);
-        } else {
-            skipped = skipSparse(numToSkip);
+        if (currEntry == null || currentInputStream == null) {
+            throw new IllegalStateException("No current tar entry");
         }
-        count(skipped);
-        entryOffset += skipped;
-        return skipped;
+        // Use Apache Commons IO to skip as it handles skipping fully
+        return org.apache.commons.io.IOUtils.skip(currentInputStream, n);
     }
 
     /**
@@ -816,37 +751,15 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
      * @throws IOException if a truncated tar archive is detected.
      */
     private void skipRecordPadding() throws IOException {
-        if (!isDirectory() && this.entrySize > 0 && this.entrySize % getRecordSize() != 0) {
-            final long available = in.available();
-            final long numRecords = this.entrySize / getRecordSize() + 1;
-            final long padding = numRecords * getRecordSize() - this.entrySize;
-            long skipped = IOUtils.skip(in, padding);
-            skipped = getActuallySkipped(available, skipped, padding);
+        final long entrySize = currEntry != null ? currEntry.getSize() : 0;
+        if (!isDirectory() && entrySize > 0 && entrySize % getRecordSize() != 0) {
+            final long padding = getRecordSize() - (entrySize % getRecordSize());
+            final long skipped = org.apache.commons.io.IOUtils.skip(in, padding);
             count(skipped);
-        }
-    }
-
-    /**
-     * Skip n bytes from current input stream, if the current input stream doesn't have enough data to skip, jump to the next input stream and skip the rest
-     * bytes, keep doing this until total n bytes are skipped or the input streams are all skipped
-     *
-     * @param n bytes of data to skip.
-     * @return actual bytes of data skipped.
-     * @throws IOException if an I/O error occurs.
-     */
-    private long skipSparse(final long n) throws IOException {
-        if (sparseInputStreams == null || sparseInputStreams.isEmpty()) {
-            return in.skip(n);
-        }
-        long bytesSkipped = 0;
-        while (bytesSkipped < n && currentSparseInputStreamIndex < sparseInputStreams.size()) {
-            final InputStream currentInputStream = sparseInputStreams.get(currentSparseInputStreamIndex);
-            bytesSkipped += currentInputStream.skip(n - bytesSkipped);
-            if (bytesSkipped < n) {
-                currentSparseInputStreamIndex++;
+            if (skipped != padding) {
+                throw new EOFException(String.format("Truncated TAR archive: failed to skip record padding for entry '%s'", currEntry.getName()));
             }
         }
-        return bytesSkipped;
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarFile.java
@@ -18,7 +18,10 @@
  */
 package org.apache.commons.compress.archivers.tar;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +30,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -58,84 +62,29 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
 
         private final TarArchiveEntry entry;
 
-        private long entryOffset;
-
-        private int currentSparseInputStreamIndex;
-
         BoundedTarEntryInputStream(final TarArchiveEntry entry, final SeekableByteChannel channel) throws IOException {
-            super(entry.getDataOffset(), entry.getRealSize());
-            if (channel.size() - entry.getSize() < entry.getDataOffset()) {
-                throw new ArchiveException("Entry size exceeds archive size");
-            }
+            super(entry.getDataOffset(), entry.getSize());
             this.entry = entry;
             this.channel = channel;
         }
 
         @Override
         protected int read(final long pos, final ByteBuffer buf) throws IOException {
-            if (entryOffset >= entry.getRealSize()) {
-                return -1;
-            }
-            final int totalRead;
-            if (entry.isSparse()) {
-                totalRead = readSparse(entryOffset, buf, buf.limit());
-            } else {
-                totalRead = readArchive(pos, buf);
-            }
+            requireNonNull(buf, "ByteBuffer");
+            // The caller ensures that [pos, pos + buf.remaining()] is within [start, end]
+            channel.position(pos);
+            final int totalRead = channel.read(buf);
             if (totalRead == -1) {
-                if (buf.array().length > 0) {
-                    throw new ArchiveException("Truncated TAR archive");
+                if (buf.remaining() > 0) {
+                    throw new EOFException(String.format("Truncated TAR archive: expected at least %d bytes, but got only %d bytes",
+                            entry.getDataOffset() + entry.getSize(), channel.position()));
                 }
+                // Marks the TarFile as having reached EOF.
                 setAtEOF(true);
             } else {
-                entryOffset += totalRead;
                 buf.flip();
             }
             return totalRead;
-        }
-
-        private int readArchive(final long pos, final ByteBuffer buf) throws IOException {
-            channel.position(pos);
-            return channel.read(buf);
-        }
-
-        private int readSparse(final long pos, final ByteBuffer buf, final int numToRead) throws IOException {
-            // if there are no actual input streams, just read from the original archive
-            final List<InputStream> entrySparseInputStreams = sparseInputStreams.get(entry.getName());
-            if (entrySparseInputStreams == null || entrySparseInputStreams.isEmpty()) {
-                return readArchive(entry.getDataOffset() + pos, buf);
-            }
-            if (currentSparseInputStreamIndex >= entrySparseInputStreams.size()) {
-                return -1;
-            }
-            final InputStream currentInputStream = entrySparseInputStreams.get(currentSparseInputStreamIndex);
-            final byte[] bufArray = new byte[numToRead];
-            final int readLen = currentInputStream.read(bufArray);
-            if (readLen != -1) {
-                buf.put(bufArray, 0, readLen);
-            }
-            // if the current input stream is the last input stream,
-            // just return the number of bytes read from current input stream
-            if (currentSparseInputStreamIndex == entrySparseInputStreams.size() - 1) {
-                return readLen;
-            }
-            // if EOF of current input stream is meet, open a new input stream and recursively call read
-            if (readLen == -1) {
-                currentSparseInputStreamIndex++;
-                return readSparse(pos, buf, numToRead);
-            }
-            // if the rest data of current input stream is not long enough, open a new input stream
-            // and recursively call read
-            if (readLen < numToRead) {
-                currentSparseInputStreamIndex++;
-                final int readLenOfNext = readSparse(pos + readLen, buf, numToRead - readLen);
-                if (readLenOfNext == -1) {
-                    return readLen;
-                }
-                return readLen + readLenOfNext;
-            }
-            // if the rest data of current input stream is enough(which means readLen == len), just return readLen
-            return readLen;
         }
     }
 
@@ -462,6 +411,12 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
      */
     public InputStream getInputStream(final TarArchiveEntry entry) throws IOException {
         try {
+            // Sparse entries are composed of multiple fragments: wrap them in a ComposedTarInputStream
+            if (entry.isSparse()) {
+                final List<InputStream> streams = sparseInputStreams.get(entry.getName());
+                return new ComposedTarInputStream(streams != null ? streams : Collections.emptyList(), entry.getRealSize());
+            }
+            // Regular entries are bounded: wrap in BoundedTarEntryInputStream to enforce size and detect premature EOF
             return new BoundedTarEntryInputStream(entry, archive);
         } catch (final RuntimeException e) {
             throw new ArchiveException("Corrupted TAR archive. Can't read entry", (Throwable) e);
@@ -484,6 +439,7 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
         final List<TarArchiveStructSparse> sparseHeaders = new ArrayList<>();
         // Handle special tar records
         boolean lastWasSpecial = false;
+        InputStream currentStream;
         do {
             // If there is a current entry, skip any unread data and padding
             if (currEntry != null) {
@@ -504,10 +460,13 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
             // Parse the header into a new entry
             final long position = archive.position();
             currEntry = new TarArchiveEntry(globalPaxHeaders, headerBuf.array(), zipEncoding, lenient, position);
+            currentStream = new BoundedTarEntryInputStream(currEntry, archive);
             lastWasSpecial = TarUtils.isSpecialTarRecord(currEntry);
             if (lastWasSpecial) {
                 // Handle PAX, GNU long name, or other special records
-                TarUtils.handleSpecialTarRecord(getInputStream(currEntry), zipEncoding, currEntry, paxHeaders, sparseHeaders, globalPaxHeaders,
+                // Make sure not to read beyond the entry data
+                final BoundedTarEntryInputStream inputStream = new BoundedTarEntryInputStream(currEntry, archive);
+                TarUtils.handleSpecialTarRecord(inputStream, zipEncoding, currEntry, paxHeaders, sparseHeaders, globalPaxHeaders,
                         globalSparseHeaders);
             }
         } while (lastWasSpecial);
@@ -515,11 +474,21 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
         TarUtils.applyPaxHeadersToEntry(currEntry, paxHeaders, sparseHeaders, globalPaxHeaders, globalSparseHeaders);
         // Handle sparse files
         if (currEntry.isSparse()) {
+            // These sparse formats have the sparse headers in the entry
             if (currEntry.isOldGNUSparse()) {
+                // Old GNU sparse format uses extra header blocks for metadata.
+                // These blocks are not included in the entry’s size, so we cannot
+                // rely on BoundedTarEntryInputStream here.
                 readOldGNUSparse();
+                // Reposition to the start of the entry data to correctly compute the sparse streams
+                currEntry.setDataOffset(archive.position());
             } else if (currEntry.isPaxGNU1XSparse()) {
-                currEntry.setSparseHeaders(TarUtils.parsePAX1XSparseHeaders(getInputStream(currEntry), recordSize));
-                currEntry.setDataOffset(currEntry.getDataOffset() + recordSize);
+                final long position = archive.position();
+                currEntry.setSparseHeaders(TarUtils.parsePAX1XSparseHeaders(currentStream, recordSize));
+                // Adjust the current entry to point to the start of the sparse file data
+                final long sparseHeadersSize = archive.position() - position;
+                currEntry.setSize(currEntry.getSize() - sparseHeadersSize);
+                currEntry.setDataOffset(currEntry.getDataOffset() + sparseHeadersSize);
             }
             // sparse headers are all done reading, we need to build
             // sparse input streams using these sparse headers
@@ -620,12 +589,8 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
                 }
                 entry = new TarArchiveSparseEntry(headerBuf.array());
                 currEntry.getSparseHeaders().addAll(entry.getSparseHeaders());
-                currEntry.setDataOffset(currEntry.getDataOffset() + recordSize);
             } while (entry.isExtended());
         }
-        // sparse headers are all done reading, we need to build
-        // sparse input streams using these sparse headers
-        buildSparseInputStreams();
     }
 
     /**
@@ -671,8 +636,7 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
      */
     private void skipRecordPadding() throws IOException {
         if (!isDirectory() && currEntry.getSize() > 0 && currEntry.getSize() % recordSize != 0) {
-            final long numRecords = currEntry.getSize() / recordSize + 1;
-            final long padding = numRecords * recordSize - currEntry.getSize();
+            final long padding = recordSize - (currEntry.getSize() % recordSize);
             repositionForwardBy(padding);
             throwExceptionIfPositionIsNotInArchive();
         }
@@ -685,7 +649,7 @@ public class TarFile implements Closeable, IOIterable<TarArchiveEntry> {
      */
     private void throwExceptionIfPositionIsNotInArchive() throws IOException {
         if (archive.size() < archive.position()) {
-            throw new ArchiveException("Truncated TAR archive");
+            throw new EOFException("Truncated TAR archive: archive should be at least " + archive.position() + " bytes but was " + archive.size() + " bytes");
         }
     }
 

--- a/src/main/java/org/apache/commons/compress/utils/ArchiveUtils.java
+++ b/src/main/java/org/apache/commons/compress/utils/ArchiveUtils.java
@@ -21,6 +21,7 @@ package org.apache.commons.compress.utils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 
@@ -259,6 +260,23 @@ public class ArchiveUtils {
         }
         sb.append(size).append(' ').append(entry.getName());
         return sb.toString();
+    }
+
+    /**
+     * Checks that the specified range is within the bounds of an array of the specified length.
+     *
+     * @param b           the array
+     * @param off         the starting offset of the range
+     * @param len         the length of the range
+     * @throws IndexOutOfBoundsException if {@code off} is negative, or {@code len} is negative, or {@code off + len} is greater than {@code arrayLength}
+     * @since 1.29.0
+     */
+    public static void checkFromIndexSize(final byte[] b, final int off, final int len) {
+        // TODO: replace with IOUtils.checkFromIndexSize, after upgrading to Commons IO 2.21.0
+        Objects.requireNonNull(b, "byte array");
+        if ((off | len) < 0 || b.length - len < off) {
+            throw new IndexOutOfBoundsException(String.format("Range [%s, %<s + %s) out of bounds for length %s", off, len, b.length));
+        }
     }
 
     /** Private constructor to prevent instantiation of this utility class. */

--- a/src/main/java/org/apache/commons/compress/utils/BoundedArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/utils/BoundedArchiveInputStream.java
@@ -69,6 +69,11 @@ public abstract class BoundedArchiveInputStream extends InputStream {
 
     @Override
     public synchronized int read(final byte[] b, final int off, final int len) throws IOException {
+        ArchiveUtils.checkFromIndexSize(b, off, len);
+        if (len == 0) {
+            return 0;
+        }
+
         if (loc >= end) {
             return -1;
         }
@@ -89,12 +94,15 @@ public abstract class BoundedArchiveInputStream extends InputStream {
     }
 
     /**
-     * Reads content of the stream into a {@link ByteBuffer}.
+     * Reads bytes from this stream into the given {@link ByteBuffer}, starting at the specified position.
      *
-     * @param pos position to start the read.
-     * @param buf buffer to add the read content.
-     * @return number of read bytes.
-     * @throws IOException if I/O fails.
+     * <p>The caller is responsible for ensuring that the requested range
+     * {@code [pos, pos + buf.remaining())} lies within the valid bounds of the stream.</p>
+     *
+     * @param pos the position within the stream at which to begin reading
+     * @param buf the buffer into which bytes are read; bytes are written starting at the buffer’s current position
+     * @return the number of bytes read into the buffer
+     * @throws IOException if an I/O error occurs while reading
      */
     protected abstract int read(long pos, ByteBuffer buf) throws IOException;
 }

--- a/src/test/java/org/apache/commons/compress/archivers/TestArchiveGenerator.java
+++ b/src/test/java/org/apache/commons/compress/archivers/TestArchiveGenerator.java
@@ -1,0 +1,390 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+public final class TestArchiveGenerator {
+
+    private static final int TIMESTAMP = 0;
+    private static final int OWNER_ID = 0;
+    private static final String OWNER_NAME = "owner";
+    private static final int GROUP_ID = 0;
+    private static final String GROUP_NAME = "group";
+    private static final int FILE_MODE = 0100644;
+    // TAR
+    private static final String OLD_GNU_MAGIC = "ustar  ";
+    private static final String PAX_MAGIC = "ustar\u000000";
+
+    public static void main(final String[] args) throws IOException {
+        if (args.length != 1) {
+            System.err.println("Expected one argument: output directory");
+            System.exit(1);
+        }
+        final Path path = Paths.get(args[0]);
+        if (!Files.isDirectory(path)) {
+            System.err.println("Not a directory: " + path);
+            System.exit(1);
+        }
+        // Sparse file examples
+        final Path sparsePath = path.resolve("sparse");
+        Files.createDirectories(sparsePath);
+        createSparseFileTestCases(sparsePath);
+    }
+
+    public static void createSparseFileTestCases(final Path path) throws IOException {
+        if (!Files.isDirectory(path)) {
+            throw new IllegalArgumentException("Not a directory: " + path);
+        }
+        oldGnuSparse(path);
+        gnuSparse00(path);
+        gnuSparse01(path);
+        gnuSparse1X(path);
+    }
+
+    private static void oldGnuSparse(final Path path) throws IOException {
+        final Path file = path.resolve("old-gnu-sparse.tar");
+        try (OutputStream out = Files.newOutputStream(file)) {
+            final byte[] data = createData(8 * 1024);
+            final List<Pair<Integer, Integer>> sparseEntries = createFragmentedSparseEntries(data.length);
+            writeOldGnuSparseFile(sparseEntries, data, data.length, out);
+            writeUstarTrailer(out);
+        }
+    }
+
+    private static void gnuSparse00(final Path path) throws IOException {
+        final Path file = path.resolve("gnu-sparse-00.tar");
+        try (OutputStream out = Files.newOutputStream(file)) {
+            final byte[] data = createData(8 * 1024);
+            final List<Pair<Integer, Integer>> sparseEntries = createFragmentedSparseEntries(data.length);
+            final byte[] paxData = createGnuSparse00PaxData(sparseEntries, data.length);
+            writeGnuSparse0File(data, paxData, out);
+            writeUstarTrailer(out);
+        }
+    }
+
+    private static void gnuSparse01(final Path path) throws IOException {
+        final Path file = path.resolve("gnu-sparse-01.tar");
+        try (OutputStream out = Files.newOutputStream(file)) {
+            final byte[] data = createData(8 * 1024);
+            final List<Pair<Integer, Integer>> sparseEntries = createFragmentedSparseEntries(data.length);
+            final byte[] paxData = createGnuSparse01PaxData(sparseEntries, data.length);
+            writeGnuSparse0File(data, paxData, out);
+            writeUstarTrailer(out);
+        }
+    }
+
+    private static void gnuSparse1X(final Path path) throws IOException {
+        final Path file = path.resolve("gnu-sparse-1.tar");
+        try (OutputStream out = Files.newOutputStream(file)) {
+            final byte[] data = createData(8 * 1024);
+            final List<Pair<Integer, Integer>> sparseEntries = createFragmentedSparseEntries(data.length);
+            writeGnuSparse1File(sparseEntries, data, out);
+            writeUstarTrailer(out);
+        }
+    }
+
+    // Very fragmented sparse file
+    private static List<Pair<Integer, Integer>> createFragmentedSparseEntries(final int realSize) {
+        final List<Pair<Integer, Integer>> sparseEntries = new ArrayList<>();
+        for (int offset = 0; offset < realSize; offset++) {
+            sparseEntries.add(Pair.of(offset, 1));
+        }
+        return sparseEntries;
+    }
+
+    private static byte[] createData(final int size) {
+        final byte[] data = new byte[size];
+        for (int i = 0; i < size; i++) {
+            data[i] = (byte) (i % 256);
+        }
+        return data;
+    }
+
+    private static void writeOldGnuSparseFile(
+            final Collection<Pair<Integer, Integer>> sparseEntries,
+            final byte[] data,
+            final int realSize,
+            final OutputStream out)
+            throws IOException {
+        int offset = writeTarUstarHeader("sparse-file.txt", data.length, OLD_GNU_MAGIC, 'S', out);
+        while (offset < 386) {
+            out.write(0);
+            offset++;
+        }
+        // Sparse entries (24 bytes each)
+        offset += writeOldGnuSparseEntries(sparseEntries, 4, out);
+        // Real size (12 bytes)
+        offset += writeOctalString(realSize, 12, out);
+        offset = padTo512Bytes(offset, out);
+        // Write extended headers
+        while (!sparseEntries.isEmpty()) {
+            offset += writeOldGnuSparseExtendedHeader(sparseEntries, out);
+        }
+        // Write file data
+        out.write(data);
+        offset += data.length;
+        padTo512Bytes(offset, out);
+    }
+
+    private static void writeGnuSparse0File(final byte[] data, final byte[] paxData, final OutputStream out)
+            throws IOException {
+        // PAX entry
+        int offset = writeTarUstarHeader("./GNUSparseFile.1/" + "sparse-file.txt", paxData.length, PAX_MAGIC, 'x', out);
+        offset = padTo512Bytes(offset, out);
+        // PAX data
+        out.write(paxData);
+        offset += paxData.length;
+        offset = padTo512Bytes(offset, out);
+        // File entry
+        offset += writeTarUstarHeader("sparse-file.txt", data.length, PAX_MAGIC, '0', out);
+        offset = padTo512Bytes(offset, out);
+        // File data
+        out.write(data);
+        offset += data.length;
+        padTo512Bytes(offset, out);
+    }
+
+    private static void writeGnuSparse1File(
+            final Collection<Pair<Integer, Integer>> sparseEntries, final byte[] data, final OutputStream out)
+            throws IOException {
+        // PAX entry
+        final byte[] paxData = createGnuSparse1PaxData(sparseEntries, data.length);
+        int offset = writeTarUstarHeader("./GNUSparseFile.1/sparse-file.txt", paxData.length, PAX_MAGIC, 'x', out);
+        offset = padTo512Bytes(offset, out);
+        // PAX data
+        out.write(paxData);
+        offset += paxData.length;
+        offset = padTo512Bytes(offset, out);
+        // File entry
+        final byte[] sparseEntriesData = createGnuSparse1EntriesData(sparseEntries);
+        offset += writeTarUstarHeader("sparse-file.txt", sparseEntriesData.length + data.length, PAX_MAGIC, '0', out);
+        offset = padTo512Bytes(offset, out);
+        // File data
+        out.write(sparseEntriesData);
+        offset += sparseEntriesData.length;
+        out.write(data);
+        offset += data.length;
+        padTo512Bytes(offset, out);
+    }
+
+    private static int writeTarUstarHeader(
+            final String fileName,
+            final long fileSize,
+            final String magicAndVersion,
+            final char typeFlag,
+            final OutputStream out)
+            throws IOException {
+        int count = 0;
+        // File name (100 bytes)
+        count += writeString(fileName, 100, out);
+        // File mode (8 bytes)
+        count += writeOctalString(FILE_MODE, 8, out);
+        // Owner ID (8 bytes)
+        count += writeOctalString(OWNER_ID, 8, out);
+        // Group ID (8 bytes)
+        count += writeOctalString(GROUP_ID, 8, out);
+        // File size (12 bytes)
+        count += writeOctalString(fileSize, 12, out);
+        // Modification timestamp (12 bytes)
+        count += writeOctalString(TIMESTAMP, 12, out);
+        // Checksum (8 bytes), filled with spaces for now
+        count += writeString(StringUtils.repeat(' ', 7), 8, out);
+        // Link indicator (1 byte)
+        out.write(typeFlag);
+        count++;
+        // Name of linked file (100 bytes)
+        count += writeString("", 100, out);
+        // Magic (6 bytes) + Version (2 bytes)
+        count += writeString(magicAndVersion, 8, out);
+        // Owner user name (32 bytes)
+        count += writeString(OWNER_NAME, 32, out);
+        // Owner group name (32 bytes)
+        count += writeString(GROUP_NAME, 32, out);
+        // Device major number (8 bytes)
+        count += writeString("", 8, out);
+        // Device minor number (8 bytes)
+        count += writeString("", 8, out);
+        return count;
+    }
+
+    private static int writeOldGnuSparseExtendedHeader(
+            final Iterable<Pair<Integer, Integer>> sparseEntries, final OutputStream out) throws IOException {
+        int offset = 0;
+        offset += writeOldGnuSparseEntries(sparseEntries, 21, out);
+        offset = padTo512Bytes(offset, out);
+        return offset;
+    }
+
+    private static void writeUstarTrailer(final OutputStream out) throws IOException {
+        int offset = 0;
+        // 1024 bytes of zero
+        while (offset < 1024) {
+            out.write(0);
+            offset++;
+        }
+    }
+
+    private static int writeOldGnuSparseEntries(
+            final Iterable<Pair<Integer, Integer>> sparseEntries, final int limit, final OutputStream out)
+            throws IOException {
+        int offset = 0;
+        int count = 0;
+        final Iterator<Pair<Integer, Integer>> it = sparseEntries.iterator();
+        while (it.hasNext()) {
+            if (count >= limit) {
+                out.write(1); // more entries follow
+                return ++offset;
+            }
+            final Pair<Integer, Integer> entry = it.next();
+            it.remove();
+            count++;
+            offset += writeOldGnuSparseEntry(entry.getLeft(), entry.getRight(), out);
+        }
+        while (count < limit) {
+            // pad with empty entries
+            offset += writeOldGnuSparseEntry(0, 0, out);
+            count++;
+        }
+        out.write(0); // no more entries
+        return ++offset;
+    }
+
+    private static int writeOldGnuSparseEntry(final int offset, final int length, final OutputStream out)
+            throws IOException {
+        int count = 0;
+        count += writeOctalString(offset, 12, out);
+        count += writeOctalString(length, 12, out);
+        return count;
+    }
+
+    private static byte[] createGnuSparse00PaxData(
+            final Collection<? extends Pair<Integer, Integer>> sparseEntries, final int realSize) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(baos, US_ASCII))) {
+            writePaxKeyValue("GNU.sparse.size", realSize, writer);
+            writePaxKeyValue("GNU.sparse.numblocks", sparseEntries.size(), writer);
+            for (final Pair<Integer, Integer> entry : sparseEntries) {
+                writePaxKeyValue("GNU.sparse.offset", entry.getLeft(), writer);
+                writePaxKeyValue("GNU.sparse.numbytes", entry.getRight(), writer);
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] createGnuSparse01PaxData(
+            final Collection<? extends Pair<Integer, Integer>> sparseEntries, final int realSize) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(baos, US_ASCII))) {
+            writePaxKeyValue("GNU.sparse.size", realSize, writer);
+            writePaxKeyValue("GNU.sparse.numblocks", sparseEntries.size(), writer);
+            final String map = sparseEntries.stream()
+                    .map(e -> e.getLeft() + "," + e.getRight())
+                    .collect(Collectors.joining(","));
+            writePaxKeyValue("GNU.sparse.map", map, writer);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] createGnuSparse1PaxData(
+            final Collection<Pair<Integer, Integer>> sparseEntries, final int realSize) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(baos, US_ASCII))) {
+            writePaxKeyValue("GNU.sparse.realsize", realSize, writer);
+            writePaxKeyValue("GNU.sparse.numblocks", sparseEntries.size(), writer);
+            writePaxKeyValue("GNU.sparse.major", 1, writer);
+            writePaxKeyValue("GNU.sparse.minor", 0, writer);
+        }
+        return baos.toByteArray();
+    }
+
+    private static void writePaxKeyValue(final String key, final String value, final PrintWriter out) {
+        final String entry = ' ' + key + "=" + value + "\n";
+        // Guess length: length of length + space + entry
+        final int length = String.valueOf(entry.length()).length() + entry.length();
+        // Recompute if number of digits changes
+        out.print(String.valueOf(length).length() + entry.length());
+        out.print(entry);
+    }
+
+    private static void writePaxKeyValue(final String key, final int value, final PrintWriter out) {
+        writePaxKeyValue(key, Integer.toString(value), out);
+    }
+
+    private static byte[] createGnuSparse1EntriesData(final Collection<? extends Pair<Integer, Integer>> sparseEntries)
+            throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(baos, US_ASCII))) {
+            writer.printf("%d\n", sparseEntries.size());
+            for (final Pair<Integer, Integer> entry : sparseEntries) {
+                writer.printf("%d\n", entry.getLeft());
+                writer.printf("%d\n", entry.getRight());
+            }
+        }
+        padTo512Bytes(baos.size(), baos);
+        return baos.toByteArray();
+    }
+
+    private static int writeOctalString(final long value, final int length, final OutputStream out) throws IOException {
+        int count = 0;
+        final String s = Long.toOctalString(value);
+        count += writeString(s, length - 1, out);
+        out.write('\0');
+        return ++count;
+    }
+
+    private static int writeString(final String s, final int length, final OutputStream out) throws IOException {
+        final byte[] bytes = s.getBytes(US_ASCII);
+        out.write(bytes);
+        for (int i = bytes.length; i < length; i++) {
+            out.write('\0');
+        }
+        return length;
+    }
+
+    private static int padTo512Bytes(final int offset, final OutputStream out) throws IOException {
+        int count = offset;
+        while (count % 512 != 0) {
+            out.write(0);
+            count++;
+        }
+        return count;
+    }
+
+    private TestArchiveGenerator() {
+        // hide constructor
+    }
+}

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStreamTest.java
@@ -36,6 +36,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -405,7 +406,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
     void testParseTarWithSpecialPaxHeaders() throws IOException {
         try (TarArchiveInputStream archive = getTestStream("COMPRESS-530-fail.tar")) {
             assertThrows(ArchiveException.class, () -> archive.getNextEntry());
-            assertThrows(ArchiveException.class, () -> IOUtils.toByteArray(archive));
+            assertThrows(EOFException.class, () -> IOUtils.toByteArray(archive));
         }
     }
 
@@ -501,7 +502,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
     void testShouldThrowAnExceptionOnTruncatedEntries() throws Exception {
         final Path dir = createTempDirectory("COMPRESS-279");
         try (TarArchiveInputStream is = getTestStream("COMPRESS-279-fail.tar")) {
-            assertThrows(ArchiveException.class, () -> {
+            assertThrows(EOFException.class, () -> {
                 TarArchiveEntry entry = is.getNextTarEntry();
                 int count = 0;
                 while (entry != null) {
@@ -518,7 +519,7 @@ class TarArchiveInputStreamTest extends AbstractTest {
         final Path dir = createTempDirectory("COMPRESS-279");
         try (TarArchiveInputStream is = getTestStream("COMPRESS-279-fail.tar")) {
             final AtomicInteger count = new AtomicInteger();
-            assertThrows(ArchiveException.class, () -> is.forEach(entry -> Files.copy(is, dir.resolve(String.valueOf(count.getAndIncrement())))));
+            assertThrows(EOFException.class, () -> is.forEach(entry -> Files.copy(is, dir.resolve(String.valueOf(count.getAndIncrement())))));
         }
     }
 


### PR DESCRIPTION
Previously, sparse files were processed recursively. On highly fragmented files, this led to deep recursion and significant inefficiency.

This change replaces the recursive approach with an iterative strategy, which scales better for files with many fragments. It also introduces generated tests that simulate sparse files with very high fragmentation to ensure correctness and performance under stress.
