### PR TITLE
Avoid unbounded recursion on empty frames in framed lz4 and snappy decoders

### DIFF
--- a/src/main/java/org/apache/commons/compress/compressors/lz4/FramedLZ4CompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/lz4/FramedLZ4CompressorInputStream.java
@@ -193,39 +193,46 @@ public class FramedLZ4CompressorInputStream extends CompressorInputStream implem
     }
 
     private void nextBlock() throws IOException {
-        maybeFinishCurrentBlock();
-        final long len = ByteUtils.fromLittleEndian(supplier, 4);
-        final boolean uncompressed = (len & UNCOMPRESSED_FLAG_MASK) != 0;
-        final int realLen = (int) (len & ~UNCOMPRESSED_FLAG_MASK);
-        if (realLen == 0) {
+        while (true) {
+            maybeFinishCurrentBlock();
+            final long len = ByteUtils.fromLittleEndian(supplier, 4);
+            final boolean uncompressed = (len & UNCOMPRESSED_FLAG_MASK) != 0;
+            final int realLen = (int) (len & ~UNCOMPRESSED_FLAG_MASK);
+            if (realLen != 0) {
+                // @formatter:off
+                InputStream capped = BoundedInputStream.builder()
+                        .setInputStream(inputStream)
+                        .setMaxCount(realLen)
+                        .setPropagateClose(false)
+                        .get();
+                // @formatter:on
+                if (expectBlockChecksum) {
+                    capped = new CheckedInputStream(capped, blockHash);
+                }
+                if (uncompressed) {
+                    inUncompressed = true;
+                    currentBlock = capped;
+                } else {
+                    inUncompressed = false;
+                    final BlockLZ4CompressorInputStream s = new BlockLZ4CompressorInputStream(capped);
+                    if (expectBlockDependency) {
+                        s.prefill(blockDependencyBuffer);
+                    }
+                    currentBlock = s;
+                }
+                return;
+            }
             verifyContentChecksum();
             if (!decompressConcatenated) {
                 endReached = true;
-            } else {
-                init(false);
+                return;
             }
-            return;
-        }
-        // @formatter:off
-        InputStream capped = BoundedInputStream.builder()
-                .setInputStream(inputStream)
-                .setMaxCount(realLen)
-                .setPropagateClose(false)
-                .get();
-        // @formatter:on
-        if (expectBlockChecksum) {
-            capped = new CheckedInputStream(capped, blockHash);
-        }
-        if (uncompressed) {
-            inUncompressed = true;
-            currentBlock = capped;
-        } else {
-            inUncompressed = false;
-            final BlockLZ4CompressorInputStream s = new BlockLZ4CompressorInputStream(capped);
-            if (expectBlockDependency) {
-                s.prefill(blockDependencyBuffer);
+            // Start of the next concatenated frame. Loop instead of recursing into init so a run of empty
+            // frames advances without growing the call stack.
+            if (!readSignature(false)) {
+                return;
             }
-            currentBlock = s;
+            readFrameDescriptor();
         }
     }
 

--- a/src/main/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStream.java
+++ b/src/main/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStream.java
@@ -226,53 +226,58 @@ public class FramedSnappyCompressorInputStream extends CompressorInputStream imp
     }
 
     private void readNextBlock() throws IOException {
-        verifyLastChecksumAndReset();
-        inUncompressedChunk = false;
-        final int type = readOneByte();
-        if (type == -1) {
-            endReached = true;
-        } else if (type == STREAM_IDENTIFIER_TYPE) {
-            inputStream.unread(type);
-            unreadBytes++;
-            pushedBackBytes(1);
-            readStreamIdentifier();
-            readNextBlock();
-        } else if (type == PADDING_CHUNK_TYPE || type > MAX_UNSKIPPABLE_TYPE && type <= MAX_SKIPPABLE_TYPE) {
-            skipBlock();
-            readNextBlock();
-        } else if (type >= MIN_UNSKIPPABLE_TYPE && type <= MAX_UNSKIPPABLE_TYPE) {
-            throw new CompressorException("Unskippable chunk with type %s (hex %s) detected.", type, Integer.toHexString(type));
-        } else if (type == UNCOMPRESSED_CHUNK_TYPE) {
-            inUncompressedChunk = true;
-            uncompressedBytesRemaining = readSize() - 4 /* CRC */;
-            if (uncompressedBytesRemaining < 0) {
-                throw new CompressorException("Found illegal chunk with negative size");
-            }
-            expectedChecksum = unmask(readCrc());
-        } else if (type == COMPRESSED_CHUNK_TYPE) {
-            final boolean expectChecksum = dialect.usesChecksumWithCompressedChunks();
-            final long size = readSize() - (expectChecksum ? 4L : 0L);
-            if (size < 0) {
-                throw new CompressorException("Found illegal chunk with negative size");
-            }
-            if (expectChecksum) {
-                expectedChecksum = unmask(readCrc());
+        while (true) {
+            verifyLastChecksumAndReset();
+            inUncompressedChunk = false;
+            final int type = readOneByte();
+            // Stream identifiers and padding/skippable chunks produce no output. Loop instead of recursing
+            // so a run of them advances without growing the call stack.
+            if (type == STREAM_IDENTIFIER_TYPE) {
+                inputStream.unread(type);
+                unreadBytes++;
+                pushedBackBytes(1);
+                readStreamIdentifier();
+            } else if (type == PADDING_CHUNK_TYPE || type > MAX_UNSKIPPABLE_TYPE && type <= MAX_SKIPPABLE_TYPE) {
+                skipBlock();
             } else {
-                expectedChecksum = -1;
+                if (type == -1) {
+                    endReached = true;
+                } else if (type >= MIN_UNSKIPPABLE_TYPE && type <= MAX_UNSKIPPABLE_TYPE) {
+                    throw new CompressorException("Unskippable chunk with type %s (hex %s) detected.", type, Integer.toHexString(type));
+                } else if (type == UNCOMPRESSED_CHUNK_TYPE) {
+                    inUncompressedChunk = true;
+                    uncompressedBytesRemaining = readSize() - 4 /* CRC */;
+                    if (uncompressedBytesRemaining < 0) {
+                        throw new CompressorException("Found illegal chunk with negative size");
+                    }
+                    expectedChecksum = unmask(readCrc());
+                } else if (type == COMPRESSED_CHUNK_TYPE) {
+                    final boolean expectChecksum = dialect.usesChecksumWithCompressedChunks();
+                    final long size = readSize() - (expectChecksum ? 4L : 0L);
+                    if (size < 0) {
+                        throw new CompressorException("Found illegal chunk with negative size");
+                    }
+                    if (expectChecksum) {
+                        expectedChecksum = unmask(readCrc());
+                    } else {
+                        expectedChecksum = -1;
+                    }
+                    // @formatter:off
+                    currentCompressedChunk = new SnappyCompressorInputStream(BoundedInputStream.builder()
+                            .setInputStream(inputStream)
+                            .setMaxCount(size)
+                            .setPropagateClose(false)
+                            .get(),
+                            blockSize);
+                    // @formatter:on
+                    // constructor reads uncompressed size
+                    count(currentCompressedChunk.getBytesRead());
+                } else {
+                    // impossible as all potential byte values have been covered
+                    throw new CompressorException("Unknown chunk type %s detected.", type);
+                }
+                return;
             }
-            // @formatter:off
-            currentCompressedChunk = new SnappyCompressorInputStream(BoundedInputStream.builder()
-                    .setInputStream(inputStream)
-                    .setMaxCount(size)
-                    .setPropagateClose(false)
-                    .get(),
-                    blockSize);
-            // @formatter:on
-            // constructor reads uncompressed size
-            count(currentCompressedChunk.getBytesRead());
-        } else {
-            // impossible as all potential byte values have been covered
-            throw new CompressorException("Unknown chunk type %s detected.", type);
         }
     }
 

--- a/src/test/java/org/apache/commons/compress/compressors/lz4/FramedLZ4CompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/lz4/FramedLZ4CompressorInputStreamTest.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.compressors.lz4;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -549,6 +551,25 @@ public final class FramedLZ4CompressorInputStreamTest extends AbstractTest {
             final byte[] actual = IOUtils.toByteArray(a);
             assertArrayEquals(new byte[] { 'H', 'e', 'l', 'l', 'o', ',', ' ', 'w', 'o', 'r', 'l', 'd', '!', '!' }, actual);
         }
+    }
+
+    @Test
+    void testManyEmptyConcatenatedFramesDoNotOverflowStack() throws IOException {
+        final byte[] singleEmptyFrame;
+        try (ByteArrayOutputStream frame = new ByteArrayOutputStream()) {
+            new FramedLZ4CompressorOutputStream(frame).close();
+            singleEmptyFrame = frame.toByteArray();
+        }
+        final ByteArrayOutputStream concatenated = new ByteArrayOutputStream();
+        for (int i = 0; i < 200_000; i++) {
+            concatenated.write(singleEmptyFrame);
+        }
+        final byte[] input = concatenated.toByteArray();
+        assertDoesNotThrow(() -> {
+            try (FramedLZ4CompressorInputStream in = new FramedLZ4CompressorInputStream(new ByteArrayInputStream(input), true)) {
+                assertEquals(-1, in.read());
+            }
+        });
     }
 
     @Test

--- a/src/test/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/compressors/snappy/FramedSnappyCompressorInputStreamTest.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.compressors.snappy;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -235,6 +236,23 @@ public final class FramedSnappyCompressorInputStreamTest extends AbstractTest {
             decompressed = decompressedOutputStream.toByteArray();
         }
         assertArrayEquals(data, decompressed);
+    }
+
+    @Test
+    void testManyPaddingChunksDoNotOverflowStack() {
+        final byte[] streamIdentifier = { (byte) 0xff, 6, 0, 0, 's', 'N', 'a', 'P', 'p', 'Y' };
+        final byte[] emptyPaddingChunk = { (byte) 0xfe, 0, 0, 0 };
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(streamIdentifier, 0, streamIdentifier.length);
+        for (int i = 0; i < 200_000; i++) {
+            out.write(emptyPaddingChunk, 0, emptyPaddingChunk.length);
+        }
+        final byte[] input = out.toByteArray();
+        assertDoesNotThrow(() -> {
+            try (FramedSnappyCompressorInputStream in = new FramedSnappyCompressorInputStream(new ByteArrayInputStream(input))) {
+                assertEquals(-1, in.read());
+            }
+        });
     }
 
 }


### PR DESCRIPTION
framedlz4compressorinputstream.nextblock and framedsnappycompressorinputstream.readnextblock advance past zero-output units by recursing rather than looping: nextblock reaches an lz4 endmark and calls init, which reads the next frame and calls nextblock again, once per empty concatenated frame; readnextblock calls itself again after every snappy stream-identifier and padding/skippable chunk. those units are all legal per the respective frame specs, so the recursion depth is just the attacker-controlled count of them. a stream of a few hundred kb of empty frames or padding chunks overflows the stack with stackoverflowerror out of read and the framedlz4 constructor, which declare only throws ioexception, so a caller catching ioexception to handle a corrupt stream gets an error instead. both paths are turned into a while loop that advances over the empty units without growing the stack; valid streams decode exactly as before. regression tests in both decoders build ~200k empty units and assert the stream now reads to eof.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
