### PR TITLE
[COMPRESS-725] Use ArchiveEntry.resolveIn in ArchiveStreamFactory decompress example

### DIFF
--- a/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
+++ b/src/main/java/org/apache/commons/compress/archivers/ArchiveStreamFactory.java
@@ -74,7 +74,7 @@ import org.apache.commons.lang3.StringUtils;
  * final InputStream is = Files.newInputStream(input.toPath());
  * ArchiveInputStream in = new ArchiveStreamFactory().createArchiveInputStream(ArchiveStreamFactory.ZIP, is);
  * ZipArchiveEntry entry = (ZipArchiveEntry) in.getNextEntry();
- * OutputStream out = Files.newOutputStream(dir.toPath().resolve(entry.getName()));
+ * OutputStream out = Files.newOutputStream(entry.resolveIn(dir.toPath()));
  * IOUtils.copy(in, out);
  * out.close();
  * in.close();


### PR DESCRIPTION
## Summary
Fixes [COMPRESS-725](https://issues.apache.org/jira/browse/COMPRESS-725).

The class-level \"Decompressing a ZIP-File\" example in `ArchiveStreamFactory` used:

```java
Files.newOutputStream(dir.toPath().resolve(entry.getName()))
```

That pattern is vulnerable to Zip Slip if copied into application code. Commons Compress already provides `ArchiveEntry.resolveIn(Path)` (since 1.26.0) as the safe extraction helper used by `Expander`.

This PR updates the example to:

```java
Files.newOutputStream(entry.resolveIn(dir.toPath()))
```

Documentation-only; no behavioral change.

## Testing
- Doc-only change in class Javadoc.