### PR TITLE
Remove Error rethrow in pack200 ReferenceForm and NewClassRefForm (unpack200 package)

### DIFF
--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/NewClassRefForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/NewClassRefForm.java
@@ -61,13 +61,9 @@ public class NewClassRefForm extends ClassRefForm {
             byteCode.setNestedPositions(new int[][] { { 0, 2 } });
         } else {
             // Look up the class in the classpool
-            try {
-                // Parent takes care of subtracting one from offset
-                // to adjust for 1-based global pool
-                setNestedEntries(byteCode, operandManager, offset);
-            } catch (final Pack200Exception ex) {
-                throw new Error("Got a pack200 exception. What to do?");
-            }
+            // Parent takes care of subtracting one from offset
+            // to adjust for 1-based global pool
+            setNestedEntries(byteCode, operandManager, offset);
         }
         operandManager.setNewClass(((CPClass) byteCode.getNestedClassFileEntries()[0]).getName());
     }

--- a/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ReferenceForm.java
+++ b/src/main/java/org/apache/commons/compress/harmony/unpack200/bytecode/forms/ReferenceForm.java
@@ -69,11 +69,7 @@ public abstract class ReferenceForm extends ByteCodeForm {
     @Override
     public void setByteCodeOperands(final ByteCode byteCode, final OperandManager operandManager, final int codeLength) throws Pack200Exception {
         final int offset = getOffset(operandManager);
-        try {
-            setNestedEntries(byteCode, operandManager, offset);
-        } catch (final Pack200Exception ex) {
-            throw new Error("Got a pack200 exception. What to do?");
-        }
+        setNestedEntries(byteCode, operandManager, offset);
     }
 
     /**

--- a/src/test/java/org/apache/commons/compress/harmony/unpack200/CodeAttributeTest.java
+++ b/src/test/java/org/apache/commons/compress/harmony/unpack200/CodeAttributeTest.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.harmony.unpack200;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -140,6 +141,33 @@ class CodeAttributeTest {
             -49, // return 4
     };
 
+    private OperandManager newOperandManager(final int[] bcClassRef, final int[] bcIMethodRef) {
+        final OperandManager operandManager = new OperandManager(new int[] {}, // bcCaseCount
+                new int[] {}, // bcCaseValues
+                new int[] {}, // bcByte
+                new int[] {}, // bcShort
+                new int[] {}, // bcLocal
+                new int[] {}, // bcLabel
+                new int[] {}, // bcIntRef
+                new int[] {}, // bcFloatRef
+                new int[] {}, // bcLongRef
+                new int[] {}, // bcDoubleRef
+                new int[] {}, // bcStringRef
+                bcClassRef, // bcClassRef
+                new int[] {}, // bcFieldRef
+                new int[] {}, // bcMethodRef
+                bcIMethodRef, // bcIMethodRef
+                new int[] {}, // bcThisField
+                new int[] {}, // bcSuperField
+                new int[] {}, // bcThisMethod
+                new int[] {}, // bcSuperMethod
+                new int[] {} // bcInitRef
+                , null);
+        operandManager.setSegment(segment);
+        operandManager.setCurrentClass("java/lang/Foo");
+        return operandManager;
+    }
+
     @Test
     void testLength() throws Pack200Exception {
         final OperandManager operandManager = new MockOperandManager();
@@ -178,6 +206,16 @@ class CodeAttributeTest {
         for (int index = 0; index < expectedLabels.length; index++) {
             assertEquals(expectedLabels[index], attribute.byteCodeOffsets.get(index).intValue());
         }
+    }
+
+    @Test
+    void testNegativeReferenceIndex() {
+        // invokeinterface with a negative bc_imethodref operand
+        assertThrows(Pack200Exception.class, () -> new CodeAttribute(1, 1, new byte[] { (byte) 185 }, segment, newOperandManager(new int[] {}, new int[] { -2 }),
+                new ArrayList<>()));
+        // new with a negative bc_classref operand
+        assertThrows(Pack200Exception.class, () -> new CodeAttribute(1, 1, new byte[] { (byte) 187 }, segment, newOperandManager(new int[] { -2 }, new int[] {}),
+                new ArrayList<>()));
     }
 
     @Test


### PR DESCRIPTION
ReferenceForm.setByteCodeOperands and NewClassRefForm.setByteCodeOperands catch the Pack200Exception raised by setNestedEntries and rethrow it as a bare java.lang.Error("Got a pack200 exception. What to do?"), dropping the cause, even though both methods already declare throws Pack200Exception. bc_imethodref, bc_fieldref, bc_methodref and the other reference bands are DELTA5 (bc_classref is UNSIGNED5 narrowed to int), so a crafted .pack can hand a negative operand to SegmentConstantPool.toIndex; the resulting Error is neither Pack200Exception nor RuntimeException, so Pack200UnpackerAdapter.unpack does not wrap it and it escapes the Pack200CompressorInputStream constructor, which declares only IOException. a mutated pack200-e1.pack from the test resources reproduces it. drop the two catch blocks so the declared exception propagates and the adapter reports it as a normal Pack200Exception ("Cannot have a negative index"), in line with the 1.29 change that already replaced the other Error throws in unpack200. regression test added to CodeAttributeTest for invokeinterface (ReferenceForm) and new (NewClassRefForm).
