### PR TITLE
Reject out-of-range directory header count in readDirectoryEntry

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
@@ -526,12 +526,13 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
                 pending.put(entry.getIno(), entry);
             }
 
+            final int headerCount = entry.getHeaderCount();
             // A tape segment header describes at most CDATA_LEN records, so a larger (or negative) count is
             // corrupt. Without this the following product overflows int and yields a bogus datalen.
-            if (entry.getHeaderCount() < 0 || entry.getHeaderCount() >= DumpArchiveEntry.TapeSegmentHeader.CDATA_LEN) {
-                throw new ArchiveException("Header count");
+            if (headerCount < 0 || headerCount >= DumpArchiveEntry.TapeSegmentHeader.CDATA_LEN) {
+                throw new ArchiveException("Invalid header count: " + headerCount + " (expected 0.." + (DumpArchiveEntry.TapeSegmentHeader.CDATA_LEN - 1) + ")");
             }
-            final int datalen = DumpArchiveConstants.TP_SIZE * entry.getHeaderCount();
+            final int datalen = DumpArchiveConstants.TP_SIZE * headerCount;
 
             if (blockBuffer.length < datalen) {
                 blockBuffer = org.apache.commons.compress.utils.IOUtils.readRange(raw, datalen);

--- a/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStream.java
@@ -526,6 +526,11 @@ public class DumpArchiveInputStream extends ArchiveInputStream<DumpArchiveEntry>
                 pending.put(entry.getIno(), entry);
             }
 
+            // A tape segment header describes at most CDATA_LEN records, so a larger (or negative) count is
+            // corrupt. Without this the following product overflows int and yields a bogus datalen.
+            if (entry.getHeaderCount() < 0 || entry.getHeaderCount() >= DumpArchiveEntry.TapeSegmentHeader.CDATA_LEN) {
+                throw new ArchiveException("Header count");
+            }
             final int datalen = DumpArchiveConstants.TP_SIZE * entry.getHeaderCount();
 
             if (blockBuffer.length < datalen) {

--- a/src/test/java/org/apache/commons/compress/archivers/dump/Compress712Test.java
+++ b/src/test/java/org/apache/commons/compress/archivers/dump/Compress712Test.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
+import org.apache.commons.compress.archivers.ArchiveException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -267,7 +268,7 @@ public class Compress712Test {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         try (DumpArchiveInputStream is = new DumpArchiveInputStream(new ByteArrayInputStream(data))) {
-            assertThrows(IndexOutOfBoundsException.class, () -> {
+            assertThrows(ArchiveException.class, () -> {
                 while (is.getNextEntry() != null) {
                     is.read(new byte[1024]);
                 }


### PR DESCRIPTION
readDirectoryEntry computes datalen as `TP_SIZE * entry.getHeaderCount()` in int, but the header count comes straight from the tape segment header and isn't bounded at that point, so a directory inode claiming around 2^21 records wraps the product to a negative value that then flows into `raw.read(blockBuffer, 0, datalen)` and surfaces as an `IndexOutOfBoundsException` rather than a normal archive error. getNextEntry already rejects a count `>= CDATA_LEN` and the sibling skip sites in getNextEntry, readBITS and readCLRI cast to long, so this one path is the odd one out; applying the same bound before the multiply keeps a corrupt count from reaching the size math. this is the COMPRESS-712 testPart2 input, whose assertion moves from the raw `IndexOutOfBoundsException` to an `ArchiveException`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
