### PR TITLE
wrap invalid entry name in ArchiveEntry.resolveIn as ArchiveException

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveEntry.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveEntry.java
@@ -19,6 +19,7 @@
 package org.apache.commons.compress.archivers;
 
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Date;
 
@@ -74,7 +75,12 @@ public interface ArchiveEntry {
      */
     default Path resolveIn(final Path parentPath) throws IOException {
         final String name = getName();
-        final Path outputFile = parentPath.resolve(name).normalize();
+        final Path outputFile;
+        try {
+            outputFile = parentPath.resolve(name).normalize();
+        } catch (final InvalidPathException e) {
+            throw new ArchiveException("Invalid entry name '" + name + "'", (Throwable) e);
+        }
         if (!outputFile.startsWith(parentPath)) {
             throw new ArchiveException("Zip slip '%s' + '%s' -> '%s'", parentPath, name, outputFile);
         }

--- a/src/test/java/org/apache/commons/compress/archivers/ArchiveEntryTest.java
+++ b/src/test/java/org/apache/commons/compress/archivers/ArchiveEntryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.compress.archivers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+class ArchiveEntryTest {
+
+    private static ArchiveEntry entry(final String name) {
+        return new ArchiveEntry() {
+            @Override
+            public Date getLastModifiedDate() {
+                return new Date(0);
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public long getSize() {
+                return 0;
+            }
+
+            @Override
+            public boolean isDirectory() {
+                return false;
+            }
+        };
+    }
+
+    private final Path parent = Paths.get("parent");
+
+    @Test
+    void testResolveInRejectsInvalidName() {
+        // A NUL byte is a legal byte in a stored entry name (for example a crafted ZIP central directory
+        // record) but is rejected by the platform Path parser, so parentPath.resolve throws the unchecked
+        // InvalidPathException. It must be reported through the declared IOException contract instead.
+        final IOException e = assertThrows(IOException.class, () -> entry("a\u0000b").resolveIn(parent));
+        assertInstanceOf(InvalidPathException.class, e.getCause());
+    }
+
+    @Test
+    void testResolveInRejectsZipSlip() {
+        assertThrows(IOException.class, () -> entry("../evil").resolveIn(parent));
+    }
+
+    @Test
+    void testResolveInResolvesValidName() throws IOException {
+        assertEquals(parent.resolve("sub/file.txt"), entry("sub/file.txt").resolveIn(parent));
+    }
+}


### PR DESCRIPTION
archiveentry.resolveIn is the default zip-slip guard that expander.expand calls for every entry, and it resolves the untrusted entry name via parentPath.resolve(getName()).normalize(). a name that carries a byte the platform path parser rejects, for example a NUL in a crafted zip central directory record, makes resolve throw an unchecked InvalidPathException out of resolveIn and out of expander.expand, both of which declare only throws IOException, so a caller draining an untrusted archive inside catch(IOException) aborts on an exception it never expects. wrap the resolve and rethrow InvalidPathException as ArchiveException, matching the zip-slip rejection already in the method. the new ArchiveEntryTest case fails before the change with the raw InvalidPathException and passes after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
