### PR TITLE
Reject unknown file type in CPIO entry mode

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -307,27 +307,31 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
             IOUtils.consume(this);
         }
         readFully(buffer2, 0, buffer2.length);
-        if (CpioUtil.byteArray2long(buffer2, false) == MAGIC_OLD_BINARY) {
-            entry = readOldBinaryEntry(false);
-        } else if (CpioUtil.byteArray2long(buffer2, true) == MAGIC_OLD_BINARY) {
-            entry = readOldBinaryEntry(true);
-        } else {
-            System.arraycopy(buffer2, 0, buffer6, 0, buffer2.length);
-            readFully(buffer6, buffer2.length, buffer4.length);
-            final String magicString = ArchiveUtils.toAsciiString(buffer6);
-            switch (magicString) {
-            case MAGIC_NEW:
-                entry = readNewEntry(false);
-                break;
-            case MAGIC_NEW_CRC:
-                entry = readNewEntry(true);
-                break;
-            case MAGIC_OLD_ASCII:
-                entry = readOldAsciiEntry();
-                break;
-            default:
-                throw new ArchiveException("Unknown magic '%s' at byte: %,d", magicString, getBytesRead());
+        try {
+            if (CpioUtil.byteArray2long(buffer2, false) == MAGIC_OLD_BINARY) {
+                entry = readOldBinaryEntry(false);
+            } else if (CpioUtil.byteArray2long(buffer2, true) == MAGIC_OLD_BINARY) {
+                entry = readOldBinaryEntry(true);
+            } else {
+                System.arraycopy(buffer2, 0, buffer6, 0, buffer2.length);
+                readFully(buffer6, buffer2.length, buffer4.length);
+                final String magicString = ArchiveUtils.toAsciiString(buffer6);
+                switch (magicString) {
+                case MAGIC_NEW:
+                    entry = readNewEntry(false);
+                    break;
+                case MAGIC_NEW_CRC:
+                    entry = readNewEntry(true);
+                    break;
+                case MAGIC_OLD_ASCII:
+                    entry = readOldAsciiEntry();
+                    break;
+                default:
+                    throw new ArchiveException("Unknown magic '%s' at byte: %,d", magicString, getBytesRead());
+                }
             }
+        } catch (final IllegalArgumentException e) {
+            throw new ArchiveException("Corrupted CPIO archive at byte: " + getBytesRead(), (Throwable) e);
         }
         entryBytesRead = 0;
         entryEOF = false;
@@ -432,7 +436,9 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         }
         newEntry.setInode(readAsciiLong(8, 16));
         final long mode = readAsciiLong(8, 16);
-        setMode(newEntry, mode);
+        if (CpioUtil.fileType(mode) != 0) { // mode is initialized to 0
+            newEntry.setMode(mode);
+        }
         newEntry.setUID(readAsciiLong(8, 16));
         newEntry.setGID(readAsciiLong(8, 16));
         newEntry.setNumberOfLinks(readAsciiLong(8, 16));
@@ -468,7 +474,9 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         ret.setDevice(readAsciiLong(6, 8));
         ret.setInode(readAsciiLong(6, 8));
         final long mode = readAsciiLong(6, 8);
-        setMode(ret, mode);
+        if (CpioUtil.fileType(mode) != 0) {
+            ret.setMode(mode);
+        }
         ret.setUID(readAsciiLong(6, 8));
         ret.setGID(readAsciiLong(6, 8));
         ret.setNumberOfLinks(readAsciiLong(6, 8));
@@ -496,7 +504,9 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         oldEntry.setDevice(readBinaryLong(2, swapHalfWord));
         oldEntry.setInode(readBinaryLong(2, swapHalfWord));
         final long mode = readBinaryLong(2, swapHalfWord);
-        setMode(oldEntry, mode);
+        if (CpioUtil.fileType(mode) != 0) {
+            oldEntry.setMode(mode);
+        }
         oldEntry.setUID(readBinaryLong(2, swapHalfWord));
         oldEntry.setGID(readBinaryLong(2, swapHalfWord));
         oldEntry.setNumberOfLinks(readBinaryLong(2, swapHalfWord));
@@ -530,27 +540,6 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
             throw new EOFException();
         }
         return b;
-    }
-
-    /**
-     * Sets the mode of an entry from a header field.
-     * <p>
-     * A mode of 0 is left unset because only the trailer may use it; the callers check that by name.
-     * </p>
-     *
-     * @param entry The entry to update.
-     * @param mode  The mode read from the header.
-     * @throws ArchiveException if the mode names a file type CPIO does not define.
-     */
-    private void setMode(final CpioArchiveEntry entry, final long mode) throws ArchiveException {
-        if (CpioUtil.fileType(mode) == 0) {
-            return;
-        }
-        try {
-            entry.setMode(mode);
-        } catch (final IllegalArgumentException e) {
-            throw new ArchiveException("Corrupted CPIO archive: Invalid file mode 0%s at byte: %,d", Long.toOctalString(mode), getBytesRead());
-        }
     }
 
     private int skip(final int length) throws IOException {

--- a/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStream.java
@@ -432,9 +432,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         }
         newEntry.setInode(readAsciiLong(8, 16));
         final long mode = readAsciiLong(8, 16);
-        if (CpioUtil.fileType(mode) != 0) { // mode is initialized to 0
-            newEntry.setMode(mode);
-        }
+        setMode(newEntry, mode);
         newEntry.setUID(readAsciiLong(8, 16));
         newEntry.setGID(readAsciiLong(8, 16));
         newEntry.setNumberOfLinks(readAsciiLong(8, 16));
@@ -470,9 +468,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         ret.setDevice(readAsciiLong(6, 8));
         ret.setInode(readAsciiLong(6, 8));
         final long mode = readAsciiLong(6, 8);
-        if (CpioUtil.fileType(mode) != 0) {
-            ret.setMode(mode);
-        }
+        setMode(ret, mode);
         ret.setUID(readAsciiLong(6, 8));
         ret.setGID(readAsciiLong(6, 8));
         ret.setNumberOfLinks(readAsciiLong(6, 8));
@@ -500,9 +496,7 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
         oldEntry.setDevice(readBinaryLong(2, swapHalfWord));
         oldEntry.setInode(readBinaryLong(2, swapHalfWord));
         final long mode = readBinaryLong(2, swapHalfWord);
-        if (CpioUtil.fileType(mode) != 0) {
-            oldEntry.setMode(mode);
-        }
+        setMode(oldEntry, mode);
         oldEntry.setUID(readBinaryLong(2, swapHalfWord));
         oldEntry.setGID(readBinaryLong(2, swapHalfWord));
         oldEntry.setNumberOfLinks(readBinaryLong(2, swapHalfWord));
@@ -536,6 +530,27 @@ public class CpioArchiveInputStream extends ArchiveInputStream<CpioArchiveEntry>
             throw new EOFException();
         }
         return b;
+    }
+
+    /**
+     * Sets the mode of an entry from a header field.
+     * <p>
+     * A mode of 0 is left unset because only the trailer may use it; the callers check that by name.
+     * </p>
+     *
+     * @param entry The entry to update.
+     * @param mode  The mode read from the header.
+     * @throws ArchiveException if the mode names a file type CPIO does not define.
+     */
+    private void setMode(final CpioArchiveEntry entry, final long mode) throws ArchiveException {
+        if (CpioUtil.fileType(mode) == 0) {
+            return;
+        }
+        try {
+            entry.setMode(mode);
+        } catch (final IllegalArgumentException e) {
+            throw new ArchiveException("Corrupted CPIO archive: Invalid file mode 0%s at byte: %,d", Long.toOctalString(mode), getBytesRead());
+        }
     }
 
     private int skip(final int length) throws IOException {

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
@@ -176,6 +176,79 @@ class CpioArchiveInputStreamTest extends AbstractTest {
     }
 
     @Test
+    void testInvalidFileTypeInMode() throws Exception {
+        // c_mode declares file type 0170000, which CPIO does not define
+        // @formatter:off
+        final String header =
+                "070701" + // c_magic
+                "00000001" + // c_ino
+                "0000F000" + // c_mode
+                "00000000" + // c_uid
+                "00000000" + // c_gid
+                "00000001" + // c_nlink
+                "00000000" + // c_mtime
+                "00000000" + // c_filesize
+                "00000000" + // c_devmajor
+                "00000000" + // c_devminor
+                "00000000" + // c_rdevmajor
+                "00000000" + // c_rdevminor
+                "00000002" + // c_namesize
+                "00000000" + // c_check
+                "a\0";
+        // @formatter:on
+        try (CpioArchiveInputStream cpio = CpioArchiveInputStream.builder()
+                .setByteArray(header.getBytes(StandardCharsets.US_ASCII))
+                .get()) {
+            assertThrows(ArchiveException.class, cpio::getNextEntry);
+        }
+    }
+
+    @Test
+    void testInvalidFileTypeInModeMagicOldAscii() throws Exception {
+        // c_mode declares file type 0170000, which CPIO does not define
+        // @formatter:off
+        final String header =
+                "070707" + // c_magic
+                "000000" + // c_dev
+                "000001" + // c_ino
+                "170000" + // c_mode
+                "000000" + // c_uid
+                "000000" + // c_gid
+                "000001" + // c_nlink
+                "000000" + // c_rdev
+                "00000000000" + // c_mtime
+                "000002" + // c_namesize
+                "00000000000" + // c_filesize
+                "a\0";
+        // @formatter:on
+        try (CpioArchiveInputStream cpio = CpioArchiveInputStream.builder()
+                .setByteArray(header.getBytes(StandardCharsets.US_ASCII))
+                .get()) {
+            assertThrows(ArchiveException.class, cpio::getNextEntry);
+        }
+    }
+
+    @Test
+    void testInvalidFileTypeInModeMagicOldBinary() throws Exception {
+        // c_mode declares file type 0170000, which CPIO does not define
+        // c_magic, c_dev, c_ino, c_mode, c_uid, c_gid, c_nlink, c_rdev as little endian half words
+        final int[] halfWords = { 070707, 0, 1, 0170000, 0, 0, 1, 0 };
+        final byte[] data = new byte[halfWords.length * 2 + 10 + 2];
+        int off = 0;
+        for (final int halfWord : halfWords) {
+            data[off++] = (byte) halfWord;
+            data[off++] = (byte) (halfWord >> 8);
+        }
+        off += 4; // c_mtime
+        data[off] = 2; // c_namesize
+        off += 6; // c_namesize and c_filesize
+        data[off] = 'a';
+        try (CpioArchiveInputStream cpio = CpioArchiveInputStream.builder().setByteArray(data).get()) {
+            assertThrows(ArchiveException.class, cpio::getNextEntry);
+        }
+    }
+
+    @Test
     void testInvalidLongValueInMetadata() throws Exception {
         try (CpioArchiveInputStream archive = CpioArchiveInputStream.builder()
                 .setURI(getURI("org/apache/commons/compress/cpio/bad_long_value.cpio"))

--- a/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/cpio/CpioArchiveInputStreamTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.compress.archivers.cpio;
 
 import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -199,7 +200,8 @@ class CpioArchiveInputStreamTest extends AbstractTest {
         try (CpioArchiveInputStream cpio = CpioArchiveInputStream.builder()
                 .setByteArray(header.getBytes(StandardCharsets.US_ASCII))
                 .get()) {
-            assertThrows(ArchiveException.class, cpio::getNextEntry);
+            final ArchiveException e = assertThrows(ArchiveException.class, cpio::getNextEntry);
+            assertInstanceOf(IllegalArgumentException.class, e.getCause());
         }
     }
 
@@ -266,6 +268,35 @@ class CpioArchiveInputStreamTest extends AbstractTest {
             IOUtils.toByteArray(archive);
             assertEquals(-1, archive.read(buf));
             assertEquals(-1, archive.read(buf));
+        }
+    }
+
+    @Test
+    void testNegativeSizeInHeader() throws Exception {
+        // c_filesize parses to -1, making CpioArchiveEntry.setSize throw IllegalArgumentException
+        // @formatter:off
+        final String header =
+                "070701" + // c_magic
+                "00000001" + // c_ino
+                "000081A4" + // c_mode
+                "00000000" + // c_uid
+                "00000000" + // c_gid
+                "00000001" + // c_nlink
+                "00000000" + // c_mtime
+                "-0000001" + // c_filesize
+                "00000000" + // c_devmajor
+                "00000000" + // c_devminor
+                "00000000" + // c_rdevmajor
+                "00000000" + // c_rdevminor
+                "00000002" + // c_namesize
+                "00000000" + // c_check
+                "a\0";
+        // @formatter:on
+        try (CpioArchiveInputStream cpio = CpioArchiveInputStream.builder()
+                .setByteArray(header.getBytes(StandardCharsets.US_ASCII))
+                .get()) {
+            final ArchiveException e = assertThrows(ArchiveException.class, cpio::getNextEntry);
+            assertInstanceOf(IllegalArgumentException.class, e.getCause());
         }
     }
 


### PR DESCRIPTION
**Invalid CPIO header fields escape as IllegalArgumentException**

`CpioArchiveEntry.setMode` accepts only the eight file types CPIO defines, so a crafted `c_mode` naming one of the seven other non-zero `S_IFMT` values (0170000, 030000, ...) throws a raw `IllegalArgumentException` out of `getNextEntry`, which declares `IOException`. `setSize` has the same problem in the two ASCII formats: a `-` in the size field parses to a negative value and the setter throws before the `getSize() < 0` checks are reached.

Rather than guarding individual call sites, `getNextCPIOEntry` now rethrows `IllegalArgumentException` from header parsing as `ArchiveException`, keeping the original exception as the cause, the same way `ArArchiveInputStream.getNextEntry` already does. This covers every entry setter the three header readers call. The `UnsupportedOperationException` sites in `CpioArchiveEntry` are format guards and each reader only calls the setters matching the format it constructs, so those are not reachable from input.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
