### PR TITLE
Reject negative counts in pack200 parseCPUTF8/SignatureReferences

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/BandSet.java
@@ -431,10 +431,7 @@ public abstract class BandSet {
      */
     protected CPUTF8[][] parseCPSignatureReferences(final String name, final InputStream in, final BHSDCodec codec, final int[] counts)
             throws IOException, Pack200Exception {
-        int sum = 0;
-        for (final int count : counts) {
-            sum += count;
-        }
+        final int sum = sumNonNegative(counts);
         final int[] indices = decodeBandInt(name, in, codec, sum);
         final CpBands cpBands = segment.getCpBands();
         final CPUTF8[] result1 = ArrayUtils.setAll(new CPUTF8[sum], i -> cpBands.cpSignatureValue(indices[i]));
@@ -498,12 +495,8 @@ public abstract class BandSet {
      */
     public CPUTF8[][] parseCPUTF8References(final String name, final InputStream in, final BHSDCodec codec, final int[] counts)
             throws IOException, Pack200Exception {
+        final int sum = sumNonNegative(counts);
         final CPUTF8[][] result = new CPUTF8[counts.length][];
-        int sum = 0;
-        for (int i = 0; i < counts.length; i++) {
-            result[i] = new CPUTF8[counts[i]];
-            sum += counts[i];
-        }
         final int[] indices = decodeBandInt(name, in, codec, sum);
         final CpBands cpBands = segment.getCpBands();
         final CPUTF8[] result1 = ArrayUtils.setAll(new CPUTF8[sum], i -> cpBands.cpUTF8Value(indices[i]));

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/BandSetTest.java
@@ -79,6 +79,19 @@ class BandSetTest {
     }
 
     @Test
+    void testParseCPUTF8AndSignatureReferencesRejectNegativeCount() {
+        final BHSDCodec codec = Codec.BYTE1;
+        // The int[] overloads of parseCPUTF8References and parseCPSignatureReferences size each sub-array straight
+        // from a per-entry count. A count decoded through a signed band can be negative, so it must be rejected
+        // here the same way decodeBandInt/parseFlags/parseReferences reject it, instead of reaching new CPUTF8[-1]
+        // and surfacing a NegativeArraySizeException that escapes the declared Pack200Exception contract.
+        assertThrows(Pack200Exception.class,
+                () -> bandSet.parseCPUTF8References("Test", new ByteArrayInputStream(new byte[0]), codec, new int[] { -1, 1 }));
+        assertThrows(Pack200Exception.class,
+                () -> bandSet.parseCPSignatureReferences("Test", new ByteArrayInputStream(new byte[0]), codec, new int[] { -1, 1 }));
+    }
+
+    @Test
     void testGetReferencesRejectsOutOfRangeIndex() throws Exception {
         // getReferences resolves band-decoded indices into a constant-pool array. An index at or past the
         // end of that array must be rejected the same way the sibling parseReferences rejects it, instead of


### PR DESCRIPTION
the int[] overloads of parseCPUTF8References and parseCPSignatureReferences in the pack200 bandset summed their per-entry counts with a plain loop and sized each sub-array straight from counts[i], unlike decodeBandInt, parseFlags and parseReferences which already route the total through sumNonNegative. a crafted archive whose code_LocalVariableTable_N, *_type_RS or anno_N band decodes to a negative count (unsigned5 is the default but a signed secondary codec can replace it for any band after the segment header) reaches new CPUTF8[-1] and throws NegativeArraySizeException out of ClassBands, escaping the declared Pack200Exception contract; the same unchecked sum can also wrap on large counts. route both through sumNonNegative so a corrupt band yields a normal Pack200Exception like the sibling overloads. follow-up to the sumNonNegative work in #782.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
