### PR TITLE
Reject negative ZIP64 offsets in positionAtCentralDirectory64

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
+++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipFile.java
@@ -1417,12 +1417,19 @@ public class ZipFile implements ArchiveFile<ZipArchiveEntry> {
             dwordBbuf.rewind();
             IOUtils.readFully(archive, dwordBbuf);
             final long relativeOffsetOfEOCD = ZipEightByteInteger.getLongValue(dwordBuf);
+            if (relativeOffsetOfEOCD < 0) {
+                throw new ArchiveException("Broken archive, ZIP64 end of central directory locator with negative offset");
+            }
             ((ZipSplitReadOnlySeekableByteChannel) archive).position(diskNumberOfEOCD, relativeOffsetOfEOCD);
         } else {
             skipBytes(ZIP64_EOCDL_LOCATOR_OFFSET - ZipConstants.WORD /* signature has already been read */);
             dwordBbuf.rewind();
             IOUtils.readFully(archive, dwordBbuf);
-            archive.position(ZipEightByteInteger.getLongValue(dwordBuf));
+            final long relativeOffsetOfEOCD = ZipEightByteInteger.getLongValue(dwordBuf);
+            if (relativeOffsetOfEOCD < 0) {
+                throw new ArchiveException("Broken archive, ZIP64 end of central directory locator with negative offset");
+            }
+            archive.position(relativeOffsetOfEOCD);
         }
 
         wordBbuf.rewind();
@@ -1442,6 +1449,9 @@ public class ZipFile implements ArchiveFile<ZipArchiveEntry> {
             dwordBbuf.rewind();
             IOUtils.readFully(archive, dwordBbuf);
             centralDirectoryStartRelativeOffset = ZipEightByteInteger.getLongValue(dwordBuf);
+            if (centralDirectoryStartRelativeOffset < 0) {
+                throw new ArchiveException("Broken archive, ZIP64 end of central directory record with negative central directory offset");
+            }
             ((ZipSplitReadOnlySeekableByteChannel) archive).position(centralDirectoryStartDiskNumber, centralDirectoryStartRelativeOffset);
         } else {
             skipBytes(ZIP64_EOCD_CFD_LOCATOR_OFFSET - ZipConstants.WORD /* signature has already been read */);
@@ -1449,6 +1459,9 @@ public class ZipFile implements ArchiveFile<ZipArchiveEntry> {
             IOUtils.readFully(archive, dwordBbuf);
             centralDirectoryStartDiskNumber = 0;
             centralDirectoryStartRelativeOffset = ZipEightByteInteger.getLongValue(dwordBuf);
+            if (centralDirectoryStartRelativeOffset < 0) {
+                throw new ArchiveException("Broken archive, ZIP64 end of central directory record with negative central directory offset");
+            }
             archive.position(centralDirectoryStartRelativeOffset);
         }
     }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipFileTest.java
@@ -1124,4 +1124,57 @@ class ZipFileTest extends AbstractArchiveFileTest<ZipArchiveEntry> {
             }
         }
     }
+
+    private static byte[] createZip64Archive() throws IOException {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(bos)) {
+            zos.setUseZip64(Zip64Mode.Always);
+            zos.putArchiveEntry(new ZipArchiveEntry("a.txt"));
+            zos.write("hello".getBytes(UTF_8));
+            zos.closeArchiveEntry();
+        }
+        return bos.toByteArray();
+    }
+
+    private static int indexOfSignature(final byte[] data, final byte[] signature) {
+        for (int i = 0; i + signature.length <= data.length; i++) {
+            int j = 0;
+            while (j < signature.length && data[i + j] == signature[j]) {
+                j++;
+            }
+            if (j == signature.length) {
+                return i;
+            }
+        }
+        return fail("signature not found");
+    }
+
+    /**
+     * The ZIP64 offsets are 8-byte signed values, so a crafted archive can make them negative. Feeding such a value straight to
+     * {@link java.nio.channels.SeekableByteChannel#position(long)} used to throw a raw {@link IllegalArgumentException} out of the {@link ZipFile} constructor,
+     * which only declares {@link IOException}.
+     */
+    @Test
+    void testZip64NegativeOffsetsAreRejected() throws Exception {
+        final byte[] valid = createZip64Archive();
+        // A well-formed ZIP64 archive still opens.
+        try (ZipFile zf = ZipFile.builder().setByteArray(valid).get()) {
+            assertNotNull(zf.getEntry("a.txt"));
+        }
+        // Negative "relative offset of the ZIP64 end of central directory record" inside the locator.
+        final byte[] badLocator = valid.clone();
+        writeNegativeLongAt(badLocator, indexOfSignature(badLocator, ZipArchiveOutputStream.ZIP64_EOCD_LOC_SIG) + 8);
+        assertThrows(ArchiveException.class, () -> ZipFile.builder().setByteArray(badLocator).get());
+        // Negative "offset of start of central directory" inside the ZIP64 end of central directory record.
+        final byte[] badRecord = valid.clone();
+        writeNegativeLongAt(badRecord, indexOfSignature(badRecord, ZipArchiveOutputStream.ZIP64_EOCD_SIG) + 48);
+        assertThrows(ArchiveException.class, () -> ZipFile.builder().setByteArray(badRecord).get());
+    }
+
+    private static void writeNegativeLongAt(final byte[] data, final int offset) {
+        for (int i = 0; i < 8; i++) {
+            data[offset + i] = 0;
+        }
+        data[offset + 7] = (byte) 0x80; // little-endian sign byte -> the 8-byte value is negative
+    }
 }


### PR DESCRIPTION
**Negative ZIP64 offsets escape ZipFile as IllegalArgumentException**

`positionAtCentralDirectory64` reads the 8-byte ZIP64 end-of-central-directory offsets as signed longs (`ZipEightByteInteger.getLongValue`) and passes them straight to the channel's `position()`, so an archive whose offset has the high bit set makes `position()` throw a raw `IllegalArgumentException` out of the `ZipFile` constructor, which declares only `IOException`. Every other size and offset field in this class already rejects negatives with `ArchiveException`; the four ZIP64 offset reads (locator and record, split and non-split) were missing that check, so a broken archive now fails with `ArchiveException`. The 32-bit path is unaffected because `ZipLong.getValue` is unsigned.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
