### PR TITLE
Fix NullPointerException when reading XZ entries in ZipArchiveInputStream

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -46,6 +46,7 @@ import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.deflate64.Deflate64CompressorInputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream;
 import org.apache.commons.compress.utils.ArchiveUtils;
 import org.apache.commons.compress.utils.InputStreamStatistics;
@@ -929,6 +930,9 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
                 case ENHANCED_DEFLATED:
                     current.inputStream = new Deflate64CompressorInputStream(bis);
                     break;
+		case XZ:
+		    current.inputStream = new XZCompressorInputStream(bis);
+		    break;
                 case ZSTD:
                 case ZSTD_DEPRECATED:
                     current.inputStream = createZstdInputStream(bis);

--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.java
@@ -930,9 +930,9 @@ public class ZipArchiveInputStream extends ArchiveInputStream<ZipArchiveEntry> i
                 case ENHANCED_DEFLATED:
                     current.inputStream = new Deflate64CompressorInputStream(bis);
                     break;
-		case XZ:
-		    current.inputStream = new XZCompressorInputStream(bis);
-		    break;
+                case XZ:
+                    current.inputStream = new XZCompressorInputStream(bis);
+                    break;
                 case ZSTD:
                 case ZSTD_DEPRECATED:
                     current.inputStream = createZstdInputStream(bis);

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -771,6 +771,21 @@ class ZipArchiveInputStreamTest extends AbstractTest {
         }
     }
 
+    @Test
+    void testUnzipXZCompressedEntry() throws Exception {
+        try (ZipArchiveInputStream in = ZipArchiveInputStream.builder().setURI(getURI("org/apache/commons/compress/zip/test-method-xz.zip")).get()) {
+            final ZipArchiveEntry ze = in.getNextZipEntry();
+            final byte[] buf = IOUtils.toByteArray(in);
+            final String text = new String(buf);
+
+	    assertEquals("LICENSE.txt", ze.getName());
+	    assertEquals(11357, text.length());
+            assertTrue(text.startsWith("                                 Apache License"), text);
+            assertTrue(text.endsWith("   limitations under the License.\n"), text);
+            assertEquals(11357, text.length());
+        }
+    }
+
     /**
      * @see "https://issues.apache.org/jira/browse/COMPRESS-176"
      */

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -778,8 +778,8 @@ class ZipArchiveInputStreamTest extends AbstractTest {
             final byte[] buf = IOUtils.toByteArray(in);
             final String text = new String(buf);
 
-	    assertEquals("LICENSE.txt", ze.getName());
-	    assertEquals(11357, text.length());
+            assertEquals("LICENSE.txt", ze.getName());
+            assertEquals(11357, text.length());
             assertTrue(text.startsWith("                                 Apache License"), text);
             assertTrue(text.endsWith("   limitations under the License.\n"), text);
             assertEquals(11357, text.length());

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -777,7 +777,6 @@ class ZipArchiveInputStreamTest extends AbstractTest {
             final ZipArchiveEntry ze = in.getNextZipEntry();
             final byte[] buf = IOUtils.toByteArray(in);
             final String text = new String(buf);
-
             assertEquals("LICENSE.txt", ze.getName());
             assertEquals(11357, text.length());
             assertTrue(text.startsWith("                                 Apache License"), text);


### PR DESCRIPTION
Reading from a zip archive with an XZ entry using `ZipArchiveInputStream` throws an exception currently, because the entry's input stream isn't initialized in `getNextZipEntry`. This fixes that. See added test to reproduce.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
