### PR TITLE
Reject out-of-range indices in pack200 BandSet.getReferences

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
@@ -184,9 +184,18 @@ public abstract class BandSet {
      * @param ints The indices into the {@code reference} array.
      * @param reference The source array.
      * @return A new array.
+     * @throws Pack200Exception if an index falls outside the range [0..reference.length-1].
      */
-    protected String[] getReferences(final int[] ints, final String[] reference) {
-        return ArrayUtils.setAll(new String[ints.length], i -> reference[ints[i]]);
+    protected String[] getReferences(final int[] ints, final String[] reference) throws Pack200Exception {
+        final String[] result = new String[ints.length];
+        for (int i = 0; i < ints.length; i++) {
+            final int index = ints[i];
+            if (index < 0 || index >= reference.length) {
+                throw new Pack200Exception("Something has gone wrong parsing references, index = %,d, array size = %,d", index, reference.length);
+            }
+            result[i] = reference[index];
+        }
+        return result;
     }
 
     /**
@@ -195,13 +204,18 @@ public abstract class BandSet {
      * @param ints The indices into the {@code reference} array.
      * @param reference The source array.
      * @return A new array.
+     * @throws Pack200Exception if an index falls outside the range [0..reference.length-1].
      */
-    protected String[][] getReferences(final int[][] ints, final String[] reference) {
+    protected String[][] getReferences(final int[][] ints, final String[] reference) throws Pack200Exception {
         final String[][] result = new String[ints.length][];
         for (int i = 0; i < result.length; i++) {
             result[i] = new String[ints[i].length];
             for (int j = 0; j < result[i].length; j++) {
-                result[i][j] = reference[ints[i][j]];
+                final int index = ints[i][j];
+                if (index < 0 || index >= reference.length) {
+                    throw new Pack200Exception("Something has gone wrong parsing references, index = %,d, array size = %,d", index, reference.length);
+                }
+                result[i][j] = reference[index];
             }
         }
         return result;

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
@@ -191,7 +191,7 @@ public abstract class BandSet {
         for (int i = 0; i < ints.length; i++) {
             final int index = ints[i];
             if (index < 0 || index >= reference.length) {
-                throw new Pack200Exception("Something has gone wrong parsing references, index = %,d, array size = %,d", index, reference.length);
+                throw new Pack200Exception("Invalid reference index = %,d, array length = %,d", index, reference.length);
             }
             result[i] = reference[index];
         }
@@ -213,7 +213,7 @@ public abstract class BandSet {
             for (int j = 0; j < result[i].length; j++) {
                 final int index = ints[i][j];
                 if (index < 0 || index >= reference.length) {
-                    throw new Pack200Exception("Something has gone wrong parsing references, index = %,d, array size = %,d", index, reference.length);
+                    throw new Pack200Exception("Invalid reference index = %,d, array length = %,d", index, reference.length);
                 }
                 result[i][j] = reference[index];
             }

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
@@ -79,6 +79,20 @@ class BandSetTest {
     }
 
     @Test
+    void testGetReferencesRejectsOutOfRangeIndex() throws Exception {
+        // getReferences resolves band-decoded indices into a constant-pool array. An index at or past the
+        // end of that array must be rejected the same way the sibling parseReferences rejects it, instead of
+        // reaching reference[index] and surfacing an ArrayIndexOutOfBoundsException that escapes the declared
+        // Pack200Exception contract.
+        final String[] reference = { "a", "b" };
+        assertThrows(Pack200Exception.class, () -> bandSet.getReferences(new int[] { 2 }, reference));
+        assertThrows(Pack200Exception.class, () -> bandSet.getReferences(new int[] { -1 }, reference));
+        assertThrows(Pack200Exception.class, () -> bandSet.getReferences(new int[][] { { 2 } }, reference));
+        // A valid index still resolves.
+        assertEquals("b", bandSet.getReferences(new int[] { 1 }, reference)[0]);
+    }
+
+    @Test
     @Disabled("TODO: Implement")
     void testParseFlags1() {
 


### PR DESCRIPTION
BandSet.getReferences resolves a band of decoded integers into entries of a constant-pool array, and its sibling parseReferences does the same job but rejects an index that falls outside the pool with a Pack200Exception. getReferences never applies that check, so the values flow straight into reference[index]. Those indices come from the archive: CpBands.parseCpDescriptor and parseCpSignature feed the cp_Descr_name, cp_Descr_type and cp_Signature_form bands through it, and ClassBands and IcBands do the same for the class/field/method this-class bands. A crafted archive whose band holds an index at or past the referenced pool size makes reference[index] throw a raw ArrayIndexOutOfBoundsException out of the segment read, which the declared throws Pack200Exception was meant to cover. I noticed it while comparing getReferences against parseReferences and the parseCPIntReferences/parseCPLongReferences resolvers, which already guard the same way. Both getReferences overloads now range-check the index and raise the same Pack200Exception, so a corrupt band surfaces as the normal checked exception; the added BandSetTest case exercises both.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
