### PR TITLE
[COMPRESS-724] Fix TAR PAX 1.x sparse header alignment

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -84,6 +84,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="pkarwasz" due-to="Tyler Nighswander, Piotr P. Karwasz, Gary Gregory">>Uniform handling of special tar records in TarFile and TarArchiveInputStream.</action>
       <action type="fix" dev="ggregory" due-to="Gary Gregory, Stanislav Fort">TarArchiveOutputStream now throws a IllegalArgumentException instead of an OutOfMemoryError.</action>
       <action type="fix" dev="ggregory" issue="COMPRESS-707" due-to="Gary Gregory, Roel van Dijk">TarUtils.verifyCheckSum() throws an Exception when checksum could not be parsed.</action>
+      <action type="fix" dev="ggregory" issue="COMPRESS-724" due-to="Ruiqi Dong, Gary Gregory">TarUtils.parsePAX1XSparseHeaders(InputStream, int) skips an extra record when sparse headers are already record-aligned.</action>
       <!-- FIX ar -->      
       <action type="fix" dev="ggregory" due-to="Gary Gregory">ArArchiveInputStream.readGNUStringTable(byte[], int, int) now provides a better exception message, wrapping the underlying exception.</action>
       <action type="fix" dev="ggregory" due-to="Gary Gregory">ArArchiveInputStream.read(byte[], int, int) now throws ArchiveException instead of ArithmeticException.</action>

--- a/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -652,7 +652,7 @@ public final class TarUtils {
             sparseHeaders.add(new TarArchiveStructSparse(sparseOffset, sparseNumbytes));
         }
         // skip the rest of this record data
-        final long bytesToSkip = recordSize - bytesRead % recordSize;
+        final long bytesToSkip = (recordSize - bytesRead % recordSize) % recordSize;
         IOUtils.skip(inputStream, bytesToSkip);
         return sparseHeaders;
     }

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -109,6 +109,16 @@ class TarUtilsTest extends AbstractTest {
         return TarUtils.parsePaxHeaders(new ByteArrayInputStream(data), globalPaxHeaders, data.length, Short.MAX_VALUE, sparseHeaders);
     }
 
+    private static byte[] pax1xSparseHeaderAlignedToSingleRecord() {
+        final StringBuilder header = new StringBuilder("100\n");
+        for (int i = 0; i < 200; i++) {
+            header.append(i < 108 ? "00\n" : "0\n");
+        }
+        final byte[] bytes = header.toString().getBytes(UTF_8);
+        assertEquals(512, bytes.length);
+        return bytes;
+    }
+
     static Stream<Arguments> testReadLongNameHandlesLimits() {
         final String empty = "";
         final String ntfsLongName = createNtfsLongNameByUtf16Units(32767);
@@ -325,6 +335,19 @@ class TarUtilsTest extends AbstractTest {
             assertEquals(0, sparse.get(0).getOffset());
             assertEquals(20, sparse.get(0).getNumbytes());
             assertEquals(-1, in.read());
+        }
+    }
+
+    @Test
+    void testParsePAX1XSparseHeadersDoesNotSkipAlignedDataRecord() throws Exception {
+        final byte[] fileData = new byte[513];
+        Arrays.fill(fileData, 0, 512, (byte) 'A');
+        fileData[512] = 'B';
+        final byte[] input = ArrayUtils.addAll(pax1xSparseHeaderAlignedToSingleRecord(), fileData);
+        try (ByteArrayInputStream in = new ByteArrayInputStream(input)) {
+            final List<TarArchiveStructSparse> sparse = TarUtils.parsePAX1XSparseHeaders(in, 512);
+            assertEquals(100, sparse.size());
+            assertEquals('A', in.read());
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/tar/TarUtilsTest.java
@@ -53,6 +53,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class TarUtilsTest extends AbstractTest {
 
+    /** Number of sparse entries whose PAX 1.X map encodes to exactly one record; see {@link #pax1xSparseHeaderAlignedToSingleRecord()}. */
+    private static final int PAX1X_ALIGNED_SPARSE_ENTRIES = 100;
+
     /**
      * Builds an NTFS-style path (\\?\C:\...) up to a target total UTF-16 length, respecting 255-unit segments.
      */
@@ -109,13 +112,27 @@ class TarUtilsTest extends AbstractTest {
         return TarUtils.parsePaxHeaders(new ByteArrayInputStream(data), globalPaxHeaders, data.length, Short.MAX_VALUE, sparseHeaders);
     }
 
+    /**
+     * Builds a PAX 1.X sparse map whose encoded length is exactly one record, so that
+     * {@link TarUtils#parsePAX1XSparseHeaders(InputStream, int)} finishes reading on a record boundary. That is the case
+     * COMPRESS-724 mishandled by skipping an extra record.
+     * <p>
+     * The map is a count line followed by an offset line and a numbytes line for each of the {@value #PAX1X_ALIGNED_SPARSE_ENTRIES}
+     * entries. The final value is padded with leading zeros (which do not change the parsed value) so the whole block fills exactly
+     * one {@link TarConstants#DEFAULT_RCDSIZE}-byte record.
+     * </p>
+     */
     private static byte[] pax1xSparseHeaderAlignedToSingleRecord() {
-        final StringBuilder header = new StringBuilder("100\n");
-        for (int i = 0; i < 200; i++) {
-            header.append(i < 108 ? "00\n" : "0\n");
+        final StringBuilder header = new StringBuilder();
+        header.append(PAX1X_ALIGNED_SPARSE_ENTRIES).append('\n');
+        for (int i = 0; i < PAX1X_ALIGNED_SPARSE_ENTRIES * 2; i++) {
+            header.append("0\n");
         }
+        // Pad the last value with leading zeros so the block is exactly one record long and therefore already record-aligned.
+        final int padding = TarConstants.DEFAULT_RCDSIZE - header.length();
+        header.insert(header.length() - 2, StringUtils.repeat('0', padding));
         final byte[] bytes = header.toString().getBytes(UTF_8);
-        assertEquals(512, bytes.length);
+        assertEquals(TarConstants.DEFAULT_RCDSIZE, bytes.length);
         return bytes;
     }
 
@@ -340,13 +357,16 @@ class TarUtilsTest extends AbstractTest {
 
     @Test
     void testParsePAX1XSparseHeadersDoesNotSkipAlignedDataRecord() throws Exception {
-        final byte[] fileData = new byte[513];
-        Arrays.fill(fileData, 0, 512, (byte) 'A');
-        fileData[512] = 'B';
+        // A full record of 'A' data plus one trailing 'B'. If the parser wrongly skips an extra record after the already
+        // record-aligned sparse header, the stream lands on 'B' instead of the first data byte 'A'.
+        final byte[] fileData = new byte[TarConstants.DEFAULT_RCDSIZE + 1];
+        Arrays.fill(fileData, 0, TarConstants.DEFAULT_RCDSIZE, (byte) 'A');
+        fileData[TarConstants.DEFAULT_RCDSIZE] = 'B';
         final byte[] input = ArrayUtils.addAll(pax1xSparseHeaderAlignedToSingleRecord(), fileData);
         try (ByteArrayInputStream in = new ByteArrayInputStream(input)) {
-            final List<TarArchiveStructSparse> sparse = TarUtils.parsePAX1XSparseHeaders(in, 512);
-            assertEquals(100, sparse.size());
+            final List<TarArchiveStructSparse> sparse = TarUtils.parsePAX1XSparseHeaders(in, TarConstants.DEFAULT_RCDSIZE);
+            assertEquals(PAX1X_ALIGNED_SPARSE_ENTRIES, sparse.size());
+            // The stream must still be positioned at the first data byte.
             assertEquals('A', in.read());
         }
     }


### PR DESCRIPTION
## Summary

Fix `TarUtils.parsePAX1XSparseHeaders(InputStream, int)` so it does not skip an extra tar record when GNU PAX 1.x sparse headers end exactly on a record boundary.

## Details

Previously, the padding calculation used `recordSize - bytesRead % recordSize`. When `bytesRead` was already aligned to `recordSize`, this computed a full-record skip instead of `0`, advancing the stream past real entry data.

This change uses modulo padding calculation so aligned sparse headers leave the stream positioned at the first data byte.

## Tests

- `mvn -q -Dtest=org.apache.commons.compress.archivers.tar.TarUtilsTest test`
- `mvn -q`