### PR TITLE
Reject short LZMA properties and oversized dictionary in LZMADecoder

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/LZMADecoder.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/LZMADecoder.java
@@ -47,9 +47,6 @@ final class LZMADecoder extends AbstractCoder {
         }
         final byte propsByte = coder.properties[0];
         final int dictSize = getDictionarySize(coder);
-        if (dictSize > LZMAInputStream.DICT_SIZE_MAX) {
-            throw new ArchiveException("Dictionary larger than 4 GiB maximum size used in '%s'", archiveName);
-        }
         final int memoryUsageKiB = LZMAInputStream.getMemoryUsage(dictSize, propsByte);
         MemoryLimitException.checkKiB(memoryUsageKiB, maxMemoryLimitKiB);
         final LZMAInputStream lzmaIn = new LZMAInputStream(in, uncompressedLength, propsByte, dictSize);
@@ -63,8 +60,15 @@ final class LZMADecoder extends AbstractCoder {
         return new FlushShieldFilterOutputStream(new LZMAOutputStream(out, getOptions(opts), false));
     }
 
-    private int getDictionarySize(final Coder coder) throws IllegalArgumentException {
-        return (int) ByteUtils.fromLittleEndian(coder.properties, 1, 4);
+    private int getDictionarySize(final Coder coder) throws ArchiveException {
+        if (coder.properties.length < 5) {
+            throw new ArchiveException("LZMA properties too short");
+        }
+        final long dictionarySize = ByteUtils.fromLittleEndian(coder.properties, 1, 4);
+        if (dictionarySize > LZMAInputStream.DICT_SIZE_MAX) {
+            throw new ArchiveException("Dictionary larger than 4 GiB maximum size");
+        }
+        return (int) dictionarySize;
     }
 
     private LZMA2Options getOptions(final Object opts) throws IOException {

--- a/src/main/java/org/apache/commons/compress/archivers/sevenz/LZMADecoder.java
+++ b/src/main/java/org/apache/commons/compress/archivers/sevenz/LZMADecoder.java
@@ -62,7 +62,7 @@ final class LZMADecoder extends AbstractCoder {
 
     private int getDictionarySize(final Coder coder) throws ArchiveException {
         if (coder.properties.length < 5) {
-            throw new ArchiveException("LZMA properties too short");
+            throw new ArchiveException("LZMA properties too short (expected 5 bytes)");
         }
         final long dictionarySize = ByteUtils.fromLittleEndian(coder.properties, 1, 4);
         if (dictionarySize > LZMAInputStream.DICT_SIZE_MAX) {

--- a/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZLZMADecoderTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/sevenz/SevenZLZMADecoderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.compress.archivers.sevenz;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for class {@link LZMADecoder}.
+ *
+ * @see LZMADecoder
+ **/
+class SevenZLZMADecoderTest {
+
+    private static final byte VALID_PROPS_BYTE = 0x5d; // lc=3, lp=0, pb=2
+
+    @Test
+    void testDecodeRejectsOversizedDictionary() {
+        // 5 valid property bytes but a 4 GiB - 1 dictionary size; the value must not narrow to a negative int and slip past the cap
+        final byte[] properties = { VALID_PROPS_BYTE, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+        final Coder coder = new Coder(null, 0, 0, properties);
+        assertThrows(ArchiveException.class,
+                () -> new LZMADecoder().decode("x", new ByteArrayInputStream(new byte[0]), 0, coder, null, Integer.MAX_VALUE));
+    }
+
+    @Test
+    void testDecodeRejectsShortProperties() throws IOException {
+        // LZMA properties are 5 bytes; a shorter field must not over-read the dictionary size bytes
+        final byte[] properties = { VALID_PROPS_BYTE };
+        final Coder coder = new Coder(null, 0, 0, properties);
+        assertThrows(ArchiveException.class,
+                () -> new LZMADecoder().decode("x", new ByteArrayInputStream(new byte[0]), 0, coder, null, Integer.MAX_VALUE));
+    }
+}


### PR DESCRIPTION
getDictionarySize reads the 4-byte lzma dictionary size at offset 1 of coder.properties, but decode and getOptionsFromCoder only reject properties.length < 1. a 7z folder whose lzma coder declares a 1..4 byte property field makes ByteUtils.fromLittleEndian over-read the array and throw ArrayIndexOutOfBoundsException rather than an ArchiveException. the value was also narrowed straight to int, so a size at or above 2^31 went negative and slipped past the DICT_SIZE_MAX cap, surfacing an org.tukaani.xz UnsupportedOptionsException from getMemoryUsage. requiring the full 5 property bytes and comparing the size as an unsigned long before narrowing, both moved into getDictionarySize, closes the over-read and the cap bypass on the decode path and on getOptionsFromCoder which had no cap at all.