### PR TITLE
Reject negative element counts in BandSet band decoding

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
@@ -151,6 +151,9 @@ public abstract class BandSet {
         final int[][] result = new int[counts.length][];
         int totalCount = 0;
         for (final int count : counts) {
+            if (count < 0) {
+                throw new Pack200Exception("count < 0");
+            }
             totalCount += count;
         }
         final int[] twoDResult = decodeBandInt(name, in, defaultCodec, totalCount);
@@ -549,6 +552,9 @@ public abstract class BandSet {
         int sum = 0;
         final long[][] result = new long[count][];
         for (int i = 0; i < count; i++) {
+            if (counts[i] < 0) {
+                throw new Pack200Exception("count < 0");
+            }
             sum += counts[i];
         }
         int[] hi = null;
@@ -630,6 +636,9 @@ public abstract class BandSet {
         }
         int sum = 0;
         for (int i = 0; i < count; i++) {
+            if (counts[i] < 0) {
+                throw new Pack200Exception("count < 0");
+            }
             sum += counts[i];
         }
         // TODO Merge the decode and parsing of a multiple structure into one

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.harmony.unpack200;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -61,6 +62,20 @@ class BandSetTest {
         for (int i = 0; i < ints.length; i++) {
             assertEquals(ints[i], bytes[i], "Wrong value in position " + i);
         }
+    }
+
+    @Test
+    void testDecodeBandIntRejectsNegativeCount() {
+        final BHSDCodec codec = Codec.BYTE1;
+        // A per-element count decoded from a signed band can be negative. It must be rejected the
+        // same way the scalar decodeBandInt(..., int) overload rejects count < 0, instead of
+        // reaching new int[]/new long[]/new String[] and surfacing a NegativeArraySizeException.
+        assertThrows(Pack200Exception.class,
+                () -> bandSet.decodeBandInt("Test", new ByteArrayInputStream(new byte[0]), codec, new int[] { -1, 1 }));
+        assertThrows(Pack200Exception.class,
+                () -> bandSet.parseFlags("Test", new ByteArrayInputStream(new byte[0]), new int[] { -1, 1 }, codec, false));
+        assertThrows(Pack200Exception.class,
+                () -> bandSet.parseReferences("Test", new ByteArrayInputStream(new byte[0]), codec, new int[] { -1, 1 }, new String[] { "a" }));
     }
 
     @Test


### PR DESCRIPTION
**Negative band counts reach array allocation in the Pack200 decoder**

The array-count overloads of `decodeBandInt`, `parseFlags` and `parseReferences` size each sub-array straight from `counts[i]` after only an upper-bound check, but count bands are decoded with signed codecs like `DELTA5`, so a crafted archive can make an element negative and turn `new int[counts[i]]` (and its `long[]`/`String[]` siblings) into a `NegativeArraySizeException` that escapes the declared `Pack200Exception` contract. The scalar `decodeBandInt(..., int)` overload already rejects `count < 0`, so this applies the same guard in the three siblings and a corrupt band surfaces as a normal `Pack200Exception`; the added `BandSetTest` case covers all three.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
