### PR TITLE
Add `AbstractArchiveBuilder` for unified archiver support

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -125,6 +125,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="add" dev="ggregory" due-to="Gary Gregory, Piotr P. Karwasz">Introduce builders for all ArchiveInputStream implementations and deprecate some constructors.</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">TarFile now implements IOIterable&lt;TarArchiveEntry&gt;.</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add a builder for the TarFile class and deprecate some constructors.</action>
+      <action type="add" dev="pkarwasz" due-to="Piotr Karwasz">SevenZFile, TarFile, and ZipFile now always close underlying resources when builder or constructor fails.</action>
       <!-- UPDATE -->
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-parent from 85 to 88 #707.</action>
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-lang3 from 3.18.0 to 3.19.0.</action>

--- a/src/main/java/org/apache/commons/compress/archivers/AbstractArchiveBuilder.java
+++ b/src/main/java/org/apache/commons/compress/archivers/AbstractArchiveBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers;
+
+import org.apache.commons.io.build.AbstractStreamBuilder;
+
+/**
+ * Base class for builder pattern implementations of all archive readers.
+ *
+ * <p>Ensures that all {@code ArchiveInputStream} implementations and other
+ * archive handlers expose a consistent set of configuration options.</p>
+ *
+ * @param <T> The type of archive stream or file to build.
+ * @param <B> The type of the concrete builder subclass.
+ * @since 1.29.0
+ */
+public abstract class AbstractArchiveBuilder<T, B extends AbstractArchiveBuilder<T, B>>
+        extends AbstractStreamBuilder<T, B> {
+
+    /**
+     * Constructs a new instance.
+     */
+    protected AbstractArchiveBuilder() {
+        // empty
+    }
+}

--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveInputStream.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.Objects;
 
 import org.apache.commons.io.Charsets;
-import org.apache.commons.io.build.AbstractStreamBuilder;
 import org.apache.commons.io.function.IOConsumer;
 import org.apache.commons.io.function.IOIterator;
 import org.apache.commons.io.input.NullInputStream;
@@ -51,24 +50,6 @@ import org.apache.commons.io.input.NullInputStream;
  * @param <E> The type of {@link ArchiveEntry} produced.
  */
 public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterInputStream {
-
-    /**
-     * Generic builder for ArchiveInputStream instances.
-     *
-     * @param <T> The type of {@link ArchiveInputStream} to build.
-     * @param <B> The type of the concrete AbstractBuilder.
-     * @since 1.29.0
-     */
-    public abstract static class AbstractBuilder<T extends ArchiveInputStream<?>, B extends AbstractBuilder<T, B>>
-            extends AbstractStreamBuilder<T, B> {
-
-        /**
-         * Constructs a new instance.
-         */
-        protected AbstractBuilder() {
-            // empty
-        }
-    }
 
     /**
      * An iterator over a collection of a specific {@link ArchiveEntry} type.
@@ -121,19 +102,7 @@ public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterI
      */
     @SuppressWarnings("resource")
     public ArchiveInputStream() {
-        this(new NullInputStream(), Charset.defaultCharset());
-    }
-
-    /**
-     * Constructs a new instance.
-     *
-     * @param inputStream the underlying input stream, or {@code null} if this instance is to be created without an underlying stream.
-     * @param charset charset.
-     * @since 1.29.0
-     */
-    protected ArchiveInputStream(final InputStream inputStream, final Charset charset) {
-        super(inputStream);
-        this.charset = Charsets.toCharset(charset);
+        this(new NullInputStream(), Charset.defaultCharset().name());
     }
 
     /**
@@ -144,7 +113,34 @@ public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterI
      * @since 1.26.0
      */
     protected ArchiveInputStream(final InputStream inputStream, final String charsetName) {
-        this(inputStream, Charsets.toCharset(charsetName));
+        super(inputStream == null ? new NullInputStream() : inputStream);
+        this.charset = Charsets.toCharset(charsetName);
+    }
+
+    /**
+     * Constructs a new instance from a builder.
+     *
+     * @param builder The builder.
+     * @since 1.29.0
+     */
+    protected ArchiveInputStream(AbstractArchiveBuilder<?, ?> builder) throws IOException {
+        this(builder.getInputStream(), builder);
+    }
+
+    /**
+     * Constructs a new instance from a builder and an input stream.
+     *
+     * <p><strong>Note:</strong> This overload exists to support legacy constructors that did not declare
+     * {@link IOException}. For new constructors, prefer
+     * {@link #ArchiveInputStream(AbstractArchiveBuilder)} and propagate I/O errors to callers.</p>
+     *
+     * @param inputStream The underlying input stream, or {@code null} if this instance is to be created without an underlying stream.
+     * @param builder The builder.
+     * @since 1.29.0
+     */
+    protected ArchiveInputStream(final InputStream inputStream, final AbstractArchiveBuilder<?, ?> builder) {
+        super(inputStream);
+        this.charset = builder.getCharset();
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/Lister.java
+++ b/src/main/java/org/apache/commons/compress/archivers/Lister.java
@@ -155,7 +155,7 @@ public final class Lister {
     }
 
     private  void listZipUsingTarFile(final Path file) throws IOException {
-        try (TarFile tarFile = new TarFile(file)) {
+        try (TarFile tarFile = TarFile.builder().setPath(file).get()) {
             println("Created " + tarFile);
             tarFile.getEntries().forEach(this::println);
         }

--- a/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ar/ArArchiveInputStream.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
+import org.apache.commons.compress.archivers.AbstractArchiveBuilder;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.utils.ArchiveUtils;
@@ -52,7 +53,7 @@ public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
      *
      * @since 1.29.0
      */
-    public static final class Builder extends AbstractBuilder<ArArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractArchiveBuilder<ArArchiveInputStream, Builder> {
 
         private Builder() {
             setCharset(StandardCharsets.US_ASCII);
@@ -167,7 +168,7 @@ public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
     private final byte[] metaData = new byte[NAME_LEN + LAST_MODIFIED_LEN + USER_ID_LEN + GROUP_ID_LEN + FILE_MODE_LEN + LENGTH_LEN];
 
     private ArArchiveInputStream(final Builder builder) throws IOException {
-        this(builder.getInputStream(), builder);
+        super(builder);
     }
 
     /**
@@ -180,7 +181,7 @@ public class ArArchiveInputStream extends ArchiveInputStream<ArArchiveEntry> {
     }
 
     private ArArchiveInputStream(final InputStream inputStream, final Builder builder) {
-        super(inputStream, builder.getCharset());
+        super(inputStream, builder);
     }
 
     private int asInt(final byte[] byteArray, final int offset, final int len, final boolean treatBlankAsZero) throws IOException {

--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.zip.CRC32;
 
+import org.apache.commons.compress.archivers.AbstractArchiveBuilder;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -60,7 +61,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream<ArjArchiveEntry> {
      *
      * @since 1.29.0
      */
-    public static final class Builder extends AbstractBuilder<ArjArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractArchiveBuilder<ArjArchiveInputStream, Builder> {
 
         private Builder() {
             setCharset(ENCODING_NAME);
@@ -117,7 +118,7 @@ public class ArjArchiveInputStream extends ArchiveInputStream<ArjArchiveEntry> {
     }
 
     private ArjArchiveInputStream(final InputStream inputStream, final Builder builder) throws ArchiveException {
-        super(new DataInputStream(inputStream), builder.getCharset());
+        super(new DataInputStream(inputStream), builder);
         dis = (DataInputStream) in;
         try {
             mainHeader = readMainHeader();

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -22,6 +22,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.commons.compress.archivers.AbstractArchiveBuilder;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipEncoding;
@@ -79,7 +80,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
      *
      * @since 1.29.0
      */
-    public static final class Builder extends AbstractBuilder<CpioArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractArchiveBuilder<CpioArchiveInputStream, Builder> {
 
         private int blockSize = BLOCK_SIZE;
 
@@ -211,7 +212,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
     }
 
     private CpioArchiveInputStream(final InputStream in, final Builder builder) {
-        super(in, builder.getCharset());
+        super(in, builder);
         if (builder.blockSize <= 0) {
             throw new IllegalArgumentException("blockSize must be bigger than 0");
         }

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
@@ -29,6 +29,7 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Stack;
 
+import org.apache.commons.compress.archivers.AbstractArchiveBuilder;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipEncoding;
@@ -60,7 +61,7 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
      *
      * @since 1.29.0
      */
-    public static final class Builder extends AbstractBuilder<DumpArchiveInputStream, Builder> {
+    public static final class Builder extends AbstractArchiveBuilder<DumpArchiveInputStream, Builder> {
 
         private Builder() {
         }
@@ -153,7 +154,7 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
     }
 
     private DumpArchiveInputStream(final InputStream is, final Builder builder) throws ArchiveException {
-        super(is, builder.getCharset());
+        super(is, builder);
         this.raw = new TapeInputStream(is);
         this.hasHitEOF = false;
         this.zipEncoding = ZipEncodingHelper.getZipEncoding(builder.getCharset());

--- a/src/main/java/org/apache/commons/compress/archivers/examples/Expander.java
+++ b/src/main/java/org/apache/commons/compress/archivers/examples/Expander.java
@@ -395,11 +395,11 @@ public class Expander {
             if (!prefersSeekableByteChannel(format)) {
                 expand(format, c.track(Channels.newInputStream(archive)), targetDirectory, CloseableConsumer.NULL_CONSUMER);
             } else if (ArchiveStreamFactory.TAR.equalsIgnoreCase(format)) {
-                expand(c.track(new TarFile(archive)), targetDirectory);
+                expand(c.track(TarFile.builder().setChannel(archive).get()), targetDirectory);
             } else if (ArchiveStreamFactory.ZIP.equalsIgnoreCase(format)) {
-                expand(c.track(ZipFile.builder().setSeekableByteChannel(archive).get()), targetDirectory);
+                expand(c.track(ZipFile.builder().setChannel(archive).get()), targetDirectory);
             } else if (ArchiveStreamFactory.SEVEN_Z.equalsIgnoreCase(format)) {
-                expand(c.track(SevenZFile.builder().setSeekableByteChannel(archive).get()), targetDirectory);
+                expand(c.track(SevenZFile.builder().setChannel(archive).get()), targetDirectory);
             } else {
                 // never reached as prefersSeekableByteChannel only returns true for TAR, ZIP and 7z
                 throw new ArchiveException("Don't know how to handle format '%s'", format);

--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/SevenZFile.java
@@ -34,12 +34,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -420,10 +417,6 @@ public class SevenZFile implements Closeable {
      */
     public static boolean matches(final byte[] buffer, final int ignored) {
         return ArrayUtils.startsWith(buffer, SIGNATURE);
-    }
-
-    private static SeekableByteChannel newByteChannel(final File file) throws IOException {
-        return Files.newByteChannel(file.toPath(), EnumSet.of(StandardOpenOption.READ));
     }
 
     private static long readUint64(final ByteBuffer in) throws IOException {

--- a/src/main/java/org/apache/commons/compress/archivers/tar/AbstractTarBuilder.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/AbstractTarBuilder.java
@@ -19,7 +19,7 @@
 
 package org.apache.commons.compress.archivers.tar;
 
-import org.apache.commons.io.build.AbstractStreamBuilder;
+import org.apache.commons.compress.archivers.AbstractArchiveBuilder;
 
 /**
  * Abstracts TAR builder operations.
@@ -28,7 +28,7 @@ import org.apache.commons.io.build.AbstractStreamBuilder;
  * @param <B> the type of builder subclass.
  * @since 1.29.0
  */
-public abstract class AbstractTarBuilder<T, B extends AbstractTarBuilder<T, B>> extends AbstractStreamBuilder<T, B> {
+public abstract class AbstractTarBuilder<T, B extends AbstractTarBuilder<T, B>> extends AbstractArchiveBuilder<T, B> {
 
     private int blockSize = TarConstants.DEFAULT_BLKSIZE;
     private int recordSize = TarConstants.DEFAULT_RCDSIZE;

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java
@@ -204,7 +204,7 @@ public class TarArchiveInputStream extends ArchiveInputStream<TarArchiveEntry> {
     }
 
     private TarArchiveInputStream(final InputStream inputStream, final Builder builder) {
-        super(inputStream, builder.getCharset());
+        super(inputStream, builder);
         this.zipEncoding = ZipEncodingHelper.getZipEncoding(builder.getCharset());
         this.recordBuffer = new byte[builder.getRecordSize()];
         this.blockSize = builder.getBlockSize();

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -42,6 +42,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 
 import org.apache.commons.compress.MemoryLimitException;
+import org.apache.commons.compress.archivers.AbstractArchiveBuilder;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -85,7 +86,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
      * @since 1.29.0
      */
     public abstract static class AbstractBuilder<T extends ZipArchiveInputStream, B extends AbstractBuilder<T, B>>
-            extends ArchiveInputStream.AbstractBuilder<T, B> {
+            extends AbstractArchiveBuilder<T, B> {
 
         private boolean useUnicodeExtraFields = true;
         private boolean supportStoredEntryDataDescriptor;
@@ -421,7 +422,7 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
     }
 
     private ZipArchiveInputStream(final InputStream inputStream, final AbstractBuilder<?, ?> builder) {
-        super(inputStream, builder.getCharset());
+        super(inputStream, builder);
         this.in = new PushbackInputStream(inputStream, buf.capacity());
         this.zipEncoding = ZipEncodingHelper.getZipEncoding(builder.getCharset());
         this.useUnicodeExtraFields = builder.isUseUnicodeExtraFields();

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.Channel;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
@@ -51,6 +52,7 @@ import java.util.stream.IntStream;
 import java.util.zip.Inflater;
 import java.util.zip.ZipException;
 
+import org.apache.commons.compress.archivers.AbstractArchiveBuilder;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.EntryStreamOffsets;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -61,11 +63,7 @@ import org.apache.commons.compress.utils.BoundedArchiveInputStream;
 import org.apache.commons.compress.utils.BoundedSeekableByteChannelInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.utils.InputStreamStatistics;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.build.AbstractOrigin.ByteArrayOrigin;
-import org.apache.commons.io.build.AbstractOrigin.ChannelOrigin;
-import org.apache.commons.io.build.AbstractStreamBuilder;
 import org.apache.commons.io.function.IOFunction;
 import org.apache.commons.io.function.IOStream;
 import org.apache.commons.io.input.BoundedInputStream;
@@ -132,12 +130,13 @@ public class ZipFile implements Closeable {
      *
      * @since 1.26.0
      */
-    public static class Builder extends AbstractStreamBuilder<ZipFile, Builder> {
+    public static class Builder extends AbstractArchiveBuilder<ZipFile, Builder> {
 
-        static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+        private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
         private boolean useUnicodeExtraFields = true;
         private boolean ignoreLocalFileHeader;
         private long maxNumberOfDisks = 1;
+        private String name;
         private IOFunction<InputStream, InputStream> zstdInputStreamFactory;
 
         /**
@@ -146,33 +145,12 @@ public class ZipFile implements Closeable {
         public Builder() {
             setCharset(DEFAULT_CHARSET);
             setCharsetDefault(DEFAULT_CHARSET);
+            setOpenOptions(StandardOpenOption.READ);
         }
 
         @Override
         public ZipFile get() throws IOException {
-            final SeekableByteChannel actualChannel;
-            final String actualDescription;
-            final boolean isChannelOrigin = checkOrigin() instanceof ChannelOrigin;
-            boolean isSeekableByteChannellOrigin = false;
-            if (isChannelOrigin) {
-                actualChannel = getChannel(SeekableByteChannel.class);
-                isSeekableByteChannellOrigin = true;
-                actualDescription = actualChannel.getClass().getSimpleName();
-            } else if (checkOrigin() instanceof ByteArrayOrigin) {
-                actualChannel = getChannel(SeekableByteChannel.class);
-                actualDescription = actualChannel.getClass().getSimpleName();
-            } else {
-                OpenOption[] openOptions = getOpenOptions();
-                if (openOptions.length == 0) {
-                    openOptions = new OpenOption[] { StandardOpenOption.READ };
-                }
-                final Path path = getPath();
-                actualChannel = openZipChannel(path, maxNumberOfDisks, openOptions);
-                actualDescription = path.toString();
-            }
-            final boolean closeOnError = isSeekableByteChannellOrigin;
-            return new ZipFile(actualChannel, actualDescription, getCharset(), useUnicodeExtraFields, closeOnError, ignoreLocalFileHeader,
-                    zstdInputStreamFactory);
+            return new ZipFile(this);
         }
 
         /**
@@ -197,12 +175,30 @@ public class ZipFile implements Closeable {
             return this;
         }
 
+        Builder setName(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        String getName() {
+            if (name == null) {
+                try {
+                    name = getPath().toAbsolutePath().toString();
+                } catch (UnsupportedOperationException ex) {
+                    name = "unknown";
+                }
+            }
+            return name;
+        }
+
         /**
          * The actual channel, overrides any other input aspects like a File, Path, and so on.
          *
          * @param seekableByteChannel The actual channel.
          * @return {@code this} instance.
+         * @deprecated Since 1.29.0, use {@link #setChannel} instead.
          */
+        @Deprecated
         public Builder setSeekableByteChannel(final SeekableByteChannel seekableByteChannel) {
             return setChannel(seekableByteChannel);
         }
@@ -512,19 +508,8 @@ public class ZipFile implements Closeable {
         org.apache.commons.io.IOUtils.closeQuietly(zipFile);
     }
 
-    /**
-     * Creates a new SeekableByteChannel for reading.
-     *
-     * @param path the path to the file to open or create
-     * @return a new seekable byte channel
-     * @throws IOException if an I/O error occurs
-     */
-    private static SeekableByteChannel newReadByteChannel(final Path path) throws IOException {
-        return Files.newByteChannel(path, READ);
-    }
-
     private static SeekableByteChannel openZipChannel(final Path path, final long maxNumberOfDisks, final OpenOption[] openOptions) throws IOException {
-        final FileChannel channel = FileChannel.open(path, StandardOpenOption.READ);
+        final FileChannel channel = FileChannel.open(path, openOptions);
         try {
             final boolean is64 = positionAtEndOfCentralDirectoryRecord(channel);
             final long numberOfDisks;
@@ -761,7 +746,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final File file) throws IOException {
-        this(file, DEFAULT_CHARSET_NAME);
+        this(builder().setFile(file));
     }
 
     /**
@@ -774,7 +759,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final File file, final String encoding) throws IOException {
-        this(file.toPath(), encoding, true);
+        this(builder().setFile(file).setCharset(encoding));
     }
 
     /**
@@ -788,7 +773,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final File file, final String encoding, final boolean useUnicodeExtraFields) throws IOException {
-        this(file.toPath(), encoding, useUnicodeExtraFields, false);
+        this(builder().setFile(file).setCharset(encoding).setUseUnicodeExtraFields(useUnicodeExtraFields));
     }
 
     /**
@@ -810,9 +795,8 @@ public class ZipFile implements Closeable {
      * @deprecated Use {@link Builder#get()}.
      */
     @Deprecated
-    @SuppressWarnings("resource") // Caller closes
     public ZipFile(final File file, final String encoding, final boolean useUnicodeExtraFields, final boolean ignoreLocalFileHeader) throws IOException {
-        this(newReadByteChannel(file.toPath()), file.getAbsolutePath(), encoding, useUnicodeExtraFields, true, ignoreLocalFileHeader);
+        this(builder().setFile(file).setCharset(encoding).setUseUnicodeExtraFields(useUnicodeExtraFields).setIgnoreLocalFileHeader(ignoreLocalFileHeader));
     }
 
     /**
@@ -825,7 +809,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final Path path) throws IOException {
-        this(path, DEFAULT_CHARSET_NAME);
+        this(builder().setPath(path));
     }
 
     /**
@@ -839,7 +823,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final Path path, final String encoding) throws IOException {
-        this(path, encoding, true);
+        this(builder().setPath(path).setCharset(encoding));
     }
 
     /**
@@ -854,7 +838,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final Path path, final String encoding, final boolean useUnicodeExtraFields) throws IOException {
-        this(path, encoding, useUnicodeExtraFields, false);
+        this(builder().setPath(path).setCharset(encoding).setUseUnicodeExtraFields(useUnicodeExtraFields));
     }
 
     /**
@@ -878,7 +862,7 @@ public class ZipFile implements Closeable {
     @SuppressWarnings("resource") // Caller closes
     @Deprecated
     public ZipFile(final Path path, final String encoding, final boolean useUnicodeExtraFields, final boolean ignoreLocalFileHeader) throws IOException {
-        this(newReadByteChannel(path), path.toAbsolutePath().toString(), encoding, useUnicodeExtraFields, true, ignoreLocalFileHeader);
+        this(builder().setPath(path).setCharset(encoding).setUseUnicodeExtraFields(useUnicodeExtraFields).setIgnoreLocalFileHeader(ignoreLocalFileHeader));
     }
 
     /**
@@ -894,7 +878,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final SeekableByteChannel channel) throws IOException {
-        this(channel, "a SeekableByteChannel", DEFAULT_CHARSET_NAME, true);
+        this(builder().setChannel(channel));
     }
 
     /**
@@ -911,32 +895,38 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final SeekableByteChannel channel, final String encoding) throws IOException {
-        this(channel, "a SeekableByteChannel", encoding, true);
+        this(builder().setChannel(channel).setCharset(encoding));
     }
 
-    private ZipFile(final SeekableByteChannel channel, final String channelDescription, final Charset encoding, final boolean useUnicodeExtraFields,
-            final boolean closeOnError, final boolean ignoreLocalFileHeader, final IOFunction<InputStream, InputStream> zstdInputStream) throws IOException {
-        this.isSplitZipArchive = channel instanceof ZipSplitReadOnlySeekableByteChannel;
-        this.encoding = Charsets.toCharset(encoding, Builder.DEFAULT_CHARSET);
-        this.zipEncoding = ZipEncodingHelper.getZipEncoding(encoding);
-        this.useUnicodeExtraFields = useUnicodeExtraFields;
-        this.archive = channel;
-        this.zstdInputStreamFactory = zstdInputStream;
-        boolean success = false;
+    private ZipFile(Builder builder) throws IOException {
+        SeekableByteChannel archive;
         try {
+            final Path path = builder.getPath();
+            archive = openZipChannel(path, builder.maxNumberOfDisks, builder.getOpenOptions());
+        } catch (UnsupportedOperationException e) {
+            archive = builder.getChannel(SeekableByteChannel.class);
+        }
+        this.archive = archive;
+        try {
+            this.isSplitZipArchive = this.archive instanceof ZipSplitReadOnlySeekableByteChannel;
+            this.encoding = builder.getCharset();
+            this.zipEncoding = ZipEncodingHelper.getZipEncoding(encoding);
+            this.useUnicodeExtraFields = builder.useUnicodeExtraFields;
+            this.zstdInputStreamFactory = builder.zstdInputStreamFactory;
             final Map<ZipArchiveEntry, NameAndComment> entriesWithoutUTF8Flag = populateFromCentralDirectory();
-            if (!ignoreLocalFileHeader) {
+            if (!builder.ignoreLocalFileHeader) {
                 resolveLocalFileHeaderData(entriesWithoutUTF8Flag);
             }
             fillNameMap();
-            success = true;
         } catch (final IOException e) {
-            throw new ArchiveException("Error reading Zip content from " + channelDescription, (Throwable) e);
-        } finally {
-            this.closed = !success;
-            if (!success && closeOnError) {
-                org.apache.commons.io.IOUtils.closeQuietly(archive);
+            final ArchiveException archiveException = new ArchiveException("Error reading Zip content from " + builder.getName(), (Throwable) e);
+            this.closed = true;
+            try {
+                this.archive.close();
+            } catch (final IOException ioException) {
+                archiveException.addSuppressed(ioException);
             }
+            throw archiveException;
         }
     }
 
@@ -957,7 +947,7 @@ public class ZipFile implements Closeable {
     @Deprecated
     public ZipFile(final SeekableByteChannel channel, final String channelDescription, final String encoding, final boolean useUnicodeExtraFields)
             throws IOException {
-        this(channel, channelDescription, encoding, useUnicodeExtraFields, false, false);
+        this(builder().setChannel(channel).setName(channelDescription).setCharset(encoding).setUseUnicodeExtraFields(useUnicodeExtraFields));
     }
 
     /**
@@ -985,12 +975,8 @@ public class ZipFile implements Closeable {
     @Deprecated
     public ZipFile(final SeekableByteChannel channel, final String channelDescription, final String encoding, final boolean useUnicodeExtraFields,
             final boolean ignoreLocalFileHeader) throws IOException {
-        this(channel, channelDescription, encoding, useUnicodeExtraFields, false, ignoreLocalFileHeader);
-    }
-
-    private ZipFile(final SeekableByteChannel channel, final String channelDescription, final String encoding, final boolean useUnicodeExtraFields,
-            final boolean closeOnError, final boolean ignoreLocalFileHeader) throws IOException {
-        this(channel, channelDescription, Charsets.toCharset(encoding), useUnicodeExtraFields, closeOnError, ignoreLocalFileHeader, null);
+        this(builder().setChannel(channel).setName(channelDescription).setCharset(encoding).setUseUnicodeExtraFields(useUnicodeExtraFields)
+                .setIgnoreLocalFileHeader(ignoreLocalFileHeader));
     }
 
     /**
@@ -1002,7 +988,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final String name) throws IOException {
-        this(new File(name).toPath(), DEFAULT_CHARSET_NAME);
+        this(builder().setFile(name));
     }
 
     /**
@@ -1015,7 +1001,7 @@ public class ZipFile implements Closeable {
      */
     @Deprecated
     public ZipFile(final String name, final String encoding) throws IOException {
-        this(new File(name).toPath(), encoding, true);
+        this(builder().setFile(name).setCharset(encoding));
     }
 
     /**

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.Channel;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -39,7 +39,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -278,10 +277,6 @@ public class ZipFile implements Closeable {
             return getCompressedCount();
         }
     }
-
-    private static final String DEFAULT_CHARSET_NAME = StandardCharsets.UTF_8.name();
-
-    private static final EnumSet<StandardOpenOption> READ = EnumSet.of(StandardOpenOption.READ);
 
     private static final int HASH_SIZE = 509;
     static final int NIBLET_MASK = 0x0f;

--- a/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
+++ b/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
@@ -246,7 +246,7 @@ class LegacyConstructorsTest extends AbstractTest {
 
     static Stream<Arguments> testZipFileConstructors() throws IOException {
         final Path path = getPath("bla.zip");
-        final String defaultEncoding = Charset.defaultCharset().name();
+        final String defaultEncoding = StandardCharsets.UTF_8.name();
         final String otherEncoding = "UTF-8".equals(defaultEncoding) ? "US-ASCII" : "UTF-8";
         return Stream.of(
                 Arguments.of(new ZipFile(path.toFile()), defaultEncoding, true),

--- a/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
+++ b/src/test/java/org/apache/commons/compress/LegacyConstructorsTest.java
@@ -21,20 +21,33 @@ package org.apache.commons.compress;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
 import static org.apache.commons.lang3.reflect.FieldUtils.readField;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.stream.Stream;
 
 import org.apache.commons.compress.archivers.arj.ArjArchiveInputStream;
 import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
 import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
 import org.apache.commons.compress.archivers.jar.JarArchiveInputStream;
+import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+import org.apache.commons.compress.archivers.sevenz.SevenZFileOptions;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarFile;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipEncoding;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -120,6 +133,63 @@ class LegacyConstructorsTest extends AbstractTest {
         }
     }
 
+    static Stream<Arguments> testSevenZFileContructors() throws IOException {
+        final Path path = getPath("bla.7z");
+        final String defaultName = "unknown archive";
+        final String otherName = path.toAbsolutePath().toString();
+        final String customName = "customName";
+        final int defaultMemoryLimit = SevenZFileOptions.DEFAULT.getMaxMemoryLimitInKb();
+        final boolean defaultUseDefaultNameForUnnamedEntries = SevenZFileOptions.DEFAULT.getUseDefaultNameForUnnamedEntries();
+        final boolean defaultTryToRecoverBrokenArchives = SevenZFileOptions.DEFAULT.getTryToRecoverBrokenArchives();
+        final SevenZFileOptions otherOptions =
+                SevenZFileOptions.builder().withMaxMemoryLimitInKb(42).withTryToRecoverBrokenArchives(true).withUseDefaultNameForUnnamedEntries(true).build();
+        final char[] otherPassword = "password".toCharArray();
+        final byte[] otherPasswordBytes = "password".getBytes(StandardCharsets.UTF_16LE);
+        return Stream.of(
+                // From File
+                Arguments.of(new SevenZFile(path.toFile()), otherName, defaultMemoryLimit, defaultUseDefaultNameForUnnamedEntries,
+                        defaultTryToRecoverBrokenArchives, null),
+                Arguments.of(new SevenZFile(path.toFile(), otherPasswordBytes), otherName, defaultMemoryLimit, defaultUseDefaultNameForUnnamedEntries,
+                        defaultTryToRecoverBrokenArchives, otherPasswordBytes),
+                Arguments.of(new SevenZFile(path.toFile(), otherPassword), otherName, defaultMemoryLimit, defaultUseDefaultNameForUnnamedEntries,
+                        defaultTryToRecoverBrokenArchives, otherPasswordBytes),
+                Arguments.of(new SevenZFile(path.toFile(), otherPassword, otherOptions), otherName, 42, true, true, otherPasswordBytes),
+                Arguments.of(new SevenZFile(path.toFile(), otherOptions), otherName, 42, true, true, null),
+                // From SeekableByteChannel
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ)), defaultName, defaultMemoryLimit,
+                        defaultUseDefaultNameForUnnamedEntries, defaultTryToRecoverBrokenArchives, null),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), otherPasswordBytes), defaultName, defaultMemoryLimit,
+                        defaultUseDefaultNameForUnnamedEntries, defaultTryToRecoverBrokenArchives, otherPasswordBytes),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), otherPassword), defaultName, defaultMemoryLimit,
+                        defaultUseDefaultNameForUnnamedEntries, defaultTryToRecoverBrokenArchives, otherPasswordBytes),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), otherPassword, otherOptions), defaultName, 42, true, true,
+                        otherPasswordBytes),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), otherOptions), defaultName, 42, true, true, null),
+                // From SeekableByteChannel with custom name
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), customName), customName, defaultMemoryLimit,
+                        defaultUseDefaultNameForUnnamedEntries, defaultTryToRecoverBrokenArchives, null),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), customName, otherPasswordBytes), customName,
+                        defaultMemoryLimit, defaultUseDefaultNameForUnnamedEntries, defaultTryToRecoverBrokenArchives, otherPasswordBytes),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), customName, otherPassword), customName, defaultMemoryLimit,
+                        defaultUseDefaultNameForUnnamedEntries, defaultTryToRecoverBrokenArchives, otherPasswordBytes),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), customName, otherPassword, otherOptions), customName, 42,
+                        true, true, otherPasswordBytes),
+                Arguments.of(new SevenZFile(Files.newByteChannel(path, StandardOpenOption.READ), customName, otherOptions), customName, 42, true,
+                        true, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testSevenZFileContructors(final SevenZFile archiveFile, final String expectedName, final int expectedMemoryLimit,
+            final boolean expectedUseDefaultNameForUnnamedEntries, final boolean expectedTryToRecoverBrokenArchives,
+            final byte[] expectedPassword) throws Exception {
+        assertEquals(expectedName, readDeclaredField(archiveFile, "fileName", true));
+        assertEquals(expectedMemoryLimit, readDeclaredField(archiveFile, "maxMemoryLimitKiB", true));
+        assertEquals(expectedUseDefaultNameForUnnamedEntries, readDeclaredField(archiveFile, "useDefaultNameForUnnamedEntries", true));
+        assertEquals(expectedTryToRecoverBrokenArchives, readDeclaredField(archiveFile, "tryToRecoverBrokenArchives", true));
+        assertArrayEquals(expectedPassword, (byte[]) readDeclaredField(archiveFile, "password", true));
+    }
+
     @ParameterizedTest
     @MethodSource
     void testTarConstructors(final TarArchiveInputStream archiveStream, final InputStream expectedInput, final int expectedBlockSize,
@@ -130,6 +200,35 @@ class LegacyConstructorsTest extends AbstractTest {
         assertEquals(expectedRecordSize, recordBuffer.length);
         assertEquals(Charset.forName(expectedEncoding), archiveStream.getCharset());
         assertEquals(expectedLenient, readField(archiveStream, "lenient", true));
+    }
+
+    static Stream<Arguments> testTarFileConstructors() throws IOException {
+        final Path path = getPath("bla.tar");
+        final File file = getFile("bla.tar");
+        final SeekableByteChannel channel = mock(SeekableByteChannel.class);
+        final String defaultEncoding = Charset.defaultCharset().name();
+        final String otherEncoding = "UTF-8".equals(defaultEncoding) ? "US-ASCII" : "UTF-8";
+        return Stream.of(
+                Arguments.of(new TarFile(IOUtils.EMPTY_BYTE_ARRAY), defaultEncoding, false),
+                Arguments.of(new TarFile(IOUtils.EMPTY_BYTE_ARRAY, true), defaultEncoding, true),
+                Arguments.of(new TarFile(IOUtils.EMPTY_BYTE_ARRAY, otherEncoding), otherEncoding, false),
+                Arguments.of(new TarFile(file), defaultEncoding, false),
+                Arguments.of(new TarFile(file, true), defaultEncoding, true),
+                Arguments.of(new TarFile(file, otherEncoding), otherEncoding, false),
+                Arguments.of(new TarFile(path), defaultEncoding, false),
+                Arguments.of(new TarFile(path, true), defaultEncoding, true),
+                Arguments.of(new TarFile(path, otherEncoding), otherEncoding, false),
+                Arguments.of(new TarFile(channel), defaultEncoding, false),
+                Arguments.of(new TarFile(channel, 1024, 1024, otherEncoding, true), otherEncoding, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testTarFileConstructors(final TarFile tarFile, final String expectedEncoding, final boolean expectedLenient) throws Exception {
+        final ZipEncoding encoding = (ZipEncoding) readDeclaredField(tarFile, "zipEncoding", true);
+        final Charset charset = (Charset) readDeclaredField(encoding, "charset", true);
+        assertEquals(Charset.forName(expectedEncoding), charset);
+        assertEquals(expectedLenient, readDeclaredField(tarFile, "lenient", true));
     }
 
     @ParameterizedTest
@@ -143,5 +242,35 @@ class LegacyConstructorsTest extends AbstractTest {
         assertEquals(expectedUseUnicodeExtraFields, readDeclaredField(archiveStream, "useUnicodeExtraFields", true));
         assertEquals(expectedSupportStoredEntryDataDescriptor, readDeclaredField(archiveStream, "supportStoredEntryDataDescriptor", true));
         assertEquals(expectedSkipSplitSignature, readDeclaredField(archiveStream, "skipSplitSignature", true));
+    }
+
+    static Stream<Arguments> testZipFileConstructors() throws IOException {
+        final Path path = getPath("bla.zip");
+        final String defaultEncoding = Charset.defaultCharset().name();
+        final String otherEncoding = "UTF-8".equals(defaultEncoding) ? "US-ASCII" : "UTF-8";
+        return Stream.of(
+                Arguments.of(new ZipFile(path.toFile()), defaultEncoding, true),
+                Arguments.of(new ZipFile(path.toFile(), otherEncoding), otherEncoding, true),
+                Arguments.of(new ZipFile(path.toFile(), otherEncoding, false), otherEncoding, false),
+                Arguments.of(new ZipFile(path.toFile(), otherEncoding, false, true), otherEncoding, false),
+                Arguments.of(new ZipFile(path), defaultEncoding, true),
+                Arguments.of(new ZipFile(path, otherEncoding), otherEncoding, true),
+                Arguments.of(new ZipFile(path, otherEncoding, false), otherEncoding, false),
+                Arguments.of(new ZipFile(path, otherEncoding, false, true), otherEncoding, false),
+                Arguments.of(new ZipFile(Files.newByteChannel(path, StandardOpenOption.READ)), defaultEncoding, true),
+                Arguments.of(new ZipFile(Files.newByteChannel(path, StandardOpenOption.READ), otherEncoding), otherEncoding, true),
+                Arguments.of(new ZipFile(Files.newByteChannel(path, StandardOpenOption.READ), null, otherEncoding, false),
+                        otherEncoding, false),
+                Arguments.of(new ZipFile(Files.newByteChannel(path, StandardOpenOption.READ), null, otherEncoding, false, true),
+                        otherEncoding, false),
+                Arguments.of(new ZipFile(path.toAbsolutePath().toString()), defaultEncoding, true),
+                Arguments.of(new ZipFile(path.toAbsolutePath().toString(), otherEncoding), otherEncoding, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testZipFileConstructors(final ZipFile zipFile, final String expectedEncoding, final boolean expectedUseUnicodeExtraFields) throws Exception {
+        assertEquals(Charset.forName(expectedEncoding), readDeclaredField(zipFile, "encoding", true));
+        assertEquals(expectedUseUnicodeExtraFields, readDeclaredField(zipFile, "useUnicodeExtraFields", true));
     }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/TarTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/TarTest.java
@@ -289,7 +289,7 @@ public final class TarTest extends AbstractTest {
     @Test
     void testTarFileCOMPRESS114() throws Exception {
         final File input = getFile("COMPRESS-114.tar");
-        try (TarFile tarFile = new TarFile(input, StandardCharsets.ISO_8859_1.name())) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("COMPRESS-114.tar")).setCharset(StandardCharsets.ISO_8859_1).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             TarArchiveEntry entry = entries.get(0);
             assertEquals("3\u00b1\u00b1\u00b1F06\u00b1W2345\u00b1ZB\u00b1la\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1\u00b1BLA", entry.getName());
@@ -304,7 +304,7 @@ public final class TarTest extends AbstractTest {
     void testTarFileCOMPRESS178() throws Exception {
         final File input = getFile("COMPRESS-178-fail.tar");
         final IOException e = assertThrows(ArchiveException.class, () -> {
-            try (TarFile tarFile = new TarFile(input)) {
+            try (TarFile tarFile = TarFile.builder().setFile(input).get()) {
                 // Compared to the TarArchiveInputStream all entries are read when instantiating the tar file
             }
         }, "Expected IOException");
@@ -315,7 +315,7 @@ public final class TarTest extends AbstractTest {
     @Test
     void testTarFileCOMPRESS178Lenient() throws Exception {
         final File input = getFile("COMPRESS-178-fail.tar");
-        try (TarFile tarFile = new TarFile(input, true)) {
+        try (TarFile tarFile = TarFile.builder().setFile(input).setLenient(true).get()) {
             // Compared to the TarArchiveInputStream all entries are read when instantiating the tar file
         }
     }
@@ -330,7 +330,7 @@ public final class TarTest extends AbstractTest {
             tos.putArchiveEntry(in);
             tos.closeArchiveEntry();
             tos.close();
-            try (TarFile tarFile = new TarFile(archive)) {
+            try (TarFile tarFile = TarFile.builder().setFile(archive).get()) {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo/", entry.getName());
@@ -346,7 +346,7 @@ public final class TarTest extends AbstractTest {
     @Test
     void testTarFileDirectoryRead() throws IOException {
         final File input = getFile("directory.tar");
-        try (TarFile tarFile = new TarFile(input)) {
+        try (TarFile tarFile = TarFile.builder().setFile(input).get()) {
             final TarArchiveEntry directoryEntry = tarFile.getEntries().get(0);
             assertEquals("directory/", directoryEntry.getName());
             assertEquals(TarConstants.LF_DIR, directoryEntry.getLinkFlag());
@@ -368,7 +368,7 @@ public final class TarTest extends AbstractTest {
             outputStream.write(file);
             outputStream.closeArchiveEntry();
             outputStream.close();
-            try (TarFile tarFile = new TarFile(archive)) {
+            try (TarFile tarFile = TarFile.builder().setFile(archive).get()) {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo", entry.getName());
@@ -390,7 +390,7 @@ public final class TarTest extends AbstractTest {
             tos.putArchiveEntry(in);
             tos.closeArchiveEntry();
             tos.close();
-            try (TarFile tarFile = new TarFile(archive)) {
+            try (TarFile tarFile = TarFile.builder().setFile(archive).get()) {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo/", entry.getName());
@@ -413,7 +413,7 @@ public final class TarTest extends AbstractTest {
             outputStream.putArchiveEntry(in);
             outputStream.write(file);
             outputStream.closeArchiveEntry();
-            try (TarFile tarFile = new TarFile(archive)) {
+            try (TarFile tarFile = TarFile.builder().setFile(archive).get()) {
                 final TarArchiveEntry entry = tarFile.getEntries().get(0);
                 assertNotNull(entry);
                 assertEquals("foo", entry.getName());
@@ -433,7 +433,7 @@ public final class TarTest extends AbstractTest {
             final String fileName = createLongName(length);
             assertEquals(length.intValue(), fileName.length());
             final byte[] data = createTarWithOneLongNameEntry(fileName);
-            try (TarFile tarFile = new TarFile(data)) {
+            try (TarFile tarFile = TarFile.builder().setByteArray(data).get()) {
                 final List<TarArchiveEntry> entries = tarFile.getEntries();
                 assertEquals(fileName, entries.get(0).getName());
                 assertEquals(TarConstants.LF_NORMAL, entries.get(0).getLinkFlag());
@@ -444,7 +444,7 @@ public final class TarTest extends AbstractTest {
     @Test
     void testTarFileUnarchive() throws Exception {
         final File file = getFile("bla.tar");
-        try (TarFile tarFile = new TarFile(file)) {
+        try (TarFile tarFile = TarFile.builder().setFile(file).get()) {
             final TarArchiveEntry entry = tarFile.getEntries().get(0);
             try (InputStream inputStream = tarFile.getInputStream(entry)) {
                 Files.copy(inputStream, newTempFile(entry.getName()).toPath());

--- a/src/test/java/org/apache/commons/compress/archivers/examples/ExpanderTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/examples/ExpanderTest.java
@@ -174,7 +174,7 @@ class ExpanderTest extends AbstractTest {
     @Test
     void testCompress603Tar() throws IOException, ArchiveException {
         setupTarForCompress603();
-        try (TarFile f = new TarFile(archive)) {
+        try (TarFile f = TarFile.builder().setFile(archive).get()) {
             new Expander().expand(f, tempResultDir);
         }
         verifyTargetDir();
@@ -261,7 +261,7 @@ class ExpanderTest extends AbstractTest {
     @Test
     void testTarFileVersion() throws IOException, ArchiveException {
         setupTar();
-        try (TarFile f = new TarFile(archive)) {
+        try (TarFile f = TarFile.builder().setFile(archive).get()) {
             new Expander().expand(f, tempResultDir);
         }
         verifyTargetDir();

--- a/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZFileTest.java
@@ -160,10 +160,6 @@ class SevenZFileTest extends AbstractTest {
 
     @Test
     void test7zMultiVolumeUnarchive() throws Exception {
-        try (@SuppressWarnings("deprecation")
-        SevenZFile sevenZFile = new SevenZFile(MultiReadOnlySeekableByteChannel.forFiles(getFile("bla-multi.7z.001"), getFile("bla-multi.7z.002")))) {
-            test7zUnarchive(sevenZFile, SevenZMethod.LZMA2);
-        }
         try (SevenZFile sevenZFile = SevenZFile.builder()
                 .setSeekableByteChannel(MultiReadOnlySeekableByteChannel.forFiles(getFile("bla-multi.7z.001"), getFile("bla-multi.7z.002"))).get()) {
             test7zUnarchive(sevenZFile, SevenZMethod.LZMA2);
@@ -184,10 +180,6 @@ class SevenZFileTest extends AbstractTest {
     }
 
     private void test7zUnarchive(final File file, final SevenZMethod method, final byte[] password) throws Exception {
-        try (@SuppressWarnings("deprecation")
-        SevenZFile sevenZFile = new SevenZFile(file, password)) {
-            test7zUnarchive(sevenZFile, method);
-        }
         try (SevenZFile sevenZFile = SevenZFile.builder().setFile(file).setPassword(password).get()) {
             test7zUnarchive(sevenZFile, method);
         }
@@ -198,11 +190,6 @@ class SevenZFileTest extends AbstractTest {
     }
 
     private void test7zUnarchive(final File file, final SevenZMethod m, final char[] password, final boolean tryToRecoverBrokenArchives) throws Exception {
-        try (@SuppressWarnings("deprecation")
-        SevenZFile sevenZFile = new SevenZFile(file, password,
-                SevenZFileOptions.builder().withTryToRecoverBrokenArchives(tryToRecoverBrokenArchives).build())) {
-            test7zUnarchive(sevenZFile, m);
-        }
         try (SevenZFile sevenZFile = SevenZFile.builder().setFile(file).setPassword(password).setTryToRecoverBrokenArchives(tryToRecoverBrokenArchives).get()) {
             test7zUnarchive(sevenZFile, m);
         }
@@ -324,8 +311,7 @@ class SevenZFileTest extends AbstractTest {
 
     @Test
     void testExtractSpecifiedFileDeprecated() throws Exception {
-        try (@SuppressWarnings("deprecation")
-        SevenZFile sevenZFile = new SevenZFile(getFile("COMPRESS-256.7z"))) {
+        try (SevenZFile sevenZFile = SevenZFile.builder().setURI(getURI("COMPRESS-256.7z")).get()) {
             // @formatter:off
             final String testTxtContents =
                     "111111111111111111111111111000101011\n"
@@ -363,10 +349,6 @@ class SevenZFileTest extends AbstractTest {
         }
         try (SevenZFile sevenZFile = SevenZFile.builder().setSeekableByteChannel(Files.newByteChannel(getFile("bla.deflate64.7z").toPath())).get()) {
             assertNull(sevenZFile.getDefaultName());
-        }
-        try (@SuppressWarnings("deprecation")
-        SevenZFile sevenZFile = new SevenZFile(Files.newByteChannel(getFile("bla.deflate64.7z").toPath()), "foo")) {
-            assertEquals("foo~", sevenZFile.getDefaultName());
         }
         try (SevenZFile sevenZFile = SevenZFile.builder().setSeekableByteChannel(Files.newByteChannel(getFile("bla.deflate64.7z").toPath()))
                 .setDefaultName("foo").get()) {
@@ -407,16 +389,6 @@ class SevenZFileTest extends AbstractTest {
 
     @Test
     void testGivenNameWinsOverDefaultName() throws Exception {
-        try (@SuppressWarnings("deprecation")
-        SevenZFile sevenZFile = new SevenZFile(getFile("bla.7z"), SevenZFileOptions.builder().withUseDefaultNameForUnnamedEntries(true).build())) {
-            SevenZArchiveEntry ae = sevenZFile.getNextEntry();
-            assertNotNull(ae);
-            assertEquals("test1.xml", ae.getName());
-            ae = sevenZFile.getNextEntry();
-            assertNotNull(ae);
-            assertEquals("test2.xml", ae.getName());
-            assertNull(sevenZFile.getNextEntry());
-        }
         try (SevenZFile sevenZFile = SevenZFile.builder().setFile(getFile("bla.7z")).setUseDefaultNameForUnnamedEntries(true).get()) {
             SevenZArchiveEntry ae = sevenZFile.getNextEntry();
             assertNotNull(ae);
@@ -512,25 +484,12 @@ class SevenZFileTest extends AbstractTest {
         testFiles.add(getPath("COMPRESS-542-endheadercorrupted.7z"));
         testFiles.add(getPath("COMPRESS-542-endheadercorrupted2.7z"));
         for (final Path file : testFiles) {
-            {
-                final IOException e = assertThrows(ArchiveException.class, () -> {
-                    try (@SuppressWarnings("deprecation")
-                    SevenZFile sevenZFile = new SevenZFile(Files.newByteChannel(file),
-                            SevenZFileOptions.builder().withTryToRecoverBrokenArchives(true).build())) {
-                        // do nothing
-                    }
-                }, "Expected IOException: start header corrupt and unable to guess end header");
-                assertEquals("Start header corrupt and unable to guess end header", e.getMessage());
-            }
-            {
-                final IOException e = assertThrows(ArchiveException.class, () -> {
-                    try (SevenZFile sevenZFile = SevenZFile.builder().setSeekableByteChannel(Files.newByteChannel(file)).setTryToRecoverBrokenArchives(true)
-                            .get()) {
-                        // do nothing
-                    }
-                }, "Expected IOException: start header corrupt and unable to guess end header");
-                assertEquals("Start header corrupt and unable to guess end header", e.getMessage());
-            }
+            final IOException e = assertThrows(ArchiveException.class, () -> {
+                try (SevenZFile sevenZFile = SevenZFile.builder().setPath(file).setTryToRecoverBrokenArchives(true).get()) {
+                    // do nothing
+                }
+            }, "Expected IOException: start header corrupt and unable to guess end header");
+            assertEquals("Start header corrupt and unable to guess end header", e.getMessage());
         }
     }
 
@@ -554,8 +513,6 @@ class SevenZFileTest extends AbstractTest {
                     .setPassword(password)
                     .setTryToRecoverBrokenArchives(true)
                     .get().close());
-        assertThrows(ArchiveException.class,
-                () -> new SevenZFile(new File(fixture), password).close());
         // @formatter:on
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/tar/BigFilesIT.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/BigFilesIT.java
@@ -94,7 +94,7 @@ public class BigFilesIT extends AbstractTest {
                 GzipCompressorInputStream gzin = new GzipCompressorInputStream(in)) {
             Files.copy(gzin, output, StandardCopyOption.REPLACE_EXISTING);
         }
-        try (TarFile tarFile = new TarFile(output)) {
+        try (TarFile tarFile = TarFile.builder().setPath(output).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(1, entries.size());
             assertNotNull(entries.get(0));

--- a/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/SparseFilesTest.java
@@ -116,7 +116,7 @@ class SparseFilesTest extends AbstractTest {
     void testCompareTarArchiveInputStreamWithTarFile() throws IOException {
         final Path file = getPath("oldgnu_sparse.tar");
         try (TarArchiveInputStream tarIn = TarArchiveInputStream.builder().setPath(file).get();
-                TarFile tarFile = new TarFile(file)) {
+                TarFile tarFile = TarFile.builder().setPath(file).get()) {
             assertNotNull(tarIn.getNextTarEntry());
             try (InputStream inputStream = tarFile.getInputStream(tarFile.getEntries().get(0))) {
                 assertArrayEquals(IOUtils.toByteArray(tarIn), IOUtils.toByteArray(inputStream));
@@ -303,7 +303,7 @@ class SparseFilesTest extends AbstractTest {
     void testTarFileExtractExtendedOldGNU() throws IOException, InterruptedException {
         final File file = getFile("oldgnu_extended_sparse.tar");
         try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparse6");
-                TarFile tarFile = new TarFile(file)) {
+                TarFile tarFile = TarFile.builder().setFile(file).get()) {
             final TarArchiveEntry ae = tarFile.getEntries().get(0);
 
             try (InputStream tarInput = tarFile.getInputStream(ae)) {
@@ -341,7 +341,7 @@ class SparseFilesTest extends AbstractTest {
     void testTarFileExtractOldGNU() throws IOException, InterruptedException {
         final File file = getFile("oldgnu_sparse.tar");
         try (InputStream sparseFileInputStream = extractTarAndGetInputStream(file, "sparsefile");
-                TarFile tarFile = new TarFile(file)) {
+                TarFile tarFile = TarFile.builder().setFile(file).get()) {
             final TarArchiveEntry entry = tarFile.getEntries().get(0);
             try (InputStream tarInput = tarFile.getInputStream(entry)) {
                 assertArrayEquals(IOUtils.toByteArray(tarInput), IOUtils.toByteArray(sparseFileInputStream));
@@ -358,7 +358,7 @@ class SparseFilesTest extends AbstractTest {
         assumeFalse(getTarBinaryHelp().startsWith("tar (GNU tar) 1.28"), "This test should be ignored if GNU tar is version 1.28");
 
         final File file = getFile("pax_gnu_sparse.tar");
-        try (TarFile paxGnu = new TarFile(file)) {
+        try (TarFile paxGnu = TarFile.builder().setFile(file).get()) {
             final List<TarArchiveEntry> entries = paxGnu.getEntries();
 
             TarArchiveEntry entry = entries.get(0);
@@ -386,12 +386,12 @@ class SparseFilesTest extends AbstractTest {
     void testTarFileExtractSparseTarsOnWindows() throws IOException {
         final File oldGNUSparseTar = getFile("oldgnu_sparse.tar");
         final File paxGNUSparseTar = getFile("pax_gnu_sparse.tar");
-        try (TarFile paxGnu = new TarFile(paxGNUSparseTar)) {
+        try (TarFile paxGnu = TarFile.builder().setFile(paxGNUSparseTar).get()) {
             final List<TarArchiveEntry> entries = paxGnu.getEntries();
 
             // compare between old GNU and PAX 0.0
             TarArchiveEntry paxGnuEntry = entries.get(0);
-            try (TarFile oldGnu = new TarFile(oldGNUSparseTar)) {
+            try (TarFile oldGnu = TarFile.builder().setFile(oldGNUSparseTar).get()) {
                 final TarArchiveEntry oldGnuEntry = oldGnu.getEntries().get(0);
                 try (InputStream old = oldGnu.getInputStream(oldGnuEntry);
                         InputStream pax = paxGnu.getInputStream(paxGnuEntry)) {
@@ -401,7 +401,7 @@ class SparseFilesTest extends AbstractTest {
 
             // compare between old GNU and PAX 0.1
             paxGnuEntry = entries.get(1);
-            try (TarFile oldGnu = new TarFile(oldGNUSparseTar)) {
+            try (TarFile oldGnu = TarFile.builder().setFile(oldGNUSparseTar).get()) {
                 final TarArchiveEntry oldGnuEntry = oldGnu.getEntries().get(0);
                 try (InputStream old = oldGnu.getInputStream(oldGnuEntry);
                         InputStream pax = paxGnu.getInputStream(paxGnuEntry)) {
@@ -411,7 +411,7 @@ class SparseFilesTest extends AbstractTest {
 
             // compare between old GNU and PAX 1.0
             paxGnuEntry = entries.get(2);
-            try (TarFile oldGnu = new TarFile(oldGNUSparseTar)) {
+            try (TarFile oldGnu = TarFile.builder().setFile(oldGNUSparseTar).get()) {
                 final TarArchiveEntry oldGnuEntry = oldGnu.getEntries().get(0);
                 try (InputStream old = oldGnu.getInputStream(oldGnuEntry);
                         InputStream pax = paxGnu.getInputStream(paxGnuEntry)) {
@@ -424,7 +424,7 @@ class SparseFilesTest extends AbstractTest {
     @Test
     void testTarFileOldGNU() throws Throwable {
         final File file = getFile("oldgnu_sparse.tar");
-        try (TarFile tarFile = new TarFile(file)) {
+        try (TarFile tarFile = TarFile.builder().setFile(file).get()) {
             final TarArchiveEntry ae = tarFile.getEntries().get(0);
             assertEquals("sparsefile", ae.getName());
             assertEquals(TarConstants.LF_GNUTYPE_SPARSE, ae.getLinkFlag());
@@ -464,7 +464,7 @@ class SparseFilesTest extends AbstractTest {
     @Test
     void testTarFilePaxGNU() throws IOException {
         final File file = getFile("pax_gnu_sparse.tar");
-        try (TarFile tarFile = new TarFile(file)) {
+        try (TarFile tarFile = TarFile.builder().setFile(file).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertPaxGNUEntry(entries.get(0), "0.0");
             assertPaxGNUEntry(entries.get(1), "0.1");

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarFileTest.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,7 +52,7 @@ import shaded.org.apache.commons.lang3.StringUtils;
 class TarFileTest extends AbstractTest {
 
     private void datePriorToEpoch(final String archive) throws Exception {
-        try (TarFile tarFile = new TarFile(getPath(archive))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI(archive)).get()) {
             final TarArchiveEntry entry = tarFile.getEntries().get(0);
             assertEquals("foo", entry.getName());
             assertEquals(TarConstants.LF_NORMAL, entry.getLinkFlag());
@@ -69,7 +70,7 @@ class TarFileTest extends AbstractTest {
     @Test
     void testArchiveWithTrailer() throws IOException {
         try (SeekableByteChannel channel = Files.newByteChannel(getPath("archive_with_trailer.tar"));
-                TarFile tarfile = new TarFile(channel, TarConstants.DEFAULT_BLKSIZE, TarConstants.DEFAULT_RCDSIZE, null, false)) {
+                TarFile tarfile = TarFile.builder().setChannel(channel).get()) {
             final String tarAppendix = "Hello, world!\n";
             final ByteBuffer buffer = ByteBuffer.allocate(tarAppendix.length());
             channel.read(buffer);
@@ -81,7 +82,7 @@ class TarFileTest extends AbstractTest {
     void testBuilderSeekableByteChannel() throws IOException {
         try (SeekableByteChannel channel = Files.newByteChannel(getPath("archive_with_trailer.tar"));
                 TarFile tarfile = TarFile.builder()
-                        .setSeekableByteChannel(channel)
+                        .setChannel(channel)
                         .setBlockSize(TarConstants.DEFAULT_BLKSIZE)
                         .setRecordSize(TarConstants.DEFAULT_RCDSIZE)
                         .setLenient(false)
@@ -95,7 +96,7 @@ class TarFileTest extends AbstractTest {
 
     @Test
     void testCompress197() throws IOException {
-        try (TarFile tarFile = new TarFile(getPath("COMPRESS-197.tar"))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("COMPRESS-197.tar")).get()) {
             // noop
         }
     }
@@ -122,7 +123,7 @@ class TarFileTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarFile tarFile = new TarFile(data)) {
+        try (TarFile tarFile = TarFile.builder().setByteArray(data).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(folderName, entries.get(0).getName());
             assertEquals(TarConstants.LF_DIR, entries.get(0).getLinkFlag());
@@ -135,7 +136,7 @@ class TarFileTest extends AbstractTest {
 
     @Test
     void testCompress657() throws IOException {
-        try (TarFile tarFile = new TarFile(getPath("COMPRESS-657/orjson-3.7.8.tar"))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("COMPRESS-657/orjson-3.7.8.tar")).get()) {
             for (final TarArchiveEntry entry : tarFile.getEntries()) {
                 if (entry.isDirectory()) {
                     // An entry cannot be a directory and a "normal file" at the same time.
@@ -184,7 +185,7 @@ class TarFileTest extends AbstractTest {
                 out.flush();
             }
             // untar these tars
-            try (TarFile tarFile = new TarFile(tarF)) {
+            try (TarFile tarFile = TarFile.builder().setFile(tarF).get()) {
                 for (final TarArchiveEntry entry : tarFile.getEntries()) {
                     assertTrue(entry.getName().endsWith("/"), "Entry name: " + entry.getName());
                 }
@@ -195,7 +196,7 @@ class TarFileTest extends AbstractTest {
     @Test
     void testMultiByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
         final byte[] buf = new byte[2];
-        try (TarFile tarFile = new TarFile(getPath("bla.tar"));
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("bla.tar")).get();
                 InputStream input = tarFile.getInputStream(tarFile.getEntries().get(0))) {
             IOUtils.toByteArray(input);
             assertEquals(-1, input.read(buf));
@@ -205,22 +206,22 @@ class TarFileTest extends AbstractTest {
 
     @Test
     void testParseTarTruncatedInContent() {
-        assertThrows(IOException.class, () -> new TarFile(getPath("COMPRESS-544_truncated_in_content.tar")));
+        assertThrows(IOException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-544_truncated_in_content.tar")).get());
     }
 
     @Test
     void testParseTarTruncatedInPadding() {
-        assertThrows(IOException.class, () -> new TarFile(getPath("COMPRESS-544_truncated_in_padding.tar")));
+        assertThrows(IOException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-544_truncated_in_padding.tar")).get());
     }
 
     @Test
     void testParseTarWithNonNumberPaxHeaders() {
-        assertThrows(ArchiveException.class, () -> new TarFile(getPath("COMPRESS-529-fail.tar")));
+        assertThrows(ArchiveException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-529-fail.tar")).get());
     }
 
     @Test
     void testParseTarWithSpecialPaxHeaders() {
-        assertThrows(ArchiveException.class, () -> new TarFile(getPath("COMPRESS-530-fail.tar")));
+        assertThrows(ArchiveException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-530-fail.tar")).get());
     }
 
     @Test
@@ -230,7 +231,7 @@ class TarFileTest extends AbstractTest {
             try (GZIPInputStream gin = new GZIPInputStream(Files.newInputStream(getPath("COMPRESS-245.tar.gz")))) {
                 Files.copy(gin, tempTar);
             }
-            try (TarFile tarFile = new TarFile(tempTar)) {
+            try (TarFile tarFile = TarFile.builder().setPath(tempTar).get()) {
                 assertEquals(31, tarFile.getEntries().size());
             }
         } catch (final IOException e) {
@@ -240,7 +241,7 @@ class TarFileTest extends AbstractTest {
 
     @Test
     void testRejectsArchivesWithNegativeSizes() throws Exception {
-        assertThrows(ArchiveException.class, () -> new TarFile(getFile("COMPRESS-569-fail.tar")));
+        assertThrows(ArchiveException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-569-fail.tar")).get());
     }
 
     @Test
@@ -256,7 +257,7 @@ class TarFileTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarFile tarFile = new TarFile(data)) {
+        try (TarFile tarFile = TarFile.builder().setByteArray(data).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(4294967294L, entries.get(0).getLongGroupId());
         }
@@ -267,7 +268,7 @@ class TarFileTest extends AbstractTest {
      */
     @Test
     void testShouldReadGNULongNameEntryWithWrongName() throws Exception {
-        try (TarFile tarFile = new TarFile(getPath("COMPRESS-324.tar"))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("COMPRESS-324.tar")).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(
                     "1234567890123456789012345678901234567890123456789012345678901234567890"
@@ -280,15 +281,15 @@ class TarFileTest extends AbstractTest {
     @Test
     void testShouldThrowAnExceptionOnTruncatedEntries() throws Exception {
         createTempDirectory("COMPRESS-279");
-        assertThrows(IOException.class, () -> new TarFile(getPath("COMPRESS-279.tar")));
+        assertThrows(IOException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-279.tar")).get());
     }
 
     @Test
     void testShouldUseSpecifiedEncodingWhenReadingGNULongNames() throws Exception {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        final String encoding = StandardCharsets.UTF_16.name();
+        final Charset encoding = StandardCharsets.UTF_16;
         final String name = "1234567890123456789012345678901234567890123456789" + "01234567890123456789012345678901234567890123456789" + "01234567890\u00e4";
-        try (TarArchiveOutputStream tos = new TarArchiveOutputStream(bos, encoding)) {
+        try (TarArchiveOutputStream tos = new TarArchiveOutputStream(bos, encoding.name())) {
             tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
             final TarArchiveEntry t = new TarArchiveEntry(name);
             t.setSize(1);
@@ -297,7 +298,7 @@ class TarFileTest extends AbstractTest {
             tos.closeArchiveEntry();
         }
         final byte[] data = bos.toByteArray();
-        try (TarFile tarFile = new TarFile(data, encoding)) {
+        try (TarFile tarFile = TarFile.builder().setByteArray(data).setCharset(encoding).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(1, entries.size());
             assertEquals(name, entries.get(0).getName());
@@ -306,7 +307,7 @@ class TarFileTest extends AbstractTest {
 
     @Test
     void testSingleByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
-        try (TarFile tarFile = new TarFile(getPath("bla.tar"));
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("bla.tar")).get();
                 InputStream input = tarFile.getInputStream(tarFile.getEntries().get(0))) {
             IOUtils.toByteArray(input);
             assertEquals(-1, input.read());
@@ -319,7 +320,7 @@ class TarFileTest extends AbstractTest {
      */
     @Test
     void testSkipsDevNumbersWhenEntryIsNoDevice() throws Exception {
-        try (TarFile tarFile = new TarFile(getPath("COMPRESS-417.tar"))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("COMPRESS-417.tar")).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(2, entries.size());
             assertEquals("test1.xml", entries.get(0).getName());
@@ -334,7 +335,7 @@ class TarFileTest extends AbstractTest {
      */
     @Test
     void testSurvivesBlankLinesInPaxHeader() throws Exception {
-        try (TarFile tarFile = new TarFile(getPath("COMPRESS-355.tar"))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("COMPRESS-355.tar")).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(1, entries.size());
             assertEquals("package/package.json", entries.get(0).getName());
@@ -347,7 +348,7 @@ class TarFileTest extends AbstractTest {
      */
     @Test
     void testSurvivesPaxHeaderWithNameEndingInSlash() throws Exception {
-        try (TarFile tarFile = new TarFile(getPath("COMPRESS-356.tar"))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("COMPRESS-356.tar")).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(1, entries.size());
             assertEquals("package/package.json", entries.get(0).getName());
@@ -357,18 +358,18 @@ class TarFileTest extends AbstractTest {
 
     @Test
     void testThrowException() {
-        assertThrows(ArchiveException.class, () -> new TarFile(getPath("COMPRESS-553-fail.tar")));
+        assertThrows(ArchiveException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-553-fail.tar")).get());
     }
 
     @Test
     void testThrowExceptionWithNullEntry() {
         // Only on Windows: throws a UnmappableCharacterException
-        assertThrows(IOException.class, () -> new TarFile(getPath("COMPRESS-554-fail.tar")));
+        assertThrows(IOException.class, () -> TarFile.builder().setURI(getURI("COMPRESS-554-fail.tar")).get());
     }
 
     @Test
     void testWorkaroundForBrokenTimeHeader() throws IOException {
-        try (TarFile tarFile = new TarFile(getPath("simple-aix-native-tar.tar"))) {
+        try (TarFile tarFile = TarFile.builder().setURI(getURI("simple-aix-native-tar.tar")).get()) {
             final List<TarArchiveEntry> entries = tarFile.getEntries();
             assertEquals(3, entries.size());
             final TarArchiveEntry entry = entries.get(1);

--- a/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/UTF8ZipFilesTest.java
@@ -201,8 +201,7 @@ class UTF8ZipFilesTest extends AbstractTest {
      */
     @Test
     void testRead7ZipArchive() throws IOException {
-        final File archive = getFile("utf8-7zip-test.zip");
-        try (ZipFile zf = new ZipFile(archive, CP437, false)) {
+        try (ZipFile zf = ZipFile.builder().setURI(getURI("utf8-7zip-test.zip")).setCharset(CP437).setUseUnicodeExtraFields(false).get()) {
             assertNotNull(zf.getEntry(ASCII_TXT));
             assertNotNull(zf.getEntry(EURO_FOR_DOLLAR_TXT));
             assertNotNull(zf.getEntry(OIL_BARREL_TXT));

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileIgnoringLocalFileHeaderTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileIgnoringLocalFileHeaderTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Enumeration;
 
@@ -38,16 +37,10 @@ class ZipFileIgnoringLocalFileHeaderTest {
     private static ZipFile openZipWithoutLocalFileHeader(final String fileName) throws IOException {
         // @formatter:off
         return ZipFile.builder()
-                .setFile(AbstractTest.getFile(fileName))
-                .setCharset(StandardCharsets.UTF_8.name())
-                .setUseUnicodeExtraFields(true)
+                .setURI(AbstractTest.getURI(fileName))
                 .setIgnoreLocalFileHeader(true)
                 .get();
         // @formatter:on
-    }
-
-    private static ZipFile openZipWithoutLocalFileHeaderDeprecated(final String fileName) throws IOException {
-        return new ZipFile(AbstractTest.getFile(fileName), StandardCharsets.UTF_8.name(), true, true);
     }
 
     @TempDir
@@ -104,7 +97,7 @@ class ZipFileIgnoringLocalFileHeaderTest {
      */
     @Test
     void testZipUnarchive() throws Exception {
-        try (ZipFile zipFile = openZipWithoutLocalFileHeaderDeprecated("bla.zip")) {
+        try (ZipFile zipFile = openZipWithoutLocalFileHeader("bla.zip")) {
             zipFile.stream().forEach(entry -> {
                 try (InputStream inputStream = zipFile.getInputStream(entry)) {
                     Files.copy(inputStream, new File(dir, entry.getName()).toPath());

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipMemoryFileSystemTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipMemoryFileSystemTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -230,8 +229,7 @@ class ZipMemoryFileSystemTest {
                 }
             }
 
-            try (ZipFile zf = new ZipFile(Files.newByteChannel(target, StandardOpenOption.READ), target.getFileName().toString(), StandardCharsets.UTF_8.name(),
-                    true)) {
+            try (ZipFile zf = ZipFile.builder().setPath(target).get()) {
                 final ZipArchiveEntry b_entry = zf.getEntries("b.txt").iterator().next();
                 assertEquals(8, b_entry.getSize());
                 try (InputStream inputStream = zf.getInputStream(b_entry)) {
@@ -245,8 +243,7 @@ class ZipMemoryFileSystemTest {
                 }
             }
 
-            try (ZipFile zf = new ZipFile(Files.newByteChannel(target, StandardOpenOption.READ), target.getFileName().toString(), StandardCharsets.UTF_8.name(),
-                    true, false)) {
+            try (ZipFile zf = ZipFile.builder().setPath(target).get()) {
                 final ZipArchiveEntry b_entry = zf.getEntries("b.txt").iterator().next();
                 assertEquals(8, b_entry.getSize());
                 try (InputStream inputStream = zf.getInputStream(b_entry)) {
@@ -328,7 +325,7 @@ class ZipMemoryFileSystemTest {
                 }
             }
 
-            try (ZipFile zf = new ZipFile(target)) {
+            try (ZipFile zf = ZipFile.builder().setPath(target).get()) {
                 final ZipArchiveEntry b_entry = zf.getEntries("b.txt").iterator().next();
                 assertEquals(8, b_entry.getSize());
                 try (InputStream inputStream = zf.getInputStream(b_entry)) {


### PR DESCRIPTION
This PR introduces a new `AbstractArchiveBuilder`, which serves as a shared foundation for all archive input streams, including `SevenZFile`, `TarFile`, and `ZipFile`.

This refactoring also leverages the new `ChannelOrigin` from Commons IO 2.21.0, streamlining the builder implementations for `SevenZFile`, `TarFile`, and `ZipFile`.

### Additional improvements

* **Constructor unification:** All constructors now delegate to a single constructor that accepts a builder.
* **Resource safety:** If an error occurs during construction (or within the builder’s `get()` method), the underlying resource is now always closed. Previously, resources provided via `SeekableByteChannel` were not closed on error, potentially leaving channels in an incoherent state.
* **Deprecation cleanup:** All references to deprecated constructors and methods have been removed. Compatibility is verified through `LegacyConstructorsTest`, which ensures the builder pattern behaves equivalently to the removed constructors.
