### PR TITLE
Reject invalid literal/length and distance codes in Deflate64 decoder

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoder.java
+++ b/src/main/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoder.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.utils.BitInputStream;
 import org.apache.commons.compress.utils.ExactMath;
 import org.apache.commons.lang3.ArrayFill;
@@ -171,14 +172,23 @@ class HuffmanDecoder implements Closeable {
             while (result < len) {
                 final int symbol = nextSymbol(reader, lengthTree);
                 if (symbol < 256) {
+                    if (symbol < 0) {
+                        throw new CompressorException("Invalid Deflate64 literal/length code %,d", symbol);
+                    }
                     b[off + result++] = memory.add((byte) symbol);
                 } else if (symbol > 256) {
+                    if (symbol - 257 >= RUN_LENGTH_TABLE.length) {
+                        throw new CompressorException("Invalid Deflate64 literal/length code %,d", symbol);
+                    }
                     final int runMask = RUN_LENGTH_TABLE[symbol - 257];
                     int run = runMask >>> 5;
                     final int runXtra = runMask & 0x1F;
                     run = ExactMath.add(run, readBits(runXtra));
 
                     final int distSym = nextSymbol(reader, distanceTree);
+                    if (distSym < 0 || distSym >= DISTANCE_TABLE.length) {
+                        throw new CompressorException("Invalid Deflate64 distance code %,d", distSym);
+                    }
 
                     final int distMask = DISTANCE_TABLE[distSym];
                     int dist = distMask >>> 4;

--- a/src/test/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoderTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoderTest.java
@@ -210,6 +210,38 @@ class HuffmanDecoderTest {
     }
 
     @Test
+    void testDecodeDynamicHuffmanBlockRejectsInvalidDistanceCode() throws Exception {
+        // final block + dynamic huffman with HLIT=1, HDIST=0, HCLEN=14. The code length tree
+        // assigns 1-bit codes to symbols 1 and 18, which encode 1-bit codes for literal/length
+        // symbols 256 and 257 and a single 1-bit code for distance symbol 0. The incomplete
+        // distance tree leaves the 1 branch empty, so the block data - length symbol 257
+        // followed by a 1 bit on the distance side - decodes to distance symbol -1.
+        final byte[] data = {
+                // |--- binary filling ---|76543210
+                0b00000000000000000000000000001101, // final block + dynamic huffman + HLIT 1
+                0b11111111111111111111111111000000, // HDIST 0 + low 3 bits of HCLEN 14
+                0b11111111111111111111111110000001, // high bit of HCLEN + zero lengths for 16, 17 + low bit of length 1 for 18
+                0b00000000000000000000000000000000, // high bits of length for 18 + zero lengths for 0, 8
+                0b00000000000000000000000000000000, // zero lengths for 7, 9 + low bits of 6
+                0b00000000000000000000000000000000, // zero lengths for 6, 10, 5
+                0b00000000000000000000000000000000, // zero lengths for 11, 4, 12
+                0b00000000000000000000000000000000, // zero lengths for 3, 13, 2
+                0b11111111111111111111111110010000, // zero length for 14 + length 1 for symbol 1 + code 18
+                0b11111111111111111111111111111111, // 7 extra bits (127 -> 138 zero lengths) + code 18
+                0b00000000000000000000000001101011, // 7 extra bits (107 -> 118 zero lengths) + code 1 (literal 256)
+                0b00000000000000000000000000001100 // code 1 twice (literal 257, distance 0) + length symbol 257 + invalid distance bit 1
+        };
+        try (HuffmanDecoder decoder = new HuffmanDecoder(new ByteArrayInputStream(data))) {
+            final byte[] result = new byte[100];
+            final CompressorException e = assertThrows(CompressorException.class, () -> {
+                final int len = decoder.decode(result);
+                fail("Should have failed but returned " + len + " entries: " + Arrays.toString(Arrays.copyOf(result, len)));
+            });
+            assertEquals("Invalid Deflate64 distance code -1", e.getMessage());
+        }
+    }
+
+    @Test
     void testDecodeFixedHuffmanBlockRejectsReservedLiteralLengthCode() throws Exception {
         // final block + fixed huffman, followed by the 8-bit fixed code 0b11000110 for
         // literal/length symbol 286. That symbol is a decodable leaf of the fixed tree

--- a/src/test/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoderTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/deflate64/HuffmanDecoderTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 
+import org.apache.commons.compress.compressors.CompressorException;
 import org.junit.jupiter.api.Test;
 
 class HuffmanDecoderTest {
@@ -205,6 +206,26 @@ class HuffmanDecoderTest {
                 fail("Should have failed but returned " + len + " entries: " + Arrays.toString(Arrays.copyOf(result, len)));
             });
             assertEquals("Illegal LEN / NLEN values", e.getMessage());
+        }
+    }
+
+    @Test
+    void testDecodeFixedHuffmanBlockRejectsReservedLiteralLengthCode() throws Exception {
+        // final block + fixed huffman, followed by the 8-bit fixed code 0b11000110 for
+        // literal/length symbol 286. That symbol is a decodable leaf of the fixed tree
+        // but is reserved by RFC 1951, so it has no entry in RUN_LENGTH_TABLE.
+        final byte[] data = {
+                // |--- binary filling ---|76543210
+                0b00000000000000000000000000011011, // final block + fixed huffman + low 5 bits of code 286
+                0b00000000000000000000000000000011 // high 3 bits of code 286
+        };
+        try (HuffmanDecoder decoder = new HuffmanDecoder(new ByteArrayInputStream(data))) {
+            final byte[] result = new byte[100];
+            final CompressorException e = assertThrows(CompressorException.class, () -> {
+                final int len = decoder.decode(result);
+                fail("Should have failed but returned " + len + " entries: " + Arrays.toString(Arrays.copyOf(result, len)));
+            });
+            assertEquals("Invalid Deflate64 literal/length code 286", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Deflate64's HuffmanDecoder decodes a literal/length symbol from the bit stream and uses it to index RUN_LENGTH_TABLE, and a distance symbol to index DISTANCE_TABLE, without checking either against the table bounds. The fixed literal/length tree assigns codes to symbols 286 and 287, which RFC 1951 reserves and which have no RUN_LENGTH_TABLE entry, so a stream that emits one of those codes runs symbol - 257 past the end of the 29-element table. An incomplete dynamic tree is also decodable to -1, which on the length side is silently written out as a 0xFF literal and on the distance side indexes DISTANCE_TABLE[-1]. I hit the length case first with a hand-built fixed-Huffman block holding the code for 286, which threw ArrayIndexOutOfBoundsException out of decode rather than a CompressorException. The fix checks each decoded symbol against its table before the lookup and rejects the out-of-range ones, which matches how the .Z and bzip2 decoders here already reject invalid codes. Added a HuffmanDecoderTest case for the 286 stream.
