### PR TITLE
Fix Zip rcount field width in x0015 and x0016 certificate id extra fields

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0015_CertificateIdForFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0015_CertificateIdForFile.java
@@ -80,9 +80,9 @@ public class X0015_CertificateIdForFile extends PKWareExtraHeader {
 
     @Override
     public void parseFromCentralDirectoryData(final byte[] data, final int offset, final int length) throws ZipException {
-        assertMinimalLength(4, length);
+        assertMinimalLength(6, length);
         super.parseFromCentralDirectoryData(data, offset, length);
-        this.rcount = ZipShort.getValue(data, offset);
-        this.hashAlg = HashAlgorithm.getAlgorithmByCode(ZipShort.getValue(data, offset + 2));
+        this.rcount = (int) ZipLong.getValue(data, offset);
+        this.hashAlg = HashAlgorithm.getAlgorithmByCode(ZipShort.getValue(data, offset + 4));
     }
 }

--- a/src/main/java/org/apache/commons/compress/archivers/zip/X0016_CertificateIdForCentralDirectory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/X0016_CertificateIdForCentralDirectory.java
@@ -81,9 +81,9 @@ public class X0016_CertificateIdForCentralDirectory extends PKWareExtraHeader {
 
     @Override
     public void parseFromCentralDirectoryData(final byte[] data, final int offset, final int length) throws ZipException {
-        assertMinimalLength(4, length);
+        assertMinimalLength(6, length);
         // TODO: double check we really do not want to call super here
-        this.rcount = ZipShort.getValue(data, offset);
-        this.hashAlg = HashAlgorithm.getAlgorithmByCode(ZipShort.getValue(data, offset + 2));
+        this.rcount = (int) ZipLong.getValue(data, offset);
+        this.hashAlg = HashAlgorithm.getAlgorithmByCode(ZipShort.getValue(data, offset + 4));
     }
 }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/X0015_X0016_CertificateIdTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/X0015_X0016_CertificateIdTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers.zip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.zip.ZipException;
+
+import org.apache.commons.compress.archivers.zip.PKWareExtraHeader.HashAlgorithm;
+import org.junit.jupiter.api.Test;
+
+class X0015_X0016_CertificateIdTest {
+
+    // RCount 0x00010001 (4 bytes LE) then HashAlg SHA256 0x800C (2 bytes LE).
+    // The low 16 bits of RCount (1) and its high 16 bits (1) are chosen so that a 2-byte read of RCount at
+    // the wrong width/offset would yield rcount == 1 and hashAlg == CRC32 (code 1) instead of the real values.
+    private static final byte[] CENTRAL_DATA = { 0x01, 0x00, 0x01, 0x00, 0x0C, (byte) 0x80 };
+
+    @Test
+    void testX0015ReadsFourByteRecordCountAndHashAlg() throws ZipException {
+        final X0015_CertificateIdForFile field = new X0015_CertificateIdForFile();
+        field.parseFromCentralDirectoryData(CENTRAL_DATA, 0, CENTRAL_DATA.length);
+        assertEquals(0x00010001, field.getRecordCount());
+        assertEquals(HashAlgorithm.SHA256, field.getHashAlgorithm());
+    }
+
+    @Test
+    void testX0016ReadsFourByteRecordCountAndHashAlg() throws ZipException {
+        final X0016_CertificateIdForCentralDirectory field = new X0016_CertificateIdForCentralDirectory();
+        field.parseFromCentralDirectoryData(CENTRAL_DATA, 0, CENTRAL_DATA.length);
+        assertEquals(0x00010001, field.getRecordCount());
+        assertEquals(HashAlgorithm.SHA256, field.getHashAlgorithm());
+    }
+
+    @Test
+    void testX0015RejectsTruncatedHashAlg() {
+        final X0015_CertificateIdForFile field = new X0015_CertificateIdForFile();
+        assertThrows(ZipException.class, () -> field.parseFromCentralDirectoryData(CENTRAL_DATA, 0, 5));
+    }
+
+    @Test
+    void testX0016RejectsTruncatedHashAlg() {
+        final X0016_CertificateIdForCentralDirectory field = new X0016_CertificateIdForCentralDirectory();
+        assertThrows(ZipException.class, () -> field.parseFromCentralDirectoryData(CENTRAL_DATA, 0, 5));
+    }
+}


### PR DESCRIPTION
the certificate-id extra fields read rcount as a 2-byte zipshort at offset and read hashalg from offset+2, but the field layout documented on both classes (and the reading in the sibling x0017_strongencryptionheader) puts a 4-byte rcount first with hashalg at offset+4. as written, x0015_certificateidforfile.parseFromCentralDirectoryData and the x0016 equivalent expose only the low 16 bits of rcount through getRecordCount and derive getHashAlgorithm from the high half of the count. read rcount as a 4-byte ziplong and hashalg at offset+4 in both, and raise the minimal-length check from 4 to 6 so a block too short to hold both fields is rejected with a zipexception rather than parsed into garbage. getRecordCount stays int (the 4 bytes are read then narrowed) so the public api is unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
