### PR TITLE
Disable JDK 26-ea tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,10 +36,15 @@ jobs:
         java: [ 8, 11, 17, 21, 25 ]
         experimental: [false]
         # Keep the same parameter order as the matrix above
-        include:
-          - os: ubuntu-latest
-            java: 26-ea
-            experimental: true
+        #
+        # PMD does not yet support Java 26 (see https://github.com/pmd/pmd/issues/5871).
+        # It is therefore too soon to run tests with Java 26.
+        # Uncomment the following lines once the above issue has been resolved.
+        #
+        # include:
+        #   - os: ubuntu-latest
+        #     java: 26-ea
+        #     experimental: true
         
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
All JDK 26-ea tests currently fail because PMD does not yet support this version (see [job 52084346962](https://github.com/apache/commons-compress/actions/runs/18292910119/job/52084346962) for an example).

While it’s valuable to stay ahead of upcoming JDK releases, having test jobs that are guaranteed to fail for reasons outside of Commons Compress or the JDK itself adds little benefit.

This PR disables JDK 26-ea tests until pmd/pmd#5871 is resolved, which will likely require upgrading to ASM 9.9 (released only a few days ago). Tests can be re-enabled once PMD adds support for Java 26.
