### PR TITLE
Reject oversized four-byte literal length in snappy decoder

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorInputStream.java
@@ -246,7 +246,7 @@ public class SnappyCompressorInputStream extends AbstractLZ77CompressorInputStre
         case 63:
             final long fourByteLength = ByteUtils.fromLittleEndian(supplier, 4);
             if (fourByteLength + 1 > Integer.MAX_VALUE) {
-                throw new CompressorException("Illegal literal length %,d in Snappy stream", fourByteLength);
+                throw new CompressorException("Illegal literal length %,d in Snappy stream", fourByteLength + 1);
             }
             length = (int) fourByteLength;
             break;

--- a/src/main/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorInputStream.java
@@ -244,7 +244,11 @@ public class SnappyCompressorInputStream extends AbstractLZ77CompressorInputStre
             length = (int) ByteUtils.fromLittleEndian(supplier, 3);
             break;
         case 63:
-            length = (int) ByteUtils.fromLittleEndian(supplier, 4);
+            final long fourByteLength = ByteUtils.fromLittleEndian(supplier, 4);
+            if (fourByteLength + 1 > Integer.MAX_VALUE) {
+                throw new CompressorException("Illegal literal length %,d in Snappy stream", fourByteLength);
+            }
+            length = (int) fourByteLength;
             break;
         default:
             length = b >> 2;

--- a/src/test/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/snappy/SnappyCompressorInputStreamTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.compressors.snappy;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for class {@link SnappyCompressorInputStream}.
+ *
+ * @see SnappyCompressorInputStream
+ */
+class SnappyCompressorInputStreamTest {
+
+    @Test
+    void testRejectsOversizedFourByteLiteralLength() throws IOException {
+        // uncompressed size varint (1000), then a literal element (tag 0xFC) whose four-byte length is 0xFFFFFFFF.
+        // The unsigned length was narrowed to int, so (len - 1) wrapped to a zero-length literal that passed the
+        // negative-size guard and produced no output, letting the decoder recurse on itself until the stack blew.
+        final byte[] input = { (byte) 0xE8, 0x07, (byte) 0xFC, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+        try (SnappyCompressorInputStream in = new SnappyCompressorInputStream(new ByteArrayInputStream(input))) {
+            final IOException e = assertThrows(CompressorException.class, () -> IOUtils.toByteArray(in));
+            assertTrue(e.getMessage().contains("literal length"), e::getMessage);
+        }
+    }
+}


### PR DESCRIPTION
snappycompressorinputstream.readliterallength reads the four-byte literal length with byteutils.fromlittleendian and casts it straight to int, so a length field of 0xffffffff narrows to -1 and, after the +1 the method adds, becomes a zero-length literal. fill only guards against a negative literal size, so the zero-length literal slips through, consumes no input and emits no output, and read() then recurses into itself once per element until a crafted run of them overflows the stack with a stackoverflowerror that escapes the declared ioexception. reading the four-byte value as an unsigned long and rejecting anything that can't fit a positive int before narrowing keeps the check at the point of the conversion; the two- and three-byte forms can't overflow so they're untouched. reachable directly and through framedsnappycompressorinputstream, which decodes each chunk with this class.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
