### PR TITLE
Reject negative element counts in pack200 decodeBandInt

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
@@ -156,6 +156,9 @@ public abstract class BandSet {
         final int[] twoDResult = decodeBandInt(name, in, defaultCodec, totalCount);
         int index = 0;
         for (int i = 0; i < result.length; i++) {
+            if (counts[i] < 0) {
+                throw new Pack200Exception("count < 0");
+            }
             if (counts[i] > twoDResult.length) {
                 throw new Pack200Exception("Counts value exceeds length of twoDResult");
             }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.harmony.unpack200;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -61,6 +62,17 @@ class BandSetTest {
         for (int i = 0; i < ints.length; i++) {
             assertEquals(ints[i], bytes[i], "Wrong value in position " + i);
         }
+    }
+
+    @Test
+    void testDecodeBandIntRejectsNegativeCount() throws IOException, Pack200Exception {
+        // A per-element count read from a band can narrow past Integer.MAX_VALUE into a negative int.
+        // When the counts still sum to a valid positive total the band itself decodes, but the negative
+        // entry then reaches new int[count]. It must be rejected like the single-count overload does.
+        final BHSDCodec codec = Codec.BYTE1;
+        final int[] counts = { -1, 2 };
+        final InputStream in = new ByteArrayInputStream(new byte[] { 5 });
+        assertThrows(Pack200Exception.class, () -> bandSet.decodeBandInt("class_attr_indexes", in, codec, counts));
     }
 
     @Test


### PR DESCRIPTION
the array-count form of decodeBandInt in BandSet slices a flat band into per-entry arrays but only rejects a counts[i] larger than the decoded length, never a negative one. a per-entry count read through UNSIGNED5 can pass Integer.MAX_VALUE and narrow to a negative int in BHSDCodec.decode, so a crafted pack200 archive whose counts still sum to a positive total reaches new int[counts[i]] and surfaces a NegativeArraySizeException instead of a Pack200Exception. the single-count decodeBandInt already guards count < 0; the same guard is added to the array form, which is what ClassBands feeds for class_attr_indexes and the line-number and local-variable tables.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
