### PR TITLE
[COMPRESS-720] Integrate OSS-Fuzz fuzzers and enable CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,27 @@
+name: CIFuzz
+on: [pull_request]
+permissions: {}
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'apache-commons-compress'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'apache-commons-compress'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v4
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -219,12 +219,6 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <artifactId>junit-pioneer</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.code-intelligence</groupId>
-      <artifactId>jazzer-junit</artifactId>
-      <version>0.24.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/commons-compress.git</connection>
@@ -411,6 +405,15 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <testExcludes>
+            <testExclude>org/apache/commons/compress/fuzz/**</testExclude>
+          </testExcludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -615,6 +618,14 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <testExcludes>
+                <testExclude>none</testExclude>
+              </testExcludes>
+            </configuration>
+          </plugin>
+          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,12 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
       <artifactId>junit-pioneer</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.code-intelligence</groupId>
+      <artifactId>jazzer-junit</artifactId>
+      <version>0.24.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/commons-compress.git</connection>
@@ -598,6 +604,22 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
               <argLine>
                 ${argLine} --add-opens java.base/java.io=ALL-UNNAMED
               </argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>fuzz</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*Fuzzer.java</include>
+              </includes>
             </configuration>
           </plugin>
         </plugins>

--- a/src/test/java/org/apache/commons/compress/fuzz/AbstractTests.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/AbstractTests.java
@@ -1,28 +1,29 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.commons.compress.fuzz;
+
+import java.io.IOException;
+import java.util.logging.LogManager;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.compressors.CompressorInputStream;
-
-import java.io.IOException;
-import java.util.logging.LogManager;
 
 /**
  * Class with common functionality shared among fuzzing harnesses.

--- a/src/test/java/org/apache/commons/compress/fuzz/AbstractTests.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/AbstractTests.java
@@ -27,7 +27,7 @@ import java.util.logging.LogManager;
 /**
  * Class with common functionality shared among fuzzing harnesses.
  */
-public class BaseTests {
+public abstract class AbstractTests {
     public static void fuzzerInitialize() {
         LogManager.getLogManager().reset();
     }

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverArFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverArFuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.ar.ArArchiveInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ArchiverArFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzArchiveInputStream(new ArArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverArFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverArFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.archivers.ar.ArArchiveInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class ArchiverArFuzzer extends BaseTests {
+public class ArchiverArFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzArchiveInputStream(new ArArchiveInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverArFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverArFuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.archivers.ar.ArArchiveInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.archivers.ar.ArArchiveInputStream;
 
 public class ArchiverArFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverArjFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverArjFuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.archivers.arj.ArjArchiveInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.archivers.arj.ArjArchiveInputStream;
 
 public class ArchiverArjFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverArjFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverArjFuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.arj.ArjArchiveInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ArchiverArjFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzArchiveInputStream(new ArjArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverArjFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverArjFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.archivers.arj.ArjArchiveInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class ArchiverArjFuzzer extends BaseTests {
+public class ArchiverArjFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzArchiveInputStream(new ArjArchiveInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverCpioFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverCpioFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class ArchiverCpioFuzzer extends BaseTests {
+public class ArchiverCpioFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzArchiveInputStream(new CpioArchiveInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverCpioFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverCpioFuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ArchiverCpioFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzArchiveInputStream(new CpioArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IllegalArgumentException | IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverCpioFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverCpioFuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
 
 public class ArchiverCpioFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverDumpFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverDumpFuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
 
 public class ArchiverDumpFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverDumpFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverDumpFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class ArchiverDumpFuzzer extends BaseTests {
+public class ArchiverDumpFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzArchiveInputStream(new DumpArchiveInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverDumpFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverDumpFuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ArchiverDumpFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzArchiveInputStream(new DumpArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverTarStreamFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverTarStreamFuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ArchiverTarStreamFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzArchiveInputStream(new TarArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverTarStreamFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverTarStreamFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class ArchiverTarStreamFuzzer extends BaseTests {
+public class ArchiverTarStreamFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzArchiveInputStream(new TarArchiveInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverTarStreamFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverTarStreamFuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
 public class ArchiverTarStreamFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverZipStreamFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverZipStreamFuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ArchiverZipStreamFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzArchiveInputStream(new ZipArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/ArchiverZipStreamFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/ArchiverZipStreamFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class ArchiverZipStreamFuzzer extends BaseTests {
+public class ArchiverZipStreamFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzArchiveInputStream(new ZipArchiveInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/BaseTests.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/BaseTests.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.compressors.CompressorInputStream;
+
+import java.io.IOException;
+import java.util.logging.LogManager;
+
+/**
+ * Class with common functionality shared among fuzzing harnesses.
+ */
+public class BaseTests {
+    public static void fuzzerInitialize() {
+        LogManager.getLogManager().reset();
+    }
+
+    /**
+     * Fuzz archiver streams by reading every entry.
+     */
+    public static void fuzzArchiveInputStream(ArchiveInputStream is) throws IOException {
+        ArchiveEntry entry;
+        while ((entry = is.getNextEntry()) != null) {
+            is.read(new byte[1024]);
+        }
+        is.close();
+    }
+
+    /**
+     * Fuzz compressor streams by reading them.
+     */
+    public static void fuzzCompressorInputStream(CompressorInputStream is) throws IOException {
+        is.read(new byte[1024]);
+        is.close();
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/BaseTests.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/BaseTests.java
@@ -19,16 +19,12 @@
 
 package org.apache.commons.compress.fuzz;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-
-public class ArchiverZipStreamFuzzer extends AbstractTests {
-    public static void fuzzerTestOneInput(byte[] data) {
-        try {
-            fuzzArchiveInputStream(new ZipArchiveInputStream(new ByteArrayInputStream(data)));
-        } catch (IOException ignored) {
-        }
-    }
+/**
+ * Temporary shim to maintain compatibility with legacy OSS-Fuzz build scripts
+ * which hardcode the class name "BaseTests".
+ * 
+ * TODO: Remove this class once the oss-fuzz project configuration is updated
+ * to use AbstractTests.
+ */
+public abstract class BaseTests extends AbstractTests {
 }

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressSevenZFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressSevenZFuzzer.java
@@ -1,29 +1,31 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
 import org.apache.commons.compress.archivers.sevenz.SevenZFileOptions;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
-
-import java.io.InputStream;
-import java.io.IOException;
 
 public class CompressSevenZFuzzer extends AbstractTests {
     private static final SevenZFileOptions options = new SevenZFileOptions.Builder()
@@ -31,15 +33,13 @@ public class CompressSevenZFuzzer extends AbstractTests {
         .build();
 
     public static void fuzzerTestOneInput(byte[] data) {
-        try {
-            SevenZFile sf = new SevenZFile(new SeekableInMemoryByteChannel(data), options);
+        try (final SevenZFile sf = new SevenZFile(new SeekableInMemoryByteChannel(data), options)) {
             SevenZArchiveEntry entry;
-            while((entry = sf.getNextEntry()) != null) {
-                InputStream is = sf.getInputStream(entry);
+            while ((entry = sf.getNextEntry()) != null) {
+                final InputStream is = sf.getInputStream(entry);
                 is.read(new byte[1024]);
             }
-            sf.close();
-        } catch (IOException ignored) {
+        } catch (final IOException ignored) {
         }
     }
 }

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressSevenZFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressSevenZFuzzer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+import org.apache.commons.compress.archivers.sevenz.SevenZFileOptions;
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+public class CompressSevenZFuzzer extends BaseTests {
+    private static final SevenZFileOptions options = new SevenZFileOptions.Builder()
+        .withMaxMemoryLimitInKb(1_000_000)
+        .build();
+
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            SevenZFile sf = new SevenZFile(new SeekableInMemoryByteChannel(data), options);
+            SevenZArchiveEntry entry;
+            while((entry = sf.getNextEntry()) != null) {
+                InputStream is = sf.getInputStream(entry);
+                is.read(new byte[1024]);
+            }
+            sf.close();
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressSevenZFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressSevenZFuzzer.java
@@ -25,7 +25,7 @@ import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import java.io.InputStream;
 import java.io.IOException;
 
-public class CompressSevenZFuzzer extends BaseTests {
+public class CompressSevenZFuzzer extends AbstractTests {
     private static final SevenZFileOptions options = new SevenZFileOptions.Builder()
         .withMaxMemoryLimitInKb(1_000_000)
         .build();

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressTarFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressTarFuzzer.java
@@ -23,7 +23,7 @@ import org.apache.commons.compress.archivers.tar.TarFile;
 import java.io.InputStream;
 import java.io.IOException;
 
-public class CompressTarFuzzer extends BaseTests {
+public class CompressTarFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             TarFile tf = new TarFile(data);

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressTarFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressTarFuzzer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarFile;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+public class CompressTarFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            TarFile tf = new TarFile(data);
+            for (TarArchiveEntry entry : tf.getEntries()) {
+                InputStream is = tf.getInputStream(entry);
+                is.read(new byte[1024]);
+            }
+            tf.close();
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressTarFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressTarFuzzer.java
@@ -1,38 +1,38 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarFile;
 
-import java.io.InputStream;
-import java.io.IOException;
-
 public class CompressTarFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
-        try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
+        try (final TarFile tf = new TarFile(data)) {
+            for (final TarArchiveEntry entry : tf.getEntries()) {
+                final InputStream is = tf.getInputStream(entry);
                 is.read(new byte[1024]);
             }
-            tf.close();
-        } catch (IOException ignored) {
+        } catch (final IOException ignored) {
         }
     }
 }

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressZipFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressZipFuzzer.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.util.Enumeration;
 
-public class CompressZipFuzzer extends BaseTests {
+public class CompressZipFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             ZipFile zf = new ZipFile(new SeekableInMemoryByteChannel(data));

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressZipFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressZipFuzzer.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Enumeration;
+
+public class CompressZipFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            ZipFile zf = new ZipFile(new SeekableInMemoryByteChannel(data));
+            Enumeration<? extends ZipArchiveEntry> entries = zf.getEntries();
+            while(entries.hasMoreElements()) {
+                ZipArchiveEntry entry = entries.nextElement();
+                InputStream is = zf.getInputStream(entry);
+                is.read(new byte[1024]);
+            }
+            zf.close();
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressZipFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressZipFuzzer.java
@@ -1,42 +1,42 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 
-import java.io.InputStream;
-import java.io.IOException;
-import java.util.Enumeration;
-
 public class CompressZipFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
-        try {
-            ZipFile zf = new ZipFile(new SeekableInMemoryByteChannel(data));
-            Enumeration<? extends ZipArchiveEntry> entries = zf.getEntries();
-            while(entries.hasMoreElements()) {
-                ZipArchiveEntry entry = entries.nextElement();
-                InputStream is = zf.getInputStream(entry);
+        try (final ZipFile zf = new ZipFile(new SeekableInMemoryByteChannel(data))) {
+            final Enumeration<? extends ZipArchiveEntry> entries = zf.getEntries();
+            while (entries.hasMoreElements()) {
+                final ZipArchiveEntry entry = entries.nextElement();
+                final InputStream is = zf.getInputStream(entry);
                 is.read(new byte[1024]);
             }
-            zf.close();
-        } catch (IOException ignored) {
+        } catch (final IOException ignored) {
         }
     }
 }

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorBZip2Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorBZip2Fuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorBZip2Fuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzCompressorInputStream(new BZip2CompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorBZip2Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorBZip2Fuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class CompressorBZip2Fuzzer extends BaseTests {
+public class CompressorBZip2Fuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzCompressorInputStream(new BZip2CompressorInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorBZip2Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorBZip2Fuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
 public class CompressorBZip2Fuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorDeflate64Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorDeflate64Fuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.compressors.deflate64.Deflate64CompressorInpu
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class CompressorDeflate64Fuzzer extends BaseTests {
+public class CompressorDeflate64Fuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzCompressorInputStream(new Deflate64CompressorInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorDeflate64Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorDeflate64Fuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.compressors.deflate64.Deflate64CompressorInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.compressors.deflate64.Deflate64CompressorInputStream;
 
 public class CompressorDeflate64Fuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorDeflate64Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorDeflate64Fuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.compressors.deflate64.Deflate64CompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorDeflate64Fuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzCompressorInputStream(new Deflate64CompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorGzipFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorGzipFuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
 public class CompressorGzipFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorGzipFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorGzipFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class CompressorGzipFuzzer extends BaseTests {
+public class CompressorGzipFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzCompressorInputStream(new GzipCompressorInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorGzipFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorGzipFuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorGzipFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzCompressorInputStream(new GzipCompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorLZ4Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorLZ4Fuzzer.java
@@ -1,27 +1,29 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream;
-import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
 
 public class CompressorLZ4Fuzzer extends AbstractTests {
     // Test both LZ4 classes

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorLZ4Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorLZ4Fuzzer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorLZ4Fuzzer extends BaseTests {
+    // Test both LZ4 classes
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzCompressorInputStream(new BlockLZ4CompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+
+        try {
+            fuzzCompressorInputStream(new FramedLZ4CompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorLZ4Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorLZ4Fuzzer.java
@@ -23,7 +23,7 @@ import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStrea
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class CompressorLZ4Fuzzer extends BaseTests {
+public class CompressorLZ4Fuzzer extends AbstractTests {
     // Test both LZ4 classes
     public static void fuzzerTestOneInput(byte[] data) {
         try {

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorPack200Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorPack200Fuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.compressors.pack200.Pack200CompressorInputStr
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class CompressorPack200Fuzzer extends BaseTests {
+public class CompressorPack200Fuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzCompressorInputStream(new Pack200CompressorInputStream(new ByteArrayInputStream(data)));

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorPack200Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorPack200Fuzzer.java
@@ -1,26 +1,28 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.compressors.pack200.Pack200CompressorInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.compressors.pack200.Pack200CompressorInputStream;
 
 public class CompressorPack200Fuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorPack200Fuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorPack200Fuzzer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.compressors.pack200.Pack200CompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorPack200Fuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzCompressorInputStream(new Pack200CompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorSnappyFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorSnappyFuzzer.java
@@ -1,27 +1,29 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream;
-import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream;
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
 
 public class CompressorSnappyFuzzer extends AbstractTests {
     // Test both Snappy classes

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorSnappyFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorSnappyFuzzer.java
@@ -23,7 +23,7 @@ import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStrea
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class CompressorSnappyFuzzer extends BaseTests {
+public class CompressorSnappyFuzzer extends AbstractTests {
     // Test both Snappy classes
     public static void fuzzerTestOneInput(byte[] data) {
         try {

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorSnappyFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorSnappyFuzzer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream;
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorSnappyFuzzer extends BaseTests {
+    // Test both Snappy classes
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzCompressorInputStream(new FramedSnappyCompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+
+        try {
+            fuzzCompressorInputStream(new SnappyCompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorZFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorZFuzzer.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-public class CompressorZFuzzer extends BaseTests {
+public class CompressorZFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             // Setting limit to avoid out of memory errors

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorZFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorZFuzzer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.compress.fuzz;
+
+import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorZFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            // Setting limit to avoid out of memory errors
+            fuzzCompressorInputStream(new ZCompressorInputStream(new ByteArrayInputStream(data), 1024*1024));
+        } catch (IllegalArgumentException | IOException ignored) {
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/compress/fuzz/CompressorZFuzzer.java
+++ b/src/test/java/org/apache/commons/compress/fuzz/CompressorZFuzzer.java
@@ -1,32 +1,34 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.commons.compress.fuzz;
 
-import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
+import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 
 public class CompressorZFuzzer extends AbstractTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             // Setting limit to avoid out of memory errors
-            fuzzCompressorInputStream(new ZCompressorInputStream(new ByteArrayInputStream(data), 1024*1024));
+            fuzzCompressorInputStream(new ZCompressorInputStream(new ByteArrayInputStream(data), 1024 * 1024));
         } catch (IllegalArgumentException | IOException ignored) {
         }
     }


### PR DESCRIPTION
JIRA Ticket: [COMPRESS-720](https://issues.apache.org/jira/browse/COMPRESS-720)
Currently, our fuzz testing lives externally in the google/oss-fuzz repository. While effective, this creates a gap between development and security testing. and also the fact that google is increasingly wanting their fuzzers to live in the upstream repositories.

This integration ensures that:
Fuzzers evolve with the code: No more "bit-rot" when internal APIs change.

Instant Feedback: The new CIFuzz workflow automatically stress-tests every Pull Request before it's merged.

Developer Empowerment: Any contributor can now run these security tests locally with a single Maven command.

Maven Integration: * Added jazzer-junit as a test-scoped dependency.

Introduced a fuzz Maven profile. This keeps the fuzzers tucked away during standard mvn test runs but makes them easy to trigger via mvn test -Pfuzz.

17 Fuzzer Targets: * We’ve integrated coverage for all major formats: Zip, Tar, 7z, Ar, Arj, Cpio, Dump, and several compressors (BZip2, Gzip, LZ4, Snappy, Z, etc.).

Automated Workflow: * Added .github/workflows/cifuzz.yml to tap into Google's cifuzz actions for continuous security monitoring. (this workflow will run a mini cifuzz test everytime someone changes something in the repo.