### PR TITLE
Reject back-reference offset larger than the window in lz77 decoder

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/lz77support/AbstractLZ77CompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/lz77support/AbstractLZ77CompressorInputStream.java
@@ -271,11 +271,14 @@ public abstract class AbstractLZ77CompressorInputStream extends CompressorInputS
      *
      * @param offset The offset of the back-reference.
      * @param length The length of the back-reference.
-     * @throws IllegalArgumentException if offset not bigger than 0 or bigger than the number of bytes available for back-references or if length is negative.
+     * @throws IllegalArgumentException if offset not bigger than 0, bigger than the window size or bigger than the number of bytes available for back-references,
+     *                                  or if length is negative.
      */
     protected final void startBackReference(final int offset, final long length) {
-        if (offset <= 0 || offset > writeIndex) {
-            throw new IllegalArgumentException("offset must be bigger than 0 but not bigger than the number of bytes available for back-references");
+        // An offset larger than windowSize can't be honored: the buffer only keeps windowSize bytes of history, so once the buffer is slid mid-copy the source
+        // index writeIndex - offset in tryToCopy would turn negative.
+        if (offset <= 0 || offset > writeIndex || offset > windowSize) {
+            throw new IllegalArgumentException("offset must be bigger than 0 but not bigger than the window size or the number of bytes available for back-references");
         }
         if (length < 0) {
             throw new IllegalArgumentException("length must not be negative");

--- a/src/test/java/org/apache/commons/compress/compressors/lz77support/AbstractLZ77CompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/lz77support/AbstractLZ77CompressorInputStreamTest.java
@@ -78,6 +78,17 @@ class AbstractLZ77CompressorInputStreamTest {
     }
 
     @Test
+    void testBackReferenceOffsetLargerThanWindowIsRejected() throws IOException {
+        // Grow writeIndex past the 1024 window without sliding, so an offset in (windowSize, writeIndex] passes the writeIndex bound but not the window.
+        final byte[] data = new byte[2000];
+        try (TestStream s = new TestStream(new ByteArrayInputStream(data))) {
+            s.literal(data.length);
+            assertEquals(data.length, s.read(new byte[data.length]));
+            assertThrows(IllegalArgumentException.class, () -> s.startBackReference(1500, 4));
+        }
+    }
+
+    @Test
     void testPrefillCanBeUsedForBackReferences() throws IOException {
         final byte[] data = { 1, 2, 3, 4 };
         try (TestStream s = new TestStream(new ByteArrayInputStream(ArrayUtils.EMPTY_BYTE_ARRAY))) {


### PR DESCRIPTION
snappy copy elements encode offsets up to 65535 but SnappyCompressorInputStream runs with a 32768-byte window, and startBackReference only rejects an offset past writeIndex, never past windowSize. such an offset is accepted while writeIndex is still near 2*windowSize, then readFromBuffer slides the buffer down by windowSize in the middle of a back-reference and the next tryToCopy uses writeIndex - offset as a negative source index, so System.arraycopy throws ArrayIndexOutOfBoundsException out of read(), which only declares IOException (crafted stream `1F...` reproduced as `arraycopy: source index -32766`). reject offset > windowSize in startBackReference so a crafted stream fails with the CompressorException that the snappy and lz4 callers already translate the IllegalArgumentException into; the window keeps at most windowSize bytes of history and lz4 offsets never exceed its 65536 window, so valid input is unaffected.