### PR TITLE
Remove unnecessary parameter from HuffmanDecoder public constructor

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/bzip2/BZip2CompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/bzip2/BZip2CompressorInputStream.java
@@ -270,7 +270,7 @@ public class BZip2CompressorInputStream extends CompressorInputStream implements
             }
             try {
                 // Same limits as in the reference C implementation of bzip2
-                dataShadow.huffmanDecoders[t] = new HuffmanDecoder(codeLengths, alphaSize, 1, MAX_CODE_LEN);
+                dataShadow.huffmanDecoders[t] = new HuffmanDecoder(codeLengths, 1, MAX_CODE_LEN);
             } catch (final IllegalArgumentException e) {
                 throw new CompressorException("Invalid Huffman data: " + e.getMessage(), e);
             }

--- a/src/main/java/org/apache/commons/compress/huffman/HuffmanDecoder.java
+++ b/src/main/java/org/apache/commons/compress/huffman/HuffmanDecoder.java
@@ -88,7 +88,7 @@ public final class HuffmanDecoder {
      * @throws IllegalArgumentException if any code length is out of range [0, 30].
      */
     public HuffmanDecoder(final int[] codeLengths) {
-        this(codeLengths, codeLengths.length, 0, MAX_SUPPORTED_CODE_LENGTH);
+        this(codeLengths, 0, MAX_SUPPORTED_CODE_LENGTH);
     }
 
     /**
@@ -99,28 +99,24 @@ public final class HuffmanDecoder {
      * </p>
      *
      * @param codeLengths    code length per symbol; {@code 0} means the symbol is not used; not {@code null}.
-     * @param codeLengthSize number of symbols to read from {@code codeLengths} (must be {@code > 0} and {@code <= codeLengths.length}).
      * @param minCodeLength  minimum allowed code length present in {@code codeLengths}.
      * @param maxCodeLength  maximum allowed code length present in {@code codeLengths}.
      * @throws NullPointerException     if {@code codeLengths} is {@code null}.
-     * @throws IllegalArgumentException if {@code codeLengthSize} is out of range, if any code length is out of range or if {@code maxCodeLength} exceeds the
+     * @throws IllegalArgumentException if {@code codeLengths} size is out of range, if any code length is out of range or if {@code maxCodeLength} exceeds the
      *                                  implementation limit (30).
      */
-    public HuffmanDecoder(final int[] codeLengths, final int codeLengthSize, final int minCodeLength, final int maxCodeLength) throws IllegalArgumentException {
+    public HuffmanDecoder(final int[] codeLengths, final int minCodeLength, final int maxCodeLength) throws IllegalArgumentException {
         Objects.requireNonNull(codeLengths, "codeLengths");
         if (maxCodeLength > MAX_SUPPORTED_CODE_LENGTH) {
             throw new IllegalArgumentException(String.format("maxCodeLength (%d) exceeds supported limit (%d)", maxCodeLength, MAX_SUPPORTED_CODE_LENGTH));
         }
-        if (codeLengthSize <= 0) {
-            throw new IllegalArgumentException(String.format("codeLengthSize must be > 0; was %d", codeLengthSize));
-        }
-        if (codeLengths.length < codeLengthSize) {
-            throw new IllegalArgumentException(String.format("codeLengthSize (%d) exceeds codeLengths.length (%d)", codeLengthSize, codeLengths.length));
+        if (codeLengths.length <= 0) {
+            throw new IllegalArgumentException(String.format("codeLengthSize must be > 0; was %d", codeLengths.length));
         }
         // Validate and find min/max lengths
         int min = maxCodeLength;
         int max = minCodeLength;
-        for (int i = 0; i < codeLengthSize; i++) {
+        for (int i = 0; i < codeLengths.length; i++) {
             final int len = codeLengths[i];
             if (len < minCodeLength || len > maxCodeLength) {
                 throw new IllegalArgumentException(
@@ -141,9 +137,9 @@ public final class HuffmanDecoder {
         // Allocate outputs; we reuse them as scratch inside fillCodeTable
         this.bias = new int[max + 1];
         this.limit = new int[max + 1];
-        this.sorted = new int[codeLengthSize];
+        this.sorted = new int[codeLengths.length];
         // Arrays are zero-initialized; no additional temps needed.
-        fillCodeTable(codeLengths, minLength, max, codeLengthSize, bias, limit, sorted);
+        fillCodeTable(codeLengths, minLength, max, bias, limit, sorted);
     }
 
     /**
@@ -167,11 +163,11 @@ public final class HuffmanDecoder {
     /**
      * Builds canonical decode tables.
      */
-    private static void fillCodeTable(final int[] codeLengths, final int minLen, final int maxLen, final int codeLengthSize, final int[] bias,
+    private static void fillCodeTable(final int[] codeLengths, final int minLen, final int maxLen, final int[] bias,
             final int[] limit, final int[] sorted) {
         // 1) Histogram of code lengths
         final int[] count = new int[maxLen + 1];
-        for (int symbol = 0; symbol < codeLengthSize; symbol++) {
+        for (int symbol = 0; symbol < codeLengths.length; symbol++) {
             final int len = codeLengths[symbol];
             if (len == 0) {
                 continue;
@@ -187,7 +183,7 @@ public final class HuffmanDecoder {
         }
         // 3) Build table of symbols sorted by length, then by symbol
         // Adjust offsets to point to the last element of each length
-        for (int symbol = 0; symbol < codeLengthSize; symbol++) {
+        for (int symbol = 0; symbol < codeLengths.length; symbol++) {
             final int len = codeLengths[symbol];
             if (len == 0) {
                 continue;

--- a/src/test/java/org/apache/commons/compress/huffman/HuffmanDecoderTest.java
+++ b/src/test/java/org/apache/commons/compress/huffman/HuffmanDecoderTest.java
@@ -47,7 +47,7 @@ class HuffmanDecoderTest {
             // Use all code lengths within valid range [1, 20]
             codeLengths[i] = (char) (i % 20 + 1);
         }
-        final HuffmanDecoder decoder = assertDoesNotThrow(() -> new HuffmanDecoder(codeLengths, codeLengths.length, 1, 20),
+        final HuffmanDecoder decoder = assertDoesNotThrow(() -> new HuffmanDecoder(codeLengths, 1, 20),
                 "HuffmanDecoder constructor should not throw for valid codeLengths array of MAX_ALPHA_SIZE");
         assertEquals(decoder.getMinLength(), 1, "Minimum code length should be 1");
         assertEquals(decoder.getMaxLength(), 20, "Maximum code length should be 20");


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [X] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [X] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [X] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

Remove unnecessary parameter `codeLengthSize` from HuffmanDecoder public constructor. This parameter is only used by `BZip2CompressorInputStream` where `alphaSize` is always the same as `codeLengths.length`.