### PR TITLE
wrap gzip FNAME/FCOMMENT charset errors as CompressorException

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStream.java
@@ -411,11 +411,19 @@ public class GzipCompressorInputStream extends CompressorInputStream implements 
         }
         // Original file name
         if ((flg & FLG.FNAME) != 0) {
-            parameters.setFileName(new String(readToNull(inData), parameters.getFileNameCharset()));
+            try {
+                parameters.setFileName(new String(readToNull(inData), parameters.getFileNameCharset()));
+            } catch (final IllegalArgumentException e) {
+                throw new CompressorException("Corrupt .gz FNAME field.", e);
+            }
         }
         // Comment
         if ((flg & FLG.FCOMMENT) != 0) {
-            parameters.setComment(new String(readToNull(inData), parameters.getFileNameCharset()));
+            try {
+                parameters.setComment(new String(readToNull(inData), parameters.getFileNameCharset()));
+            } catch (final IllegalArgumentException e) {
+                throw new CompressorException("Corrupt .gz FCOMMENT field.", e);
+            }
         }
         // Header "CRC16" which is actually a truncated CRC32 (which isn't
         // as good as real CRC16). I don't know if any encoder implementation

--- a/src/test/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/gzip/GzipCompressorInputStreamTest.java
@@ -21,10 +21,14 @@ package org.apache.commons.compress.compressors.gzip;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -35,9 +39,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.io.function.IOStream;
@@ -350,6 +358,57 @@ class GzipCompressorInputStreamTest {
             assertEquals("hello1.txt", gis.getMetaData().getFileName());
             assertEquals("Hello1\nHello2\n", IOUtils.toString(gis, StandardCharsets.ISO_8859_1));
             assertEquals("hello2.txt", gis.getMetaData().getFileName());
+        }
+    }
+
+    private static byte[] gzipMemberWithFileName(final byte[] fileNameField) throws IOException {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        bos.write(0x1f);
+        bos.write(0x8b); // magic
+        bos.write(0x08); // deflate
+        bos.write(0x08); // FLG: FNAME present
+        bos.write(new byte[] { 0, 0, 0, 0 }); // MTIME
+        bos.write(0x00); // XFL
+        bos.write(0xff); // OS unknown
+        bos.write(fileNameField);
+        bos.write(0x00); // NUL terminator for FNAME
+        final ByteArrayOutputStream deflated = new ByteArrayOutputStream();
+        try (DeflaterOutputStream dos = new DeflaterOutputStream(deflated, new Deflater(Deflater.DEFAULT_COMPRESSION, true))) {
+            // empty payload
+        }
+        bos.write(deflated.toByteArray());
+        final long crc = new CRC32().getValue();
+        bos.write((int) (crc & 0xff));
+        bos.write((int) (crc >> 8 & 0xff));
+        bos.write((int) (crc >> 16 & 0xff));
+        bos.write((int) (crc >> 24 & 0xff));
+        bos.write(new byte[] { 0, 0, 0, 0 }); // ISIZE
+        return bos.toByteArray();
+    }
+
+    /**
+     * A member whose FNAME field cannot be round-tripped through the configured charset must fail with a CompressorException rather than a raw
+     * IllegalArgumentException escaping the IOException contract of read().
+     */
+    @Test
+    void testUnencodableFileNameThrowsCompressorException() throws IOException {
+        // Under UTF-32BE a single stray byte decodes to U+FFFD, which re-encodes to bytes containing a NUL.
+        final byte[] gz = gzipMemberWithFileName(new byte[] { 0x41 });
+        assertThrows(CompressorException.class, () -> {
+            try (GzipCompressorInputStream gis = GzipCompressorInputStream.builder()
+                    .setInputStream(new ByteArrayInputStream(gz))
+                    .setFileNameCharset(Charset.forName("UTF-32BE"))
+                    .get()) {
+                IOUtils.toString(gis, StandardCharsets.ISO_8859_1);
+            }
+        });
+        // A member that round-trips cleanly still parses.
+        final byte[] ok = gzipMemberWithFileName("name.txt".getBytes(StandardCharsets.ISO_8859_1));
+        try (GzipCompressorInputStream gis = GzipCompressorInputStream.builder()
+                .setInputStream(new ByteArrayInputStream(ok))
+                .get()) {
+            assertEquals("", IOUtils.toString(gis, StandardCharsets.ISO_8859_1));
+            assertEquals("name.txt", gis.getMetaData().getFileName());
         }
     }
 


### PR DESCRIPTION
The gzip reader parses the FNAME and FCOMMENT header fields by decoding their raw bytes with the configured file-name charset and handing the result to GzipParameters.setFileName/setComment. Those setters re-encode the string and reject a NUL byte with an IllegalArgumentException, a guard aimed at the write path. When a caller selects a non-default multibyte charset through Builder.setFileNameCharset (UTF-32BE for example), decoding a malformed field yields a replacement character that re-encodes with a NUL byte, so a crafted member makes the reader throw IllegalArgumentException out of the constructor and out of read(), both of which only declare IOException. I hit it while feeding a fuzzed member through a non-Latin-1 charset. This lines up with the recent work moving these readers to CompressorException, so I catch the IllegalArgumentException at the two parse sites and rethrow it there. I kept the change in the reader so the public GzipParameters setters stay as they are.