### PR TITLE
Reject missing main header in ArjArchiveInputStream.readMainHeader

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
+++ b/src/main/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStream.java
@@ -416,6 +416,9 @@ public class ArjArchiveInputStream extends ArchiveInputStream<ArjArchiveEntry> {
 
     private MainHeader readMainHeader(final boolean selfExtracting) throws IOException {
         final byte[] basicHeaderBytes = selfExtracting ? findMainHeader() : readHeader();
+        if (basicHeaderBytes == null) {
+            throw new ArchiveException("Corrupted ARJ archive: Missing main header");
+        }
         final MainHeader header = new MainHeader();
         try (InputStream basicHeader = new ByteArrayInputStream(basicHeaderBytes)) {
             final int firstHeaderSize = readUnsignedByte(basicHeader);

--- a/src/test/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/arj/ArjArchiveInputStreamTest.java
@@ -180,6 +180,18 @@ class ArjArchiveInputStreamTest extends AbstractTest {
         assertEquals(expected.toString(), result.toString());
     }
 
+    /**
+     * A basic header size of zero is the end-of-archive marker, so an archive starting with one carries no main header.
+     *
+     * @param selfExtracting whether to scan for the main header.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void testMissingMainHeader(final boolean selfExtracting) {
+        final byte[] bytes = { 0x60, (byte) 0xEA, 0x00, 0x00 };
+        assertThrows(ArchiveException.class, () -> ArjArchiveInputStream.builder().setByteArray(bytes).setSelfExtracting(selfExtracting).get());
+    }
+
     @Test
     void testMultiByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
         final byte[] buf = new byte[2];


### PR DESCRIPTION
readHeader returns null when the basic header size field is zero, which is the arj end-of-archive marker, and readLocalFileHeader tests for that before using the result. readMainHeader does not, so an archive whose first header is the terminator reaches new ByteArrayInputStream(null) and throws NullPointerException out of a constructor that declares IOException; it escapes ArchiveStreamFactory the same way, since matches only needs the two signature bytes for the format to be detected. the whole input is 60 ea 00 00. throwing ArchiveException there matches the rest of readHeader's malformed-header handling, and the self-extracting path already rejects those bytes that way through findMainHeader, so only the streaming path changes. readHeader has two callers and this was the one missing the check.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
