### PR TITLE
Add tests for lh5 decompression

### DIFF
--- a/src/test/java/org/apache/commons/compress/archivers/lha/LhStaticHuffmanCompressorInputStreamTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/lha/LhStaticHuffmanCompressorInputStreamTest.java
@@ -20,11 +20,14 @@
 package org.apache.commons.compress.archivers.lha;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.compress.AbstractTest;
 import org.apache.commons.compress.compressors.CompressorException;
@@ -39,6 +42,34 @@ class LhStaticHuffmanCompressorInputStreamTest {
 
     private LhStaticHuffmanCompressorInputStream createLh5CompressorInputStream(final int... data) throws IOException {
         return LhStaticHuffmanCompressorInputStream.lh5CompressorInputStream(new ByteArrayInputStream(AbstractTest.toByteArray(data)));
+    }
+
+    @Test
+    void testDecompressFailureForTreeWithTooManyLeafNodes() {
+        // This compressed data contains an invalid Huffman tree with too many leaf nodes,
+        // which should throw an exception when trying to decompress it.
+        final int[] compressedData = new int[] {
+            0x00, 0x04, 0x28, 0x25, 0x30, 0x70, 0xB7, 0x95, 0xD0, 0x21, 0xB0
+        };
+
+        final CompressorException e = assertThrows(CompressorException.class, () -> IOUtils.toByteArray(createLh5CompressorInputStream(compressedData)),
+                "Expected CompressorException due to too many leaf nodes in the Huffman tree");
+        assertEquals("Tree contains too many leaf nodes for depth 1", e.getMessage());
+    }
+
+    @Test
+    void testDecompressSingleCodeLengthHuffmanTree() throws IOException {
+        // This compressed data contains a single code length in one of the Huffman trees, which is handled
+        // differently in LHx compressors compared to other Huffman based compressors.
+        final int[] compressedData = new int[] {
+            0x00, 0x09, 0x38, 0x0a, 0x2a, 0x1d, 0x0b, 0x70, 0x12, 0xc3, 0x03, 0xe0, 0x53, 0x97, 0x7e
+        };
+
+        try (InputStream is = createLh5CompressorInputStream(compressedData)) {
+            final byte[] data = IOUtils.toByteArray(is);
+            assertEquals(24, data.length);
+            assertEquals("ABCDEFGHABCDEFGHABCDEFGH", new String(data, StandardCharsets.US_ASCII));
+        }
     }
 
     @Test


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [X] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [X] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [X] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

This PR contains two edge case tests that will fail if `HuffmanDecoder` is used as-is from the `LhStaticHuffmanCompressorInputStream`.

When is PR together with the other LHA related PRs are merged then I think we are ready to replace `BinaryTree` used in `LhStaticHuffmanCompressorInputStream` with the generic `HuffmanDecoder`.
