### PR TITLE
Add AbstractTest.toByteArray

### DIFF
--- a/src/test/java/org/apache/commons/compress/AbstractTest.java
+++ b/src/test/java/org/apache/commons/compress/AbstractTest.java
@@ -110,6 +110,24 @@ public abstract class AbstractTest extends AbstractTempDirTest {
         return Files.readAllBytes(getPath(path));
     }
 
+    /**
+     * Converts an array of integers to an array of bytes by casting each integer to a byte.
+     *
+     * @param data the array of integers to convert
+     * @return an array of bytes corresponding to the input integers
+     */
+    public static byte[] toByteArray(final int... data) {
+        final byte[] bytes = new byte[data.length];
+        for (int i = 0; i < data.length; i++) {
+            final int value = data[i];
+            if (value < 0 || value > 255) {
+                throw new IllegalArgumentException(String.format("Value %d at index %d is not within range [0, 255]", value, i));
+            }
+            bytes[i] = (byte) value;
+        }
+        return bytes;
+    }
+
     @TempDir
     protected File tempResultDir;
 

--- a/src/test/java/org/apache/commons/compress/archivers/lha/BinaryTreeTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/lha/BinaryTreeTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
+import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.utils.BitInputStream;
 import org.junit.jupiter.api.Test;
@@ -33,11 +34,7 @@ import org.junit.jupiter.api.Test;
 class BinaryTreeTest {
 
     private BitInputStream createBitInputStream(final int... data) throws IOException {
-        final byte[] bytes = new byte[data.length];
-        for (int i = 0; i < data.length; i++) {
-            bytes[i] = (byte) data[i];
-        }
-        return new BitInputStream(new ByteArrayInputStream(bytes), ByteOrder.BIG_ENDIAN);
+        return new BitInputStream(new ByteArrayInputStream(AbstractTest.toByteArray(data)), ByteOrder.BIG_ENDIAN);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/archivers/lha/LhStaticHuffmanCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/lha/LhStaticHuffmanCompressorInputStreamTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
+import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.utils.BitInputStream;
 import org.apache.commons.io.IOUtils;
@@ -37,11 +38,7 @@ import org.junit.jupiter.api.Test;
 class LhStaticHuffmanCompressorInputStreamTest {
 
     private LhStaticHuffmanCompressorInputStream createLh5CompressorInputStream(final int... data) throws IOException {
-        final byte[] bytes = new byte[data.length];
-        for (int i = 0; i < data.length; i++) {
-            bytes[i] = (byte) data[i];
-        }
-        return LhStaticHuffmanCompressorInputStream.lh5CompressorInputStream(new ByteArrayInputStream(bytes));
+        return LhStaticHuffmanCompressorInputStream.lh5CompressorInputStream(new ByteArrayInputStream(AbstractTest.toByteArray(data)));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/archivers/lha/LhaArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/lha/LhaArchiveInputStreamTest.java
@@ -106,14 +106,6 @@ class LhaArchiveInputStreamTest extends AbstractTest {
     };
     // @formatter:on
 
-    private static byte[] toByteArray(final int... data) {
-        final byte[] bytes = new byte[data.length];
-        for (int i = 0; i < data.length; i++) {
-            bytes[i] = (byte) data[i];
-        }
-        return bytes;
-    }
-
     private static ByteBuffer toByteBuffer(final int... data) {
         return ByteBuffer.wrap(toByteArray(data)).order(ByteOrder.LITTLE_ENDIAN);
     }

--- a/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/zip/ZipArchiveInputStreamTest.java
@@ -164,11 +164,7 @@ class ZipArchiveInputStreamTest extends AbstractTest {
     }
 
     private void fuzzingTest(final int[] bytes) throws Exception {
-        final int len = bytes.length;
-        final byte[] input = new byte[len];
-        for (int i = 0; i < len; i++) {
-            input[i] = (byte) bytes[i];
-        }
+        final byte[] input = toByteArray(bytes);
         try (ArchiveInputStream<?> ais = ArchiveStreamFactory.DEFAULT.createArchiveInputStream("zip", new ByteArrayInputStream(input))) {
             ais.getNextEntry();
             IOUtils.toByteArray(ais);

--- a/src/test/java/org/apache/commons/compress/compressors/bzip2/BZip2CompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/bzip2/BZip2CompressorInputStreamTest.java
@@ -51,11 +51,7 @@ class BZip2CompressorInputStreamTest extends AbstractTest {
     private static final int MAX_CODE_LEN = 20;
 
     private void fuzzingTest(final int[] bytes) throws IOException, ArchiveException {
-        final int len = bytes.length;
-        final byte[] input = new byte[len];
-        for (int i = 0; i < len; i++) {
-            input[i] = (byte) bytes[i];
-        }
+        final byte[] input = toByteArray(bytes);
         try (ArchiveInputStream<?> ais = ArchiveStreamFactory.DEFAULT.createArchiveInputStream("zip", new ByteArrayInputStream(input))) {
             ais.getNextEntry();
             IOUtils.toByteArray(ais);

--- a/src/test/java/org/apache/commons/compress/compressors/deflate64/Deflate64CompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/deflate64/Deflate64CompressorInputStreamTest.java
@@ -55,11 +55,7 @@ class Deflate64CompressorInputStreamTest {
     private Deflate64Decoder decoder;
 
     private void fuzzingTest(final int[] bytes) throws IOException, ArchiveException {
-        final int len = bytes.length;
-        final byte[] input = new byte[len];
-        for (int i = 0; i < len; i++) {
-            input[i] = (byte) bytes[i];
-        }
+        final byte[] input = AbstractTest.toByteArray(bytes);
         try (ArchiveInputStream<?> ais = ArchiveStreamFactory.DEFAULT.createArchiveInputStream("zip", new ByteArrayInputStream(input))) {
             ais.getNextEntry();
             IOUtils.toByteArray(ais);

--- a/src/test/java/org/apache/commons/compress/huffman/HuffmanDecoderTest.java
+++ b/src/test/java/org/apache/commons/compress/huffman/HuffmanDecoderTest.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.utils.BitInputStream;
 import org.junit.jupiter.api.Test;
@@ -50,12 +51,12 @@ class HuffmanDecoderTest {
                 //   Symbol 1: 1
                 Arguments.of(
                         new int[] {1, 1},
-                        new byte[] {(byte) 0b1_0_1_0_0_1_1_1},
+                        new int[] {0b1_0_1_0_0_1_1_1},
                         Arrays.asList(1, 0, 1, 0, 0, 1, 1, 1),
                         ByteOrder.BIG_ENDIAN),
                 Arguments.of(
                         new int[] {1, 1},
-                        new byte[] {(byte) 0b1_1_1_0_0_1_0_1},
+                        new int[] {0b1_1_1_0_0_1_0_1},
                         Arrays.asList(1, 0, 1, 0, 0, 1, 1, 1),
                         ByteOrder.LITTLE_ENDIAN),
                 // Two levels, three symbols
@@ -64,12 +65,12 @@ class HuffmanDecoderTest {
                 //   Symbol 3: 0
                 Arguments.of(
                         new int[] {2, 2, 0, 1},
-                        new byte[] {(byte) 0b10_11_0_0_0_0},
+                        new int[] {0b10_11_0_0_0_0},
                         Arrays.asList(0, 1, 3, 3, 3, 3),
                         ByteOrder.BIG_ENDIAN),
                 Arguments.of(
                         new int[] {2, 2, 0, 1},
-                        new byte[] {(byte) 0b01_11_0_0_0_0},
+                        new int[] {0b01_11_0_0_0_0},
                         Arrays.asList(3, 3, 3, 3, 1, 0),
                         ByteOrder.LITTLE_ENDIAN),
                 // Two levels, three symbols, decode across byte boundary
@@ -78,12 +79,12 @@ class HuffmanDecoderTest {
                 // Symbol 2: 0
                 Arguments.of(
                         new int[] {2, 2, 1, 0},
-                        new byte[] {(byte) 0b0_11_10_11_1, (byte) 0b0_11_10_11_0},
+                        new int[] {0b0_11_10_11_1, 0b0_11_10_11_0},
                         Arrays.asList(2, 1, 0, 1, 0, 1, 0, 1, 2),
                         ByteOrder.BIG_ENDIAN),
                 Arguments.of(
                         new int[] {2, 2, 1, 0},
-                        new byte[] {(byte) 0b1_11_01_11_0, (byte) 0b0_11_01_11_0},
+                        new int[] {0b1_11_01_11_0, 0b0_11_01_11_0},
                         Arrays.asList(2, 1, 0, 1, 0, 1, 0, 1, 2),
                         ByteOrder.LITTLE_ENDIAN),
                 // Five levels, six symbols, decode across byte boundary
@@ -95,19 +96,19 @@ class HuffmanDecoderTest {
                 // Symbol 6: 0
                 Arguments.of(
                         new int[] {4, 2, 3, 0, 5, 5, 1},
-                        new byte[] {(byte) 0b0_10_110_11, (byte) 0b10_11110_1, (byte) 0b1111_0000},
+                        new int[] {0b0_10_110_11, 0b10_11110_1, 0b1111_0000},
                         Arrays.asList(6, 1, 2, 0, 4, 5),
                         ByteOrder.BIG_ENDIAN),
                 Arguments.of(
                         new int[] {4, 2, 3, 0, 5, 5, 1},
-                        new byte[] {(byte) 0b11_011_01_0, (byte) 0b1_01111_01, (byte) 0b0000_1111},
+                        new int[] {0b11_011_01_0, 0b1_01111_01, 0b0000_1111},
                         Arrays.asList(6, 1, 2, 0, 4, 5),
                         ByteOrder.LITTLE_ENDIAN));
         // @formatter:on
     }
 
-    private int decodeSymbol(final HuffmanDecoder decoder, final byte... data) throws IOException {
-        try (BitInputStream in = new BitInputStream(new ByteArrayInputStream(data), ByteOrder.BIG_ENDIAN)) {
+    private int decodeSymbol(final HuffmanDecoder decoder, final int... data) throws IOException {
+        try (BitInputStream in = new BitInputStream(new ByteArrayInputStream(AbstractTest.toByteArray(data)), ByteOrder.BIG_ENDIAN)) {
             return decoder.decodeSymbol(in);
         }
     }
@@ -128,10 +129,10 @@ class HuffmanDecoderTest {
 
     @ParameterizedTest
     @MethodSource
-    void testDecodeSymbols(final int[] codeLengths, final byte[] inputData, final List<Integer> expectedSymbols, final ByteOrder byteOrder) throws IOException {
+    void testDecodeSymbols(final int[] codeLengths, final int[] inputData, final List<Integer> expectedSymbols, final ByteOrder byteOrder) throws IOException {
         final HuffmanDecoder decoder = new HuffmanDecoder(codeLengths);
         final Collection<Integer> actualSymbols = new ArrayList<>();
-        try (BitInputStream in = new BitInputStream(new ByteArrayInputStream(inputData), byteOrder)) {
+        try (BitInputStream in = new BitInputStream(new ByteArrayInputStream(AbstractTest.toByteArray(inputData)), byteOrder)) {
             for (int i = 0; i < expectedSymbols.size(); i++) {
                 actualSymbols.add(decoder.decodeSymbol(in));
             }
@@ -144,12 +145,12 @@ class HuffmanDecoderTest {
         final int[] length = { 4, 2, 3, 0, 5, 0, 1 };
         // Value: 0 1 2 3 4 5 6
         final HuffmanDecoder decoder = new HuffmanDecoder(length);
-        assertEquals(6, decodeSymbol(decoder, (byte) 0x00)); // 0xxx xxxx
-        assertEquals(1, decodeSymbol(decoder, (byte) 0x80)); // 10xx xxxx
-        assertEquals(2, decodeSymbol(decoder, (byte) 0xc0)); // 110x xxxx
-        assertEquals(0, decodeSymbol(decoder, (byte) 0xe0)); // 1110 xxxx
-        assertEquals(4, decodeSymbol(decoder, (byte) 0xf0)); // 1111 0xxx
-        final CompressorException e = assertThrows(CompressorException.class, () -> decodeSymbol(decoder, (byte) 0xf8),
+        assertEquals(6, decodeSymbol(decoder, 0x00)); // 0xxx xxxx
+        assertEquals(1, decodeSymbol(decoder, 0x80)); // 10xx xxxx
+        assertEquals(2, decodeSymbol(decoder, 0xc0)); // 110x xxxx
+        assertEquals(0, decodeSymbol(decoder, 0xe0)); // 1110 xxxx
+        assertEquals(4, decodeSymbol(decoder, 0xf0)); // 1111 0xxx
+        final CompressorException e = assertThrows(CompressorException.class, () -> decodeSymbol(decoder, 0xf8),
                 "Expected CompressorException for invalid bitstream");
         assertEquals("Invalid Huffman code: 62", e.getMessage());
     }
@@ -204,7 +205,7 @@ class HuffmanDecoderTest {
     @Test
     void testNoLeafNodes() throws Exception {
         final HuffmanDecoder decoder = new HuffmanDecoder(new int[] { 0, 0, 0, 0, 0 });
-        final CompressorException e = assertThrows(CompressorException.class, () -> decodeSymbol(decoder, (byte) 0, (byte) 0, (byte) 0, (byte) 0),
+        final CompressorException e = assertThrows(CompressorException.class, () -> decodeSymbol(decoder, 0, 0, 0, 0),
                 "Expected CompressorException when decoding symbols for tree with no leaf nodes");
         assertEquals("Invalid Huffman code: 0", e.getMessage());
     }
@@ -214,7 +215,7 @@ class HuffmanDecoderTest {
         final int[] length = { 4, 2, 3, 0, 5, 5, 1 };
         // Value: 0 1 2 3 4 5 6
         final HuffmanDecoder decoder = new HuffmanDecoder(length);
-        try (BitInputStream in = new BitInputStream(new ByteArrayInputStream(new byte[] { (byte) 0b11111_110 }), ByteOrder.BIG_ENDIAN)) {
+        try (BitInputStream in = new BitInputStream(new ByteArrayInputStream(AbstractTest.toByteArray(0b11111_110)), ByteOrder.BIG_ENDIAN)) {
             assertEquals(5, decoder.decodeSymbol(in)); // 1111 1xxx
             assertEquals(2, decoder.decodeSymbol(in)); // 110x xxxx
             final EOFException e = assertThrows(EOFException.class, () -> decoder.decodeSymbol(in),
@@ -228,8 +229,8 @@ class HuffmanDecoderTest {
         final int[] length = { 1 };
         // Value: 0
         final HuffmanDecoder decoder = new HuffmanDecoder(length);
-        assertEquals(0, decodeSymbol(decoder, (byte) 0x00)); // 0xxx xxxx
-        final CompressorException e = assertThrows(CompressorException.class, () -> decodeSymbol(decoder, (byte) 0x80),
+        assertEquals(0, decodeSymbol(decoder, 0x00)); // 0xxx xxxx
+        final CompressorException e = assertThrows(CompressorException.class, () -> decodeSymbol(decoder, 0x80),
                 "Expected CompressorException for invalid bitstream");
         assertEquals("Invalid Huffman code: 2", e.getMessage());
     }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [X] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [X] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [X] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

Add helper method `AbstractTest.toByteArray` to simplify creating byte arrays for testing and avoid having to manually cast from integer to byte.
